### PR TITLE
Fix #184 Fix #211

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumAnnotations.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumAnnotations.java
@@ -1,6 +1,7 @@
 package io.appium.java_client.pagefactory;
 
 import static io.appium.java_client.remote.MobilePlatform.*;
+import static io.appium.java_client.remote.AutomationName.*;
 import io.appium.java_client.MobileBy;
 
 import java.lang.annotation.Annotation;
@@ -300,7 +301,7 @@ class AppiumAnnotations extends Annotations {
 		SelendroidFindBy selendroidBy = mobileField
 				.getAnnotation(SelendroidFindBy.class);
 		if (selendroidBy != null && ANDROID.toUpperCase().equals(platform)
-				&& "Selendroid".toUpperCase().equals(automation)) {
+				&& SELENDROID.toUpperCase().equals(automation)) {
 			return setByForTheNativeContentAndReturn(
 					getMobileBy(selendroidBy, getFilledValue(selendroidBy)),
 					contentMap);
@@ -309,7 +310,7 @@ class AppiumAnnotations extends Annotations {
 		SelendroidFindBys selendroidBys = mobileField
 				.getAnnotation(SelendroidFindBys.class);
 		if (selendroidBys != null && ANDROID.toUpperCase().equals(platform)
-				&& "Selendroid".toUpperCase().equals(automation)) {
+				&& SELENDROID.toUpperCase().equals(automation)) {
 			return setByForTheNativeContentAndReturn(
 					getComplexMobileBy(selendroidBys.value(), ByChained.class),
 					contentMap);
@@ -318,7 +319,7 @@ class AppiumAnnotations extends Annotations {
 		SelendroidFindAll selendroidAll = mobileField
 				.getAnnotation(SelendroidFindAll.class);
 		if (selendroidAll != null && ANDROID.toUpperCase().equals(platform)
-				&& "Selendroid".toUpperCase().equals(automation)) {
+				&& SELENDROID.toUpperCase().equals(automation)) {
 			return setByForTheNativeContentAndReturn(
 					getComplexMobileBy(selendroidAll.value(), ByAll.class),
 					contentMap);

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -106,8 +106,9 @@ class AppiumElementLocator implements ElementLocator {
         if (IOSDriver.class.isAssignableFrom(driverClass))
             return MobilePlatform.IOS;
 
-        //it is possible that here customers implementation of WebDriver
-        //At this case it has to implement HasCapabilities
+        //it is possible that somebody uses RemoteWebDriver or their
+        //own WebDriver implementation. At this case capabilities are used
+        //to detect platform
         if (HasCapabilities.class.isAssignableFrom(driverClass))
             return String.valueOf(((HasCapabilities) d).getCapabilities().
                     getCapability(MobileCapabilityType.PLATFORM_NAME));

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -1,5 +1,7 @@
 package io.appium.java_client.pagefactory;
 
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.MobileCapabilityType;
 
 import java.lang.reflect.Field;
@@ -7,14 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.openqa.selenium.By;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.SearchContext;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.WebElement;
+import io.appium.java_client.remote.MobilePlatform;
+import org.openqa.selenium.*;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
 import org.openqa.selenium.support.ui.FluentWait;
 
@@ -26,6 +22,7 @@ class AppiumElementLocator implements ElementLocator {
 	private static class WaitingFunction implements
 			Function<By, List<WebElement>> {
 		private final SearchContext searchContext;
+        private final static String INVALID_SELECTOR_PATTERN = "Invalid locator strategy:";
 
 		private WaitingFunction(SearchContext searchContext) {
 			this.searchContext = searchContext;
@@ -37,12 +34,26 @@ class AppiumElementLocator implements ElementLocator {
 				result.addAll(searchContext.findElements(by));
 			} catch (StaleElementReferenceException ignored) {
 			}
+            catch (RuntimeException e){
+                if (!isInvalidSelectorRootCause(e))
+                    throw e;
+            }
 			if (result.size() > 0) {
 				return result;
 			} else {
 				return null;
 			}
 		}
+
+        private static boolean isInvalidSelectorRootCause(Throwable e){
+            if (e == null)
+                return false;
+
+            if (String.valueOf(e.getMessage()).contains(INVALID_SELECTOR_PATTERN))
+                return true;
+
+            return isInvalidSelectorRootCause(e.getCause());
+        }
 	}
 
 	private final SearchContext searchContext;
@@ -66,15 +77,9 @@ class AppiumElementLocator implements ElementLocator {
 	AppiumElementLocator(SearchContext searchContext, Field field,
 			TimeOutDuration timeOutDuration) {
 		this.searchContext = searchContext;
-		// All known webdrivers implement HasCapabilities
-		Capabilities capabilities = ((HasCapabilities) WebDriverUnpackUtility.
-				unpackWebDriverFromSearchContext(this.searchContext))
-				.getCapabilities();
 
-		String platform = String.valueOf(capabilities
-				.getCapability(MobileCapabilityType.PLATFORM_NAME));
-		String automation = String.valueOf(capabilities
-				.getCapability(MobileCapabilityType.AUTOMATION_NAME));
+		String platform = getPlatform();
+		String automation = getAutomation();
 
 		AppiumAnnotations annotations = new AppiumAnnotations(field, platform,
 				automation);
@@ -87,6 +92,41 @@ class AppiumElementLocator implements ElementLocator {
 		shouldCache = annotations.isLookupCached();
 		by = annotations.buildBy();
 	}
+
+    private String getPlatform(){
+        WebDriver d = WebDriverUnpackUtility.
+                unpackWebDriverFromSearchContext(this.searchContext);
+        if (d == null)
+            return null;
+
+        Class<?> driverClass = d.getClass();
+        if (AndroidDriver.class.isAssignableFrom(driverClass))
+            return MobilePlatform.ANDROID;
+
+        if (IOSDriver.class.isAssignableFrom(driverClass))
+            return MobilePlatform.IOS;
+
+        //it is possible that here customers implementation of WebDriver
+        //At this case it has to implement HasCapabilities
+        if (HasCapabilities.class.isAssignableFrom(driverClass))
+            return String.valueOf(((HasCapabilities) d).getCapabilities().
+                    getCapability(MobileCapabilityType.PLATFORM_NAME));
+
+        return null;
+    }
+
+    private String getAutomation(){
+        WebDriver d = WebDriverUnpackUtility.
+                unpackWebDriverFromSearchContext(this.searchContext);
+        if (d == null)
+            return null;
+
+        if (HasCapabilities.class.isAssignableFrom(d.getClass()))
+            return String.valueOf(((HasCapabilities) d).getCapabilities().
+                    getCapability(MobileCapabilityType.AUTOMATION_NAME));
+
+        return null;
+    }
 
 	private void changeImplicitlyWaitTimeOut(long newTimeOut,
 			TimeUnit newTimeUnit) {

--- a/src/main/java/io/appium/java_client/pagefactory/ContentMappedBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ContentMappedBy.java
@@ -22,7 +22,9 @@ class ContentMappedBy extends By {
 		if (!ContextAware.class.isAssignableFrom(driver.getClass())){ //it is desktop browser 
 			return map.get(ContentType.HTML);
 		}
-		
+
+        By result = null;
+
 		ContextAware contextAware = ContextAware.class.cast(driver);
 		String currentContext = contextAware.getContext();
 		if (currentContext.contains(NATIVE_APP_PATTERN))
@@ -34,5 +36,18 @@ class ContentMappedBy extends By {
 	public List<WebElement> findElements(SearchContext context) {
 		return context.findElements(returnRelevantBy(context));
 	}
+
+    @Override
+    public String toString(){
+        By defaultBy = map.get(ContentType.HTML);
+        By nativeBy  = map.get(ContentType.NATIVE);
+
+        if (defaultBy.equals(nativeBy))
+            return defaultBy.toString();
+
+        return  "Locator map: " + "\n" +
+                "- native content: \"" + nativeBy.toString() + "\" \n" +
+                "- html content: \"" + defaultBy.toString() + "\"";
+    }
 
 }

--- a/src/main/java/io/appium/java_client/pagefactory/ContentMappedBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ContentMappedBy.java
@@ -23,8 +23,6 @@ class ContentMappedBy extends By {
 			return map.get(ContentType.HTML);
 		}
 
-        By result = null;
-
 		ContextAware contextAware = ContextAware.class.cast(driver);
 		String currentContext = contextAware.getContext();
 		if (currentContext.contains(NATIVE_APP_PATTERN))

--- a/src/main/java/io/appium/java_client/remote/AutomationName.java
+++ b/src/main/java/io/appium/java_client/remote/AutomationName.java
@@ -1,0 +1,7 @@
+package io.appium.java_client.remote;
+
+
+public interface AutomationName {
+    String APPIUM = "Appium";
+    String SELENDROID = "Selendroid";
+}

--- a/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
@@ -160,6 +160,14 @@ public class AndroidPageObjectTest {
 
     @AndroidFindBy(uiAutomator = "new UiSelector().resourceId(\"android:id/text1\")")
     private TouchableElement touchabletextVieW;
+
+    @iOSFindBy(uiAutomator = ".elements()[0]")
+    @FindBy(css = "e.e1.e2")
+    private List<WebElement> elementsWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy;
+
+    @iOSFindBy(uiAutomator = ".elements()[0]")
+    @FindBy(css = "e.e1.e2")
+    private WebElement elementWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy;
 	
 	@SuppressWarnings("rawtypes")
 	@Before
@@ -347,5 +355,21 @@ public class AndroidPageObjectTest {
         androidElement = (AndroidElement) androidTextView; //declared as WedElement
         androidElement = (AndroidElement) remotetextVieW;  //declared as RemoteWedElement
         androidElement = (AndroidElement) touchabletextVieW; //declared as TouchABLEElement
+    }
+
+    @Test
+    public void checkThatTestWillNotBeFailedBecauseOfInvalidFindBy(){
+        try {
+            Assert.assertNotEquals(null, elementWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy.getAttribute("text"));
+        }
+        catch (NoSuchElementException ignored){
+            return;
+        }
+        throw new RuntimeException(NoSuchElementException.class.getName() + " has been expected.");
+    }
+
+    @Test
+    public void checkThatTestWillNotBeFailedBecauseOfInvalidFindBy_List(){
+        Assert.assertEquals(0, elementsWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy.size());
     }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/SelendroidModeTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/SelendroidModeTest.java
@@ -6,6 +6,7 @@ import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.SelendroidFindAll;
 import io.appium.java_client.pagefactory.SelendroidFindBy;
 import io.appium.java_client.pagefactory.SelendroidFindBys;
+import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.remote.MobileCapabilityType;
 
 import org.openqa.selenium.WebElement;
@@ -79,7 +80,7 @@ public class SelendroidModeTest {
         DesiredCapabilities capabilities = new DesiredCapabilities();
         capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, "Android Emulator");
         capabilities.setCapability(MobileCapabilityType.APP, app.getAbsolutePath());
-        capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, "Selendroid");
+        capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.SELENDROID);
         capabilities.setCapability(MobileCapabilityType.SELENDROID_PORT, SELENDROID_PORT);
         driver = new AndroidDriver<WebElement>(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
 

--- a/src/test/java/io/appium/java_client/pagefactory_tests/iOSPageObjectTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/iOSPageObjectTest.java
@@ -117,6 +117,14 @@ public class iOSPageObjectTest {
 	})
 	private List<WebElement> findAllElements;
 
+    @AndroidFindBy(className = "android.widget.TextView")
+    @FindBy(css = "e.e1.e2")
+    private List<WebElement> elementsWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy;
+
+    @AndroidFindBy(className = "android.widget.TextView")
+    @FindBy(css = "e.e1.e2")
+    private WebElement elementWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy;
+
 	@SuppressWarnings("rawtypes")
 	@Before
 	public void setUp() throws Exception {
@@ -279,5 +287,21 @@ public class iOSPageObjectTest {
         iOSElement = (IOSElement) iosUIAutomatorButton; //declared as WebElement
         iOSElement = (IOSElement) remotetextVieW;  //declared as RemoteWebElement
         iOSElement = (IOSElement) touchableButton; //declared as TouchABLEElement
+    }
+
+    @Test
+    public void checkThatTestWillNotBeFailedBecauseOfInvalidFindBy(){
+        try {
+            Assert.assertNotEquals(null, elementWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy.getAttribute("text"));
+        }
+        catch (NoSuchElementException ignored){
+            return;
+        }
+        throw new RuntimeException(NoSuchElementException.class.getName() + " has been expected.");
+    }
+
+    @Test
+    public void checkThatTestWillNotBeFailedBecauseOfInvalidFindBy_List(){
+        Assert.assertEquals(0, elementsWhenAndroidLocatorIsNotDefinedAndThereIsInvalidFindBy.size());
     }
 }


### PR DESCRIPTION
Change list:
- fixed #184 and #211. Now the choosing is by-strategy is depending on only driver class. There was outdated code. Now it is updated. Summary:
So when here is __AnroidDriver__ and current context is native app then will be choosen By-strategy defined via __AndroidFindBy/AndroidFindBys/AndroidFindAll__ annotations.  When here is __IOSDriver__ and current context is native app then will be choosen By-strategy defined via __iOSFindBy/iOSFindBys/iOSFindAll__. annotations.
By-strategy that is built using defaul __FindBy/FindBys/FindAll__ will be used for browser/webview content or when there is no specific annotations for Android/iOS native apps.

There is one specific remark. If somebody desires to use their own Webdriver implementation then it has to implement HasCapabilities.

- AutomationName has been added in order to define the desired automation type correctly in Capabilities.

- Now the class ContentMappedBy has overridden __toString()__ method

- I fixed a problem that is not reported yet. 

How to reproduce:

```java
//Right now we are testing an Android app

@iOSFindBy(iOS locator)
@FindBy(css = "e.e1.e2")
private e;
```

or

```java
//Right now we are testing an iOS app

@AndroidFindBy(className = "android.widget.TextView")
@FindBy(css = "e.e1.e2")
private WebElement e;
```

At these cases By-locator defined via __FindBy__ is used. If we are testing a native app the test is failed because of UnsupportedCommandException. CSS and link text are not supported by automation tools. 

So now NoSuchElementException will be thrown an this case insted of UnsupportedCommandException. This minor bug here since 1.7.0 version. 

 

 