### PR TITLE
added a method "scrollTobyCellIndex" to scroll by index on IOSDriver and IOSElement class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.appium</groupId>
     <artifactId>java-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.01</version>
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -44,6 +44,14 @@ public class IOSDriver extends AppiumDriver implements IOSDeviceActionShortcuts,
    public MobileElement scrollToExact(String text) {
 	  return ((IOSElement) findElementByClassName("UIATableView")).scrollToExact(text);
    }
+    /**
+     * Scroll to the CellView whose 'index' is equal to the input cellIndex.
+     * This scrolling happens within the first UIATableView on the UI. Use the method on IOSElement to scroll from a different ScrollView.
+     * @param integer input text to match
+     */
+    public MobileElement scrollTobyCellIndex(int cellIndex){
+        return ((IOSElement) findElementByClassName("UIATableView")).scrollTobyCellIndex(cellIndex);
+    }
 
    /**
 	 * @see IOSDeviceActionShortcuts#hideKeyboard(String, String)

--- a/src/main/java/io/appium/java_client/ios/IOSElement.java
+++ b/src/main/java/io/appium/java_client/ios/IOSElement.java
@@ -42,6 +42,16 @@ public class IOSElement extends MobileElement implements FindsByIosUIAutomation,
 	public MobileElement scrollToExact(String text) {
 		return (MobileElement) findElementByIosUIAutomation(".scrollToElementWithName(\"" + text + "\")");
 	}
+    /**
+     * Scroll to the CellView whose 'index' is equal to the input cellIndex.
+     * This scrolling happens within the first UIATableView on the UI. Use the method on IOSElement to scroll from a different ScrollView.
+     * @param integer cell index to match
+     */
+
+    public MobileElement scrollTobyCellIndex(int cellIndex){
+        cellIndex = cellIndex -1;
+        return (MobileElement) findElementByIosUIAutomation(".cells()["+cellIndex+"].scrollToVisible();");
+    }
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void setValue(String value) {		


### PR DESCRIPTION
Actually in iOS, ScrollTo method is defined to scroll over a TableView which has multiple cells. It is always recommended to use it over the UIATableView and it scroll to the respective cell of this table depending the search text is present in the cell name.

If we have cells with duplicate names then there is no way to scroll to each of these cells. So I have added a new method called "scrollTobyCellIndex" in the IOSElement class where you can pass the index of the cell and it will scroll to that specific cell.