### PR TITLE
junit dependency is not required for compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Now I develop a Java test tool which depends on the appium java-client library.
My test tool supports both JUnit3 and JUnit4, and I don't want the appium java-client to include junit4 dependency since this dependency may cause conflict.

I think appium java-client requires junit4 dependency only for test scope.



