### PR TITLE
Page factory. Fixes

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -92,7 +92,7 @@ class AppiumElementLocator implements ElementLocator {
 			while (element instanceof WrapsElement){
 				element = ((WrapsElement) element).getWrappedElement();
 			}
-			driver = ((WrapsDriver) searchContext).getWrappedDriver();
+			driver = ((WrapsDriver) element).getWrappedDriver();
 		}
 		return driver;
 	}

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -92,8 +92,12 @@ public class AppiumFieldDecorator implements FieldDecorator, ResetsImplicitlyWai
 	}
 
 	private Object proxyForLocator(Field field, ElementLocator locator) {
+		Class<?> type = field.getType();
+		if (type.equals(WebElement.class)){
+			type = RemoteWebElement.class;
+		}
 		ElementInterceptor elementInterceptor = new ElementInterceptor(locator);
-		return ProxyFactory.getEnhancedProxy(field.getType(),
+		return ProxyFactory.getEnhancedProxy(type,
 				elementInterceptor);
 	}
 	


### PR DESCRIPTION
There is a bug which I found yesterday. Here is the way to reproduce it:

``` java
//declaration
@FindByAnnotation
//It is not reproduced when RemoteWebElement or MobileElement are declared instead of
WebElement someElement; 


//Populate
PageFactory.initElements(new AppiumFieldDecorator(driver), pageObjectInstance); //or something like this


//execution
((JavascriptExecutor) driver).executeScript("someScript", someElement);
```

Exception

``` java
FAILED: androidHybridAppTest
java.lang.IllegalArgumentException: Argument is of an illegal type: org.openqa.selenium.WebElement$$EnhancerByCGLIB$$eedfaea9
    at org.openqa.selenium.remote.internal.WebElementToJsonConverter.apply(WebElementToJsonConverter.java:78)
    at com.google.common.collect.Iterators$8.transform(Iterators.java:794)
    at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48)
    at com.google.common.collect.Iterators.addAll(Iterators.java:357)
    at com.google.common.collect.Lists.newArrayList(Lists.java:147)
    at com.google.common.collect.Lists.newArrayList(Lists.java:129)
    at org.openqa.selenium.remote.RemoteWebDriver.executeScript(RemoteWebDriver.java:504)
    at org.openqa.selenium.remote.RemoteWebDriver$$FastClassBySpringCGLIB$$589f8ff4.invoke(<generated>)
    at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204)
    at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:708)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
    at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:85)
    at org.arachnidium.core.beans.webdriver.AspectWebDriverEventListener.doAround(AspectWebDriverEventListener.java:455)
    at sun.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:621)
    at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:610)
    at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:68)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
    at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:92)
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
    at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:644)
    at io.appium.java_client.AppiumDriver$$EnhancerBySpringCGLIB$$26800e50.executeScript(<generated>)
....
```

I attempted to execute javaScript (hybrid Android application). 

I fixed an issue that was found by by @prattpratt. See comments here: c912100#commitcomment-7202750 
