### PR TITLE
#201 fix update to Selenium 2.46 + Some improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Depends upon the Selenium Java client library, available [here](http://docs.sele
 </dependency>
 ```
 
-It currently depends on selenium-java 2.43.1. If it is necessary to use another version of Selenium then you can configure pom.xml as follows:
+It currently depends on selenium-java 2.46.0. If it is necessary to use another version of Selenium then you can configure pom.xml as follows:
 
 ```
 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.45.0</version>
+            <version>2.46.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumAnnotations.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumAnnotations.java
@@ -171,7 +171,8 @@ class AppiumAnnotations extends Annotations {
 		}
 	}
 
-	private void assertValidAnnotations() {
+	@Override
+	protected void assertValidAnnotations() {
 		AndroidFindBy androidBy = mobileField
 				.getAnnotation(AndroidFindBy.class);
 		AndroidFindBys androidBys = mobileField
@@ -201,6 +202,7 @@ class AppiumAnnotations extends Annotations {
 		checkDisallowedAnnotationPairs(iOSBy, iOSBys);
 		checkDisallowedAnnotationPairs(iOSBy, iOSFindAll);
 		checkDisallowedAnnotationPairs(iOSBys, iOSFindAll);
+		super.assertValidAnnotations();
 	}
 
 	private static Method[] prepareAnnotationMethods(

--- a/src/main/java/io/appium/java_client/pagefactory/WebDriverUnpackUtility.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WebDriverUnpackUtility.java
@@ -2,27 +2,28 @@ package io.appium.java_client.pagefactory;
 
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.WrapsDriver;
 import org.openqa.selenium.internal.WrapsElement;
 
 final class WebDriverUnpackUtility {
 
-	static WebDriver unpackWebDriverFromSearchContext(SearchContext searchContext){
+	static WebDriver unpackWebDriverFromSearchContext(
+			SearchContext searchContext) {
 		WebDriver driver = null;
-		if (searchContext instanceof WebDriver){
-			driver = (WebDriver) searchContext;
-		}		
-		//Search context it is not only Webdriver. Webelement is search context too.
-		//RemoteWebElement and MobileElement implement WrapsDriver
-		if (searchContext instanceof WebElement){
-			WebElement element = (WebElement) searchContext; //there can be something that 
-			//implements WebElement interface and wraps original
-			while (element instanceof WrapsElement){
-				element = ((WrapsElement) element).getWrappedElement();
-			}
-			driver = ((WrapsDriver) element).getWrappedDriver();
-		}
+		if (searchContext instanceof WebDriver)
+			return (WebDriver) searchContext;
+
+		// Search context it is not only Webdriver. Webelement is search context
+		// too.
+		// RemoteWebElement and MobileElement implement WrapsDriver
+		if (searchContext instanceof WrapsElement)
+			return unpackWebDriverFromSearchContext(((WrapsElement) searchContext)
+					.getWrappedElement());
+
+		if (searchContext instanceof WrapsDriver)
+			return unpackWebDriverFromSearchContext(((WrapsDriver) searchContext)
+					.getWrappedDriver());
+
 		return driver;
 	}
 }


### PR DESCRIPTION
Changes:

- update dependencies to Selenium 2.46

-I have found a problem recently. Page object fields couldn't be populated because a customized implementation of the SearhContext was used. So now it is possible to use classes like that as well as
WebDriver and WebElement. But user's SearchContext implementations have to implement WrapsElement or WrapsDriver too.