### PR TITLE
#185 fix

### DIFF
--- a/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
@@ -1,6 +1,7 @@
 package io.appium.java_client.pagefactory_tests;
 
 import io.appium.java_client.MobileElement;
+import io.appium.java_client.TouchableElement;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.AndroidElement;
 import io.appium.java_client.pagefactory.AndroidFindAll;
@@ -17,6 +18,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.xpath.operations.And;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,6 +77,9 @@ public class AndroidPageObjectTest {
 	@iOSFindBys({@iOSFindBy(uiAutomator = ".elements()[0]"),
 		@iOSFindBy(xpath = "//someElement")})
 	private List<WebElement> chainAndroidOrIOSUIAutomatorViews;
+
+    @AndroidFindBy(uiAutomator = "new UiSelector().resourceId(\"android:id/text1\")")
+    private List<TouchableElement> touchabletextVieWs;
 
 	@FindBy(id = "android:id/text1")
 	private WebElement textView;
@@ -153,6 +158,9 @@ public class AndroidPageObjectTest {
         @AndroidFindBy(id = "android:id/text1")
         @SelendroidFindBy(id = "Invalid Identifier")
         private WebElement textAndroidId;
+
+    @AndroidFindBy(uiAutomator = "new UiSelector().resourceId(\"android:id/text1\")")
+    private TouchableElement touchabletextVieW;
 	
 	@Before
 	public void setUp() throws Exception {
@@ -320,5 +328,23 @@ public class AndroidPageObjectTest {
 	@Test
 	public void findByAndroidAnnotationOnlyTest(){
 		Assert.assertNotEquals(null, textAndroidId.getAttribute("text"));
-	}	
+	}
+
+    @Test
+    public void isTouchableElement(){
+        Assert.assertNotEquals(null, touchabletextVieW.getAttribute("text"));
+    }
+
+    @Test
+    public void areTouchableElements(){
+        Assert.assertNotEquals(0, touchabletextVieWs.size());
+    }
+
+    @Test
+    public void isTheFieldAndroidElement(){
+        AndroidElement androidElement = (AndroidElement) mobiletextVieW; //declared as MobileElement
+        androidElement = (AndroidElement) androidTextView; //declared as WedElement
+        androidElement = (AndroidElement) remotetextVieW;  //declared as RemoteWedElement
+        androidElement = (AndroidElement) touchabletextVieW; //declared as TouchABLEElement
+    }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/iOSPageObjectTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/iOSPageObjectTest.java
@@ -1,6 +1,8 @@
 package io.appium.java_client.pagefactory_tests;
 
 import io.appium.java_client.MobileElement;
+import io.appium.java_client.TouchableElement;
+import io.appium.java_client.android.AndroidElement;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.ios.IOSElement;
 import io.appium.java_client.pagefactory.AndroidFindBy;
@@ -79,6 +81,12 @@ public class iOSPageObjectTest {
 
 	@iOSFindBy(uiAutomator = ".elements()[0]")
 	private MobileElement mobileButton;
+
+    @iOSFindBy(uiAutomator = ".elements()[0]")
+    private TouchableElement touchableButton;
+
+    @iOSFindBy(uiAutomator = ".elements()[0]")
+    private List<TouchableElement> touchableButtons;
 
 	@FindBy(className = "UIAButton")
 	private MobileElement mobiletFindBy_Button;
@@ -253,4 +261,22 @@ public class iOSPageObjectTest {
 	public void findAllElementTest(){
 		Assert.assertNotEquals(null, findAllElement.getText());
 	}
+
+    @Test
+    public void isTouchAbleElement(){
+        Assert.assertNotEquals(null, touchableButton.getText());
+    }
+
+    @Test
+    public void areTouchAbleElements(){
+        Assert.assertNotEquals(0, touchableButtons.size());
+    }
+
+    @Test
+    public void isTheFieldIOSElement(){
+        IOSElement iOSElement = (IOSElement) mobileButton; //declared as MobileElement
+        iOSElement = (IOSElement) iosUIAutomatorButton; //declared as WedElement
+        iOSElement = (IOSElement) remotetextVieW;  //declared as RemoteWedElement
+        iOSElement = (IOSElement) touchableButton; //declared as TouchABLEElement
+    }
 }


### PR DESCRIPTION
Fixed #185 

```java
@FindBy(locator)
MobileElement element;
...


(AndroidElement) element..//if now test of an Android app is being run
//or
(IOSElement) element..//if now test of an iOS app is being run
```

Also now there is something like... bounding. It means that user is not allowed to declare IOSElement field for Android-specific scripts/pageobjects and AndroidElement field for iOS-specific scripts/pageobjects.

- Additional change:
An ability to declare TouchableElement field has been added.

```java
@FindBy(locator)
TouchableElement element;
...
```