### PR TITLE
getAppStrings method returns a map instead of an string

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ If you are using the Eclipse IDE, make sure you are using version Luna or later.
 ##Changelog##
 *4.0.0 (still not released)*
 - `getAppStrings()` methods now return a map with the app strings keys and values, instead of an string
+- Add `getAppStrings(String language, String stringFile)` method to allow searching app strings in the specified file
 
 *3.3.0*
 - updated the dependency on Selenium to version 2.48.2

--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ Locators:
 
 ## Note to developers! ##
 If you are working on this project and use Intellij Idea, you need to change the compiler to the Eclipse compilers instead of the default.
-If you are using the Eclipse IDE, make sure you are using verison Luna or later.
+If you are using the Eclipse IDE, make sure you are using version Luna or later.
 
 ##Changelog##
+*4.0.0 (still not released)*
+- `getAppStrings()` methods now return a map with the app strings keys and values, instead of an string
+
 *3.3.0*
 - updated the dependency on Selenium to version 2.48.2
 - bug fix and enhancements of io.appium.java_client.service.local.AppiumDriverLocalService

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -35,6 +35,7 @@ import javax.xml.bind.DatatypeConverter;
 import java.net.URL;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static io.appium.java_client.MobileCommand.*;
@@ -602,26 +603,28 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
     }
 
     /**
+     * @return a map with localized strings defined in the app
+     *
      * @see HasAppStrings#getAppStrings()
      */
     @Override
-    public String getAppStrings() {
+    public Map<String, String> getAppStrings() {
         Response response = execute(GET_STRINGS);
-        return response.getValue().toString();
+        return (Map<String, String>) response.getValue();
     }
 
     /**
      * @param language
      *            strings language code
-     * @return a string of all the localized strings defined in the app
+     * @return a map with localized strings defined in the app
      *
      * @see HasAppStrings#getAppStrings(String)
      */
     @Override
-    public String getAppStrings(String language) {
+    public Map<String, String> getAppStrings(String language) {
         Response response = execute(GET_STRINGS,
                 getCommandImmutableMap(LANGUAGE_PARAM, language));
-        return response.getValue().toString();
+        return (Map<String, String>) response.getValue();
     }
 
     private TouchAction createTap(WebElement element, int duration) {

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -66,6 +66,7 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
     private final String SETTINGS = "settings";
 
     private final String LANGUAGE_PARAM = "language";
+    private final String STRING_FILE_PARAM = "stringFile";
 
     /**
      * @param originalCapabilities
@@ -624,6 +625,24 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
     public Map<String, String> getAppStrings(String language) {
         Response response = execute(GET_STRINGS,
                 getCommandImmutableMap(LANGUAGE_PARAM, language));
+        return (Map<String, String>) response.getValue();
+    }
+
+    /**
+     * @param language
+     *            strings language code
+     * @param stringFile
+     *            strings filename
+     * @return a map with localized strings defined in the app
+     *
+     * @see HasAppStrings#getAppStrings(String, String)
+     */
+    @Override
+    public Map<String, String> getAppStrings(String language, String stringFile) {
+        String[] parameters = new String[] { LANGUAGE_PARAM, STRING_FILE_PARAM };
+        Object[] values = new Object[] { language, stringFile };
+        Response response = execute(GET_STRINGS,
+                getCommandImmutableMap(parameters, values));
         return (Map<String, String>) response.getValue();
     }
 

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -21,18 +21,31 @@ import java.util.Map;
 public interface HasAppStrings {
 
     /**
-    * Get all defined Strings from an app for the default language
-    *
-    * @return a map with localized strings defined in the app
-    */
+     * Get all defined Strings from an app for the default language
+     *
+     * @return a map with localized strings defined in the app
+     */
     Map<String, String> getAppStrings();
 
     /**
-    * Get all defined Strings from an app for the specified language
-    *
-    * @param language strings language code
-    * @return a map with localized strings defined in the app
-    */
+     * Get all defined Strings from an app for the specified language
+     *
+     * @param language
+     *            strings language code
+     * @return a map with localized strings defined in the app
+     */
     Map<String, String> getAppStrings(String language);
+
+    /**
+     * Get all defined Strings from an app for the specified language and
+     * strings filename
+     *
+     * @param language
+     *            strings language code
+     * @param stringFile
+     *            strings filename
+     * @return a map with localized strings defined in the app
+     */
+    Map<String, String> getAppStrings(String language, String stringFile);
 
 }

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -16,22 +16,23 @@
 
 package io.appium.java_client;
 
+import java.util.Map;
 
 public interface HasAppStrings {
 
     /**
     * Get all defined Strings from an app for the default language
     *
-    * @return a string of all the localized strings defined in the app
+    * @return a map with localized strings defined in the app
     */
-    String getAppStrings();
+    Map<String, String> getAppStrings();
 
     /**
     * Get all defined Strings from an app for the specified language
     *
     * @param language strings language code
-    * @return a string of all the localized strings defined in the app
+    * @return a map with localized strings defined in the app
     */
-    String getAppStrings(String language);
+    Map<String, String> getAppStrings(String language);
 
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.io.File;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -81,14 +82,14 @@ public class AndroidDriverTest {
 
   @Test
   public void getStringsTest() {
-    String strings = driver.getAppStrings();
-    assert(strings.length() > 100);
+    Map<String, String> strings = driver.getAppStrings();
+    assertTrue(strings.size() > 100);
   }
 
   @Test
   public void getStringsWithLanguageTest() {
-    String strings = driver.getAppStrings("en");
-    assert(strings.length() > 100);
+    Map<String, String> strings = driver.getAppStrings("en");
+    assertTrue(strings.size() > 100);
   }
 
   @Test

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -28,10 +28,11 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.io.File;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -70,14 +71,14 @@ public class IOSDriverTest {
 
   @Test
   public void getStringsTest() {
-    String strings = driver.getAppStrings();
-    assert(strings.length() > 100);
+    Map<String, String> strings = driver.getAppStrings();
+    assertTrue(strings.size() > 10);
   }
 
   @Test
   public void getStringsWithLanguageTest() {
-    String strings = driver.getAppStrings("en");
-    assert(strings.length() > 100);
+    Map<String, String> strings = driver.getAppStrings("en");
+    assertTrue(strings.size() > 10);
   }
 
   @Test

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -82,6 +82,18 @@ public class IOSDriverTest {
   }
 
   @Test
+  public void getStringsWithLanguageAndStringFileTest() {
+    Map<String, String> strings = driver.getAppStrings("en", "Localizable.strings");
+    assertTrue(strings.size() > 10);
+  }
+
+  @Test
+  public void getStringsWithUnknownStringFileTest() {
+    Map<String, String> strings = driver.getAppStrings("en", "Unknown.strings");
+    assertTrue(strings.size() > 10);
+  }
+
+  @Test
   public void resetTest() {
     driver.resetApp();
   }


### PR DESCRIPTION
With this change getAppStrings returns a Map<String, String>, making it easier to be used:
```
Map<String, String> strings = driver.getAppStrings();
String string_value = strings.get('string_id');
```
