### PR TITLE
#162 fix

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -71,7 +71,43 @@ public abstract class AppiumDriver extends RemoteWebDriver implements MobileDriv
 		return dc;
 	}
 
-	/**
+    public MobileElement findElement(By by){
+        return (MobileElement) super.findElement(by);
+    }
+
+    public MobileElement findElementById(String using){
+        return (MobileElement) super.findElementById(using);
+    }
+
+    public MobileElement findElementByClassName(String using){
+        return (MobileElement) super.findElementByClassName(using);
+    }
+
+    public MobileElement findElementByName(String using){
+        return (MobileElement) super.findElementByName(using);
+    }
+
+    public MobileElement findElementByTagName(String using){
+        return (MobileElement) super.findElementByTagName(using);
+    }
+
+    public MobileElement findElementByCssSelector(String using){
+        return (MobileElement) super.findElementByCssSelector(using);
+}
+
+    public MobileElement findElementByLinkText(String using){
+        return (MobileElement) super.findElementByLinkText(using);
+    }
+
+    public MobileElement findElementByPartialLinkText(String using){
+        return (MobileElement) super.findElementByPartialLinkText(using);
+    }
+
+    public MobileElement findElementByXPath(String using){
+        return (MobileElement) super.findElementByXPath(using);
+    }
+
+    /**
 	 * @param param
 	 *            is a parameter name
 	 * @param value
@@ -572,8 +608,8 @@ public abstract class AppiumDriver extends RemoteWebDriver implements MobileDriv
 	}
 
 	@Override
-	public WebElement findElementByAccessibilityId(String using) {
-		return findElement("accessibility id", using);
+	public MobileElement findElementByAccessibilityId(String using) {
+		return (MobileElement) findElement("accessibility id", using);
 	}
 
 	@Override

--- a/src/main/java/io/appium/java_client/FindsByAccessibilityId.java
+++ b/src/main/java/io/appium/java_client/FindsByAccessibilityId.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 public interface FindsByAccessibilityId {
-  WebElement findElementByAccessibilityId(String using);
+  <T extends WebElement> T findElementByAccessibilityId(String using);
 
   List<WebElement> findElementsByAccessibilityId(String using);
 }

--- a/src/main/java/io/appium/java_client/FindsByAndroidUIAutomator.java
+++ b/src/main/java/io/appium/java_client/FindsByAndroidUIAutomator.java
@@ -21,7 +21,8 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 public interface FindsByAndroidUIAutomator {
-  WebElement findElementByAndroidUIAutomator(String using);
 
-  List<WebElement> findElementsByAndroidUIAutomator(String using);
+    <T extends WebElement> T findElementByAndroidUIAutomator(String using);
+
+    List<WebElement> findElementsByAndroidUIAutomator(String using);
 }

--- a/src/main/java/io/appium/java_client/FindsByIosUIAutomation.java
+++ b/src/main/java/io/appium/java_client/FindsByIosUIAutomation.java
@@ -21,7 +21,8 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 public interface FindsByIosUIAutomation {
-  WebElement findElementByIosUIAutomation(String using);
 
-  List<WebElement> findElementsByIosUIAutomation(String using);
+    <T extends WebElement> T findElementByIosUIAutomation(String using);
+
+    List<WebElement> findElementsByIosUIAutomation(String using);
 }

--- a/src/main/java/io/appium/java_client/MobileElement.java
+++ b/src/main/java/io/appium/java_client/MobileElement.java
@@ -34,10 +34,6 @@ public abstract class MobileElement extends RemoteWebElement implements FindsByA
 		return by.findElements(this);
 	}
 
-	public WebElement findElement(By by) {
-		return by.findElement(this);
-	}
-
 	public WebElement findElementByAccessibilityId(String using) {
 		return findElement("accessibility id", using);
 	}
@@ -79,4 +75,40 @@ public abstract class MobileElement extends RemoteWebElement implements FindsByA
 		direction.swipe((AppiumDriver) parent, this, offsetFromStartBorder, 
 				offsetFromEndBorder, duration);		
 	}
+
+    public MobileElement findElement(By by){
+        return (MobileElement) super.findElements(by);
+    }
+
+    public MobileElement findElementById(String using){
+        return (MobileElement) super.findElementById(using);
+    }
+
+    public MobileElement findElementByClassName(String using){
+        return (MobileElement) super.findElementByClassName(using);
+    }
+
+    public MobileElement findElementByName(String using){
+        return (MobileElement) super.findElementByName(using);
+    }
+
+    public MobileElement findElementByTagName(String using){
+        return (MobileElement) super.findElementByTagName(using);
+    }
+
+    public MobileElement findElementByCssSelector(String using){
+        return (MobileElement) super.findElementByCssSelector(using);
+    }
+
+    public MobileElement findElementByLinkText(String using){
+        return (MobileElement) super.findElementByLinkText(using);
+    }
+
+    public MobileElement findElementByPartialLinkText(String using){
+        return (MobileElement) super.findElementByPartialLinkText(using);
+    }
+
+    public MobileElement findElementByXPath(String using){
+        return (MobileElement) super.findElementByXPath(using);
+    }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -251,8 +251,8 @@ public class AndroidDriver extends AppiumDriver implements
 	}	
 	
 	@Override
-	public WebElement findElementByAndroidUIAutomator(String using) {
-		return findElement("-android uiautomator", using);
+	public AndroidElement findElementByAndroidUIAutomator(String using) {
+		return (AndroidElement) findElement("-android uiautomator", using);
 	}
 
 	@Override

--- a/src/main/java/io/appium/java_client/android/AndroidElement.java
+++ b/src/main/java/io/appium/java_client/android/AndroidElement.java
@@ -11,8 +11,8 @@ public class AndroidElement extends MobileElement implements
 		FindsByAndroidUIAutomator {
 	
 	@Override
-	public WebElement findElementByAndroidUIAutomator(String using) {
-		return findElement("-android uiautomator", using);
+	public AndroidElement findElementByAndroidUIAutomator(String using) {
+		return (AndroidElement) findElement("-android uiautomator", using);
 	}
 
 	@Override

--- a/src/main/java/io/appium/java_client/ios/GetsNamedTextField.java
+++ b/src/main/java/io/appium/java_client/ios/GetsNamedTextField.java
@@ -12,6 +12,6 @@ public interface GetsNamedTextField {
 	 *            accessiblity id of TextField
 	 * @return The textfield with the given accessibility id
 	 */
-	public WebElement getNamedTextField(String name);
+	public <T extends IOSElement> T getNamedTextField(String name);
 
 }

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -75,17 +75,17 @@ public class IOSDriver extends AppiumDriver implements IOSDeviceActionShortcuts,
 	 * @see GetsNamedTextField#getNamedTextField(String)
 	 */
 	@Override
-	public WebElement getNamedTextField(String name) {
-		MobileElement element = (MobileElement) findElementByAccessibilityId(name);
+	public IOSElement getNamedTextField(String name) {
+        IOSElement element = (IOSElement) findElementByAccessibilityId(name);
 		if (element.getTagName() != "TextField") {
-			return element.findElementByAccessibilityId(name);
+			return (IOSElement) element.findElementByAccessibilityId(name);
 		}
 		return element;
 	}
 	
 	@Override
-	public WebElement findElementByIosUIAutomation(String using) {
-		return findElement("-ios uiautomation", using);
+	public IOSElement findElementByIosUIAutomation(String using) {
+		return (IOSElement) findElement("-ios uiautomation", using);
 	}
 
 	@Override

--- a/src/main/java/io/appium/java_client/ios/IOSElement.java
+++ b/src/main/java/io/appium/java_client/ios/IOSElement.java
@@ -14,8 +14,8 @@ import java.util.List;
 public class IOSElement extends MobileElement implements FindsByIosUIAutomation, ScrollsTo {
 	
 	@Override
-	public WebElement findElementByIosUIAutomation(String using) {
-		return findElement("-ios uiautomation", using);
+	public IOSElement findElementByIosUIAutomation(String using) {
+		return (IOSElement) findElement("-ios uiautomation", using);
 	}
 
 	@Override

--- a/src/test/java/io/appium/java_client/android/AndroidAccessibilityTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidAccessibilityTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.MobileBy;
+import io.appium.java_client.MobileElement;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.remote.MobileCapabilityType;
 
@@ -44,7 +45,8 @@ public class AndroidAccessibilityTest {
 
 	@Test
 	  public void findElementTest() {
-	    WebElement element = driver.findElementByAccessibilityId("Accessibility");
+        //WebElement element =
+	    MobileElement element = driver.findElementByAccessibilityId("Accessibility");
 	    assertNotNull(element);
 	  }
 

--- a/src/test/java/io/appium/java_client/android/AndroidGestureTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidGestureTest.java
@@ -96,37 +96,37 @@ public class AndroidGestureTest {
   @Test
   public void elementGestureTest(){
 	  driver.manage().timeouts().implicitlyWait(2, TimeUnit.SECONDS);
-	  MobileElement e = (MobileElement) driver.findElement(MobileBy.AccessibilityId("App"));
+	  MobileElement e = driver.findElement(MobileBy.AccessibilityId("App"));
 	  e.tap(1, 1500);
     System.out.println("tap");
-	  MobileElement e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+	  MobileElement e2 = driver.findElementByClassName("android.widget.TextView");
 	  e2.zoom();
     System.out.println("zoom");
     e2.swipe(SwipeElementDirection.RIGHT,1000);
     System.out.println("RIGHT");
     
-    e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+    e2 = driver.findElementByClassName("android.widget.TextView");
 	e2.swipe(SwipeElementDirection.RIGHT, 10, 20, 1000);
     System.out.println("RIGHT Left border + 10 Right border - 20");
     
-    e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+    e2 = driver.findElementByClassName("android.widget.TextView");
 	e2.swipe(SwipeElementDirection.LEFT, 1000);
     System.out.println("LEFT");
     
-    e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+    e2 = driver.findElementByClassName("android.widget.TextView");
 	e2.swipe(SwipeElementDirection.LEFT, 10, 20, 1000);
     System.out.println("LEFT Right border - 10 Left border + 20");
     
     driver.sendKeyEvent(AndroidKeyCode.BACK);
-    e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+    e2 = driver.findElementByClassName("android.widget.TextView");
 	e2.swipe(SwipeElementDirection.DOWN,1000);    
 	System.out.println("DOWN");
 	
-	e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+	e2 = driver.findElementByClassName("android.widget.TextView");
 	e2.swipe(SwipeElementDirection.DOWN, 10, 20, 1000);    
 	System.out.println("DOWN Top - 10 Bottom + 20");
 	
-	e2 = (MobileElement) driver.findElementByClassName("android.widget.TextView");
+	e2 = driver.findElementByClassName("android.widget.TextView");
     e2.swipe(SwipeElementDirection.UP,1000);
     System.out.println("UP");
     

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -80,25 +80,25 @@ public class IOSDriverTest {
 
   @Test
   public void namedTextFieldTest() {
-    MobileElement element = (MobileElement)driver.findElementByAccessibilityId("Text Fields, AAPLTextFieldViewController");
+    MobileElement element = driver.findElementByAccessibilityId("Text Fields, AAPLTextFieldViewController");
     element.click();
-    element = (MobileElement)driver.getNamedTextField("DEFAULT");
+    element = driver.getNamedTextField("DEFAULT");
     ((IOSElement) element).setValue("Grace Hopper");
     assertEquals("Grace Hopper", element.getText());
   }
 
   @Test
   public void hideKeyboardWithParametersTest() {
-    MobileElement element = (MobileElement)driver.findElementByAccessibilityId("Text Fields, AAPLTextFieldViewController");
+    MobileElement element = driver.findElementByAccessibilityId("Text Fields, AAPLTextFieldViewController");
     element.click();
-    element = (MobileElement)driver.findElementByAccessibilityId("DEFAULT");
+    element = driver.findElementByAccessibilityId("DEFAULT");
     element.click();
     driver.hideKeyboard(HideKeyboardStrategy.PRESS_KEY, "Done");
   }
 
   @Test
   public void scrollToTest() {
-    MobileElement searchBar = (MobileElement) driver.findElementByName("Search Bars");
+    MobileElement searchBar = driver.findElementByName("Search Bars");
     Point before = searchBar.getLocation();
     driver.scrollTo("Search Ba");
     Point after = searchBar.getLocation();
@@ -107,7 +107,7 @@ public class IOSDriverTest {
 
   @Test
   public void scrollToExactTest() {
-    MobileElement searchBar = (MobileElement) driver.findElementByName("Search Bars");
+    MobileElement searchBar = driver.findElementByName("Search Bars");
     Point before = searchBar.getLocation();
     driver.scrollToExact("Search Bars");
     Point after = searchBar.getLocation();


### PR DESCRIPTION
- interfaces FindsByAndroidUIAutomator, FindsByAccessibilityId and FindsByIosUIAutomation were changed 
- findElement(By) and findElementBy* were overriden. Now they return MobileElement or subclass.

I have tried to override findElements(By) and findElementsBy*. But there are casting problems of java-collections. Also there is a problem of backward compatibility. Sometimes I hate Java :)