### PR TITLE
add Settings, and ignoreUnimportantViews setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ More can be found in the docs, but here's a quick list of features which this pr
 - closeApp()
 - endTestCoverage()
 - lockScreen()
+- isLocked()
 - shake()
 - complexFind()
 - scrollTo()
@@ -51,6 +52,7 @@ More can be found in the docs, but here's a quick list of features which this pr
 - openNotifications()
 - Context Switching: .context(), .getContextHandles(), getContext())
 - getNetworkConnection(), setNetworkConnection()
+- ignoreUnimportantViews
 
 Locators:
 - findElementByAccessibilityId()

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -19,6 +19,8 @@ package io.appium.java_client;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.appium.java_client.internal.JsonToMobileElementConverter;
 import org.openqa.selenium.*;
 import org.openqa.selenium.html5.Location;
@@ -80,6 +82,8 @@ public class AppiumDriver extends RemoteWebDriver implements MobileDriver, Conte
             .put(OPEN_NOTIFICATIONS, postC("/session/:sessionId/appium/device/open_notifications"))
             .put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"))
             .put(SET_NETWORK_CONNECTION, postC("/session/:sessionId/network_connection"))
+            .put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"))
+            .put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"))
             ;
     ImmutableMap<String, CommandInfo> mobileCommands = builder.build();
 
@@ -557,6 +561,62 @@ public class AppiumDriver extends RemoteWebDriver implements MobileDriver, Conte
            .put("parameters", ImmutableMap.of("type", connection.value));
 
     execute(SET_NETWORK_CONNECTION, builder.build());
+  }
+
+  /**
+   * Get settings stored for this test session
+   * It's probably better to use a convenience function, rather than use this function directly.
+   * Try finding the method for the specific setting you want to read
+   *
+   * @return JsonObject, a straight-up hash of settings
+   */
+  public JsonObject getSettings() {
+    Response response = execute(GET_SETTINGS);
+
+    JsonParser parser = new JsonParser();
+    JsonObject settings = (JsonObject)parser.parse(response.getValue().toString());
+
+    return settings;
+  }
+
+  /**
+   * Set settings for this test session
+   * It's probably better to use a convenience function, rather than use this function directly.
+   * Try finding the method for the specific setting you want to change
+   *
+   * @param settings Map of setting keys and values
+   */
+  private void setSettings(ImmutableMap settings) {
+
+    ImmutableMap.Builder builder = ImmutableMap.builder();
+    builder.put("settings", settings);
+
+    execute(SET_SETTINGS, builder.build());
+  }
+
+  /**
+   * Set a setting for this test session
+   * It's probably better to use a convenience function, rather than use this function directly.
+   * Try finding the method for the specific setting you want to change
+   *
+   * @param setting AppiumSetting you wish to set
+   * @param value value of the setting
+   */
+  private void setSetting(AppiumSetting setting, Object value) {
+    ImmutableMap.Builder builder = ImmutableMap.builder();
+    builder.put(setting.toString(), value);
+    setSettings(builder.build());
+  }
+
+  /**
+   * Set the `ignoreUnimportantViews` setting.
+   *
+   * Sets whether Android devices should use `setCompressedLayoutHeirarchy()` which ignores all views which are marked IMPORTANT_FOR_ACCESSIBILITY_NO or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important by the system), in an attempt to make things less confusing or faster.
+   *
+   * @param compress ignores unimportant views if true, doesn't ignore otherwise.
+   */
+  public void ignoreUnimportantViews(Boolean compress) {
+    setSetting(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS, compress);
   }
 
   @Override

--- a/src/main/java/io/appium/java_client/AppiumSetting.java
+++ b/src/main/java/io/appium/java_client/AppiumSetting.java
@@ -1,0 +1,37 @@
+/*
+ +Copyright 2014 Appium contributors
+ +Copyright 2014 Software Freedom Conservancy
+ +
+ +Licensed under the Apache License, Version 2.0 (the "License");
+ +you may not use this file except in compliance with the License.
+ +You may obtain a copy of the License at
+ +
+ +     http://www.apache.org/licenses/LICENSE-2.0
+ +
+ +Unless required by applicable law or agreed to in writing, software
+ +distributed under the License is distributed on an "AS IS" BASIS,
+ +WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ +See the License for the specific language governing permissions and
+ +limitations under the License.
+ + */
+
+package io.appium.java_client;
+
+/**
+ * Enums defining constants for Appium Settings which can be set and toggled during a test session.
+ * 
+ */
+public enum AppiumSetting {
+
+  IGNORE_UNIMPORTANT_VIEWS("ignoreUnimportantViews");
+  private String name;
+
+  private AppiumSetting(String name) {
+    this.name = name;
+  }
+
+  public String toString() {
+    return this.name;
+  }
+
+}

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -49,5 +49,7 @@ public interface MobileCommand {
   String OPEN_NOTIFICATIONS = "openNotifications";
   String GET_NETWORK_CONNECTION = "getNetworkConnection";
   String SET_NETWORK_CONNECTION = "setNetworkConnection";
+  String GET_SETTINGS = "getSettings";
+  String SET_SETTINGS = "setSettings";
 
 }

--- a/src/test/java/io/appium/java_client/MobileDriverAndroidTest.java
+++ b/src/test/java/io/appium/java_client/MobileDriverAndroidTest.java
@@ -129,4 +129,14 @@ public class MobileDriverAndroidTest {
   public void isLockedTest() {
     assertEquals(false, driver.isLocked());
   }
+
+  @Test
+  public void ignoreUnimportantViews() {
+    driver.ignoreUnimportantViews(true);
+    boolean ignoreViews = driver.getSettings().get(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS.toString()).getAsBoolean();
+    assertTrue(ignoreViews);
+    driver.ignoreUnimportantViews(false);
+    ignoreViews = driver.getSettings().get(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS.toString()).getAsBoolean();
+    assertFalse(ignoreViews);
+  }
 }


### PR DESCRIPTION
What do people think of this implementation of the new Settings methods?
I see Java as a more strict environment, where users should only really be setting settings which are already specified.

Could make the general SetSetting methods public though... thoughts?
