### PR TITLE
#110 Fix

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -52,8 +52,7 @@ class AppiumElementLocator implements ElementLocator {
 	private WebElement cachedElement;
 	private List<WebElement> cachedElementList;
 	
-	private final long implicitlyWaitTimeOut;
-	private final TimeUnit timeUnit ;
+	private final TimeOutContainer timeOutContainer;
 
 	/**
 	 * Creates a new mobile element locator. It instantiates {@link WebElement}
@@ -64,8 +63,8 @@ class AppiumElementLocator implements ElementLocator {
 	 * @param field
 	 *            The field on the Page Object that will hold the located value
 	 */
-	public AppiumElementLocator(SearchContext searchContext, Field field,
-			long implicitlyWaitTimeOut, TimeUnit timeUnit) {
+	AppiumElementLocator(SearchContext searchContext, Field field,
+			TimeOutContainer timeOutContainer) {
 		this.searchContext = searchContext;
 		// All known webdrivers implement HasCapabilities
 		String platform = String
@@ -73,8 +72,7 @@ class AppiumElementLocator implements ElementLocator {
 						.getCapabilities().getCapability(
 								MobileCapabilityType.PLATFORM_NAME));
 		AppiumAnnotations annotations = new AppiumAnnotations(field, platform);
-		this.implicitlyWaitTimeOut = implicitlyWaitTimeOut;
-		this.timeUnit = timeUnit;
+		this.timeOutContainer = timeOutContainer;
 		shouldCache = annotations.isLookupCached();
 		by = annotations.buildBy();
 	}
@@ -109,14 +107,15 @@ class AppiumElementLocator implements ElementLocator {
 		try{
 			changeImplicitlyWaitTimeOut(0, TimeUnit.SECONDS);
 			FluentWait<By> wait = new FluentWait<By>(by);
-			wait.withTimeout(implicitlyWaitTimeOut, timeUnit);	
+			wait.withTimeout(timeOutContainer.getTimeValue(), timeOutContainer.getTimeUnitValue());	
 			return wait.until(new WaitingFunction(searchContext));
 		}
 		catch (TimeoutException e){
 			return new ArrayList<WebElement>();
 		}
 		finally{
-			changeImplicitlyWaitTimeOut(implicitlyWaitTimeOut, timeUnit);
+			changeImplicitlyWaitTimeOut(timeOutContainer.getTimeValue(), 
+					timeOutContainer.getTimeUnitValue());
 		}
 	}
 	

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocatorFactory.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocatorFactory.java
@@ -12,14 +12,12 @@ class AppiumElementLocatorFactory implements ElementLocatorFactory, ResetsImplic
     private static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
 	
 	private final SearchContext searchContext;
-	private long implicitlyWaitTimeOut;
-	private TimeUnit timeUnit;
+	private final TimeOutContainer timeOutContainer;
 
 	public AppiumElementLocatorFactory(SearchContext searchContext,
 			long implicitlyWaitTimeOut, TimeUnit timeUnit) {
 		this.searchContext = searchContext;
-		this.implicitlyWaitTimeOut = implicitlyWaitTimeOut;
-		this.timeUnit = timeUnit;
+		this.timeOutContainer = new TimeOutContainer(implicitlyWaitTimeOut, timeUnit);
 	}
 	
 	public AppiumElementLocatorFactory(SearchContext searchContext) {
@@ -27,12 +25,11 @@ class AppiumElementLocatorFactory implements ElementLocatorFactory, ResetsImplic
 	}	
 
 	public ElementLocator createLocator(Field field) {
-		return new AppiumElementLocator(searchContext, field, implicitlyWaitTimeOut, timeUnit);
+		return new AppiumElementLocator(searchContext, field, timeOutContainer);
 	}
 
 	@Override
 	public void resetImplicitlyWaitTimeOut(long timeOut, TimeUnit timeUnit) {
-		implicitlyWaitTimeOut = timeOut;
-		this.timeUnit = timeUnit;
+		timeOutContainer.resetImplicitlyWaitTimeOut(timeOut, timeUnit);
 	}
 }

--- a/src/main/java/io/appium/java_client/pagefactory/TimeOutContainer.java
+++ b/src/main/java/io/appium/java_client/pagefactory/TimeOutContainer.java
@@ -1,0 +1,32 @@
+package io.appium.java_client.pagefactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Instances of this class contain
+ * implicit time outs which are used by {@link AppiumElementLocator} 
+ */
+class TimeOutContainer implements ResetsImplicitlyWaitTimeOut{
+	private long timeOutValue;
+	private TimeUnit timeUnit;
+	
+	TimeOutContainer(long initialTimeOutValue, TimeUnit initialTimeUnit){
+		this.timeOutValue = initialTimeOutValue;
+		this.timeUnit     = initialTimeUnit;
+	}
+
+	@Override
+	public void resetImplicitlyWaitTimeOut(long timeOut, TimeUnit timeUnit) {
+		this.timeOutValue = timeOut;
+		this.timeUnit     = timeUnit;		
+	}
+	
+	long getTimeValue(){
+		return timeOutValue;
+	}
+	
+	TimeUnit getTimeUnitValue(){
+		return timeUnit;
+	}
+
+}

--- a/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
@@ -1,0 +1,89 @@
+package io.appium.java_client.pagefactory_tests;
+
+import io.appium.java_client.pagefactory.AppiumFieldDecorator;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class TimeOutResetTest {
+	private WebDriver driver;
+	private final static long ACCEPTABLE_DELTA_MILLS = 500;
+
+	/**
+	 * Default time out parameters
+	 */
+
+	private static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
+	private static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
+
+	@FindBy(className = "ClassWhichDoesNotExist")
+	private List<WebElement> stubElements;
+	private AppiumFieldDecorator afd;
+
+	@Before
+	public void setUp() throws Exception {
+		driver = new FirefoxDriver();
+		afd = new AppiumFieldDecorator(driver);
+
+		PageFactory.initElements(afd, this);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		driver.quit();
+	}
+
+	private static void checkTimeDifference(long etalonTime,
+			TimeUnit etalonTimeUnit, long currentMillis) {
+		long etalonMillis = TimeUnit.MILLISECONDS.convert(etalonTime,
+				etalonTimeUnit);
+		try{
+			Assert.assertEquals(true,
+					((currentMillis - etalonMillis) < ACCEPTABLE_DELTA_MILLS)
+							&& ((currentMillis - etalonMillis) >= 0));
+		}
+		catch (Error e){
+			String message = String.valueOf(etalonTime) + " "  + etalonTimeUnit.toString() + " current duration in millis " +
+					String.valueOf(currentMillis) + " Failed";
+			throw new RuntimeException(message, e);
+		}
+	}
+
+	private long getBenchMark() {
+		long startMark = Calendar.getInstance().getTimeInMillis();
+		stubElements.size();
+		long endMark = Calendar.getInstance().getTimeInMillis();
+		return endMark - startMark;
+	}
+
+	@Test
+	public void test() {
+		checkTimeDifference(DEFAULT_IMPLICITLY_WAIT_TIMEOUT, DEFAULT_TIMEUNIT,
+				getBenchMark());
+		System.out.println(String.valueOf(DEFAULT_IMPLICITLY_WAIT_TIMEOUT)
+				+ " " + DEFAULT_TIMEUNIT.toString() + ": Fine");
+
+		afd.resetImplicitlyWaitTimeOut(15500000, TimeUnit.MICROSECONDS);
+		checkTimeDifference(15500000, TimeUnit.MICROSECONDS, getBenchMark());
+		System.out.println("Change time: " + String.valueOf(15500000) + " "
+				+ TimeUnit.MICROSECONDS.toString() + ": Fine");
+
+		afd.resetImplicitlyWaitTimeOut(3, TimeUnit.SECONDS);
+		checkTimeDifference(3, TimeUnit.SECONDS, getBenchMark());
+		System.out.println("Change time: " + String.valueOf(3) + " "
+				+ TimeUnit.SECONDS.toString() + ": Fine");
+
+	}
+
+}


### PR DESCRIPTION
#110 Fix.

Now it is possible to change timeout of the implicit waiting for element is present for already instantiated proxy of WebElement. 

Raw example:

``` java
public class MyScreen_PageObject{

@FindBy annotation with locator value
WebElement field;

//staff
AppiumFieldDecorator afd = new AppiumFieldDecorator(driver);
PageFactory.initElements(afd, this);
//staff

public void clickOnField(){
  afd.resetImplicitlyWaitTimeOut(2, TimeUnit.SECONDS);
  //It will wait for element is present for 2 seconds.
  field.click();
}
```

I think this feature is good for some common situations and it would be great when Spring or CGLIB are used. 
