### PR TITLE
Moved HasAppStrings interface from AndroidDriver to AppiumDriver

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -41,7 +41,7 @@ import static io.appium.java_client.MobileCommand.*;
 public abstract class AppiumDriver extends RemoteWebDriver implements MobileDriver,
 		ContextAware, Rotatable, FindsByAccessibilityId, LocationContext,
 		DeviceActionShortcuts, TouchShortcuts, InteractsWithFiles,
-		InteractsWithApps, ScrollsTo {
+		InteractsWithApps, ScrollsTo, HasAppStrings {
 
 	private final static ErrorHandler errorHandler = new ErrorHandler(
 			new ErrorCodesMobile(), true);
@@ -53,6 +53,8 @@ public abstract class AppiumDriver extends RemoteWebDriver implements MobileDriv
 	protected final String KEY_CODE = "keycode";
 	protected final String PATH = "path";
 	private final String SETTINGS = "settings";
+
+	private final String LANGUAGE_PARAM = "language";
 
 	/**
 	 * @param originalCapabilities
@@ -596,6 +598,29 @@ public abstract class AppiumDriver extends RemoteWebDriver implements MobileDriv
 	@Override
 	public void setLocation(Location location) {
 		locationContext.setLocation(location);
+	}
+
+	/**
+	 * @see HasAppStrings#getAppStrings()
+ 	 */
+	@Override
+	public String getAppStrings() {
+		Response response = execute(GET_STRINGS);
+		return response.getValue().toString();
+	}
+
+	/**
+	 * @param language
+	 *            strings language code
+	 * @return a string of all the localized strings defined in the app
+	 * 
+	 * @see HasAppStrings#getAppStrings(String)
+	 */
+	@Override
+	public String getAppStrings(String language) {
+		Response response = execute(GET_STRINGS,
+				getCommandImmutableMap(LANGUAGE_PARAM, language));
+		return response.getValue().toString();
 	}
 
 	private TouchAction createTap(WebElement element, int duration) {

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -1,17 +1,17 @@
-package io.appium.java_client.android;
+package io.appium.java_client;
 
 
 public interface HasAppStrings {
 	
 	/**
-	* Get all defined Strings from an Android app for the default language
+	* Get all defined Strings from an app for the default language
 	*
 	* @return a string of all the localized strings defined in the app
 	*/
 	public String getAppStrings();
 
 	/**
-	* Get all defined Strings from an Android app for the specified language
+	* Get all defined Strings from an app for the specified language
 	*
 	* @param language strings language code
 	* @return a string of all the localized strings defined in the app

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -22,13 +22,12 @@ import static io.appium.java_client.MobileCommand.*;
 import static io.appium.java_client.remote.MobileCapabilityType.*;
 
 public class AndroidDriver extends AppiumDriver implements
-		AndroidDeviceActionShortcuts, HasAppStrings, HasNetworkConnection, PushesFiles, 
+		AndroidDeviceActionShortcuts, HasNetworkConnection, PushesFiles,
 		StartsActivity, FindsByAndroidUIAutomator {
 
 	private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
 
 	private final String METASTATE_PARAM = "metastate";
-	private final String LANGUAGE_PARAM = "language";
 	private final String CONNECTION_NAME_PARAM = "name";
 	private final String CONNECTION_PARAM_PARAM = "parameters";
 	private final String DATA_PARAM = "data";
@@ -85,29 +84,6 @@ public class AndroidDriver extends AppiumDriver implements
 		String[] parameters = new String[] { KEY_CODE, METASTATE_PARAM };
 		Object[] values = new Object[] { key, metastate };
 		execute(KEY_EVENT, getCommandImmutableMap(parameters, values));
-	}
-
-	/**
-	 * @see HasAppStrings#getAppStrings()
-	 */
-	@Override
-	public String getAppStrings() {
-		Response response = execute(GET_STRINGS);
-		return response.getValue().toString();
-	}
-
-	/**
-	 * @param language
-	 *            strings language code
-	 * @return a string of all the localized strings defined in the app
-	 * 
-	 * @see HasAppStrings#getAppStrings(String)
-	 */
-	@Override
-	public String getAppStrings(String language) {
-		Response response = execute(GET_STRINGS,
-				getCommandImmutableMap(LANGUAGE_PARAM, language));
-		return response.getValue().toString();
 	}
 
 	/**

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -62,6 +62,18 @@ public class IOSDriverTest {
   }
 
   @Test
+  public void getStringsTest() {
+    String strings = driver.getAppStrings();
+    assert(strings.length() > 100);
+  }
+
+  @Test
+  public void getStringsWithLanguageTest() {
+    String strings = driver.getAppStrings("en");
+    assert(strings.length() > 100);
+  }
+
+  @Test
   public void resetTest() {
     driver.resetApp();
   }


### PR DESCRIPTION
I have moved HasAppStrings interface from AndroidDriver to AppiumDriver to allow getting app strings in iOS, not only in Android.
I have also added two tests in IOSDriver.
