### PR TITLE
#283 fix: Improvement of AppiumDriverLocalService for the multithreading.

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -44,7 +44,7 @@ public final class AppiumDriverLocalService extends DriverService {
     private final String ipAddress;
     private final long startupTimeout;
     private final TimeUnit timeUnit;
-    private final ReentrantLock lock = new ReentrantLock(true);
+    private final ReentrantLock lock = new ReentrantLock(true); //uses "fair" thread ordering policy
     private final ListOutputStream stream = new ListOutputStream().add(System.out);
 
 

--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -159,9 +159,10 @@ public final class AppiumDriverLocalService extends DriverService {
     public void stop() {
         lock.lock();
         try {
-            if (process.isRunning()) {
+            if (process != null) {
                 destroyProcess();
             }
+            process = null;
         }
         finally {
             lock.unlock();
@@ -170,8 +171,9 @@ public final class AppiumDriverLocalService extends DriverService {
 
 
     private void destroyProcess(){
-        if (process != null)
+        if (process.isRunning()) {
             process.destroy();
+        }
     }
 
     /**

--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -153,8 +153,12 @@ public final class AppiumDriverLocalService extends DriverService {
     @Override
     public void stop() {
         lock.lock();
-        destroyProcess();
-        lock.unlock();
+        try {
+            destroyProcess();
+        }
+        finally {
+            lock.unlock();
+        }
     }
 
 

--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -44,7 +44,7 @@ public final class AppiumDriverLocalService extends DriverService {
     private final String ipAddress;
     private final long startupTimeout;
     private final TimeUnit timeUnit;
-    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock(true);
     private final ListOutputStream stream = new ListOutputStream().add(System.out);
 
 

--- a/src/test/java/io/appium/java_client/localserver/ServerBuilderTest.java
+++ b/src/test/java/io/appium/java_client/localserver/ServerBuilderTest.java
@@ -179,4 +179,35 @@ public class ServerBuilderTest {
                 file.delete();
         }
     }
+
+    @Test
+    public void checkAbilityToShutDownService() {
+        AppiumDriverLocalService service = AppiumDriverLocalService.buildDefaultService();
+        service.start();
+        service.stop();
+        assertTrue(!service.isRunning());
+    }
+
+    @Test
+    public void checkAbilityToStartAndShutDownFewServices() throws Exception{
+        AppiumDriverLocalService service1 = new AppiumServiceBuilder().usingAnyFreePort().build();
+        AppiumDriverLocalService service2 = new AppiumServiceBuilder().usingAnyFreePort().build();
+        AppiumDriverLocalService service3 = new AppiumServiceBuilder().usingAnyFreePort().build();
+        AppiumDriverLocalService service4 = new AppiumServiceBuilder().usingAnyFreePort().build();
+        service1.start();
+        service2.start();
+        service3.start();
+        service4.start();
+        service1.stop();
+        Thread.sleep(1000);
+        service2.stop();
+        Thread.sleep(1000);
+        service3.stop();
+        Thread.sleep(1000);
+        service4.stop();
+        assertTrue(!service1.isRunning());
+        assertTrue(!service2.isRunning());
+        assertTrue(!service3.isRunning());
+        assertTrue(!service4.isRunning());
+    }
 }

--- a/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
+++ b/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
@@ -178,7 +178,9 @@ public class ThreadSafetyTest {
 
         try {
             runThread.start(); //(1)
+            Thread.sleep(10);
             isRunningThread.start();//(2)
+            Thread.sleep(10);
             stopThread.start(); //(3)
 
             while (runThread.isAlive() || isRunningThread.isAlive() || stopThread.isAlive()) {

--- a/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
+++ b/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
@@ -1,0 +1,236 @@
+package io.appium.java_client.localserver;
+
+
+import io.appium.java_client.service.local.AppiumDriverLocalService;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ThreadSafetyTest {
+
+    private static abstract class Action implements Cloneable {
+        abstract Object perform();
+
+        public Action clone() {
+            try {
+                return (Action) super.clone();
+            }
+            catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        }
+    }
+
+    private static class TestThread implements Runnable {
+        private final Action action;
+        private Object result;
+        private Throwable t;
+
+        TestThread(Action action) {
+            this.action = action;
+        }
+
+        @Override
+        public void run() {
+            try {
+                result = action.perform();
+            }
+            catch (Throwable t) {
+                this.t = t;
+            }
+
+        }
+    }
+
+    final AppiumDriverLocalService service = AppiumDriverLocalService.buildDefaultService();
+    final Action run = new Action() {
+        @Override
+        Object perform() {
+            service.start();
+            return "OK";
+        }
+    };
+    final Action run2 = run.clone();
+
+    final Action isRunning = new Action() {
+        @Override
+        Object perform() {
+            return service.isRunning();
+        }
+    };
+    final Action isRunning2 = isRunning.clone();
+
+    final Action stop = new Action() {
+        @Override
+        Object perform() {
+            service.stop();
+            return "OK";
+        }
+    };
+
+    final Action stop2 = stop.clone();
+
+    @Test
+    public void whenFewTreadsDoTheSameWork() throws Throwable {
+
+        TestThread runTestThread = new TestThread(run);
+        TestThread runTestThread2 = new TestThread(run2);
+
+        TestThread isRunningTestThread = new TestThread(isRunning);
+        TestThread isRunningTestThread2 = new TestThread(isRunning2);
+
+        TestThread stopTestThread = new TestThread(stop);
+        TestThread stopTestThread2 = new TestThread(stop2);
+
+        Thread runThread = new Thread(runTestThread);
+        Thread runThread2 = new Thread(runTestThread2);
+
+        Thread isRunningThread = new Thread(isRunningTestThread);
+        Thread isRunningThread2 = new Thread(isRunningTestThread2);
+
+        Thread stopThread = new Thread(stopTestThread);
+        Thread stopThread2 = new Thread(stopTestThread2);
+
+        try {
+            runThread.start();
+            runThread2.start();
+
+            while (runThread.isAlive() || runThread2.isAlive()) {
+                //do nothing
+            }
+
+            if (runTestThread.t != null) {
+                throw runTestThread.t;
+            }
+
+            if (runTestThread2.t != null) {
+                throw runTestThread2.t;
+            }
+
+            assertTrue(runTestThread.result.equals("OK"));
+            assertTrue(runTestThread2.result.equals("OK"));
+            assertTrue(service.isRunning());
+
+            isRunningThread.start();
+            isRunningThread2.start();
+
+            while (isRunningThread.isAlive() || isRunningThread2.isAlive()) {
+                //do nothing
+            }
+
+            if (isRunningTestThread.t != null) {
+                throw isRunningTestThread.t;
+            }
+
+            if (isRunningTestThread2.t != null) {
+                throw isRunningTestThread2.t;
+            }
+
+            assertTrue(isRunningTestThread.result.equals(true));
+            assertTrue(isRunningTestThread2.result.equals(true));
+
+            stopThread.start();
+            stopThread2.start();
+
+            while (stopThread.isAlive() || stopThread2.isAlive()) {
+                //do nothing
+            }
+
+            if (stopTestThread.t != null) {
+                throw stopTestThread.t;
+            }
+
+            if (stopTestThread2.t != null) {
+                throw stopTestThread2.t;
+            }
+
+            assertTrue(stopTestThread.result.equals("OK"));
+            assertTrue(stopTestThread2.result.equals("OK"));
+            assertTrue(!service.isRunning());
+        }
+        finally {
+            if (service.isRunning()) {
+                service.stop();
+            }
+        }
+
+    }
+
+    @Test
+    public void whenFewTreadsDoDifferentWork() throws Throwable {
+        TestThread runTestThread = new TestThread(run);
+        TestThread runTestThread2 = new TestThread(run2);
+
+        TestThread isRunningTestThread = new TestThread(isRunning);
+        TestThread isRunningTestThread2 = new TestThread(isRunning2);
+
+        TestThread stopTestThread = new TestThread(stop);
+        TestThread stopTestThread2 = new TestThread(stop2);
+
+        Thread runThread = new Thread(runTestThread);
+        Thread runThread2 = new Thread(runTestThread2);
+
+        Thread isRunningThread = new Thread(isRunningTestThread);
+        Thread isRunningThread2 = new Thread(isRunningTestThread2);
+
+        Thread stopThread = new Thread(stopTestThread);
+        Thread stopThread2 = new Thread(stopTestThread2);
+
+        try {
+            runThread.start(); //(1)
+            isRunningThread.start();//(2)
+            stopThread.start(); //(3)
+
+            while (runThread.isAlive() || isRunningThread.isAlive() || stopThread.isAlive()) {
+                //do nothing
+            }
+
+            if (runTestThread.t != null) {
+                throw runTestThread.t;
+            }
+
+            if (isRunningTestThread.t != null) {
+                throw isRunningTestThread.t;
+            }
+
+            if (stopTestThread.t != null) {
+                throw stopTestThread.t;
+            }
+
+            assertTrue(runTestThread.result.equals("OK")); //the service had been started firstly (see (1))
+            assertTrue(isRunningTestThread.result.equals(true)); //it was running (see (2))
+            assertTrue(stopTestThread.result.equals("OK")); //and then the test tried to shut down it (see (3))
+            assertTrue(!service.isRunning());
+
+            stopThread2.start(); // (1)
+            isRunningThread2.start(); // (2)
+            runThread2.start(); //(3)
+
+            while (runThread2.isAlive() || isRunningThread2.isAlive() || stopThread2.isAlive()) {
+                //do nothing
+            }
+
+            if (runTestThread2.t != null) {
+                throw runTestThread.t;
+            }
+
+            if (isRunningTestThread2.t != null) {
+                throw isRunningTestThread.t;
+            }
+
+            if (stopTestThread2.t != null) {
+                throw stopTestThread.t;
+            }
+
+            assertTrue(stopTestThread2.result.equals("OK")); //the service had not been started firstly (see (1)), it is ok
+            assertTrue(isRunningTestThread2.result.equals(false)); //so it couldn't being running (see (2))
+            assertTrue(runTestThread2.result.equals("OK")); //and then it was started (see (3))
+            assertTrue(service.isRunning());
+        }
+        finally {
+            if (service.isRunning()) {
+                service.stop();
+            }
+        }
+    }
+}

--- a/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
+++ b/src/test/java/io/appium/java_client/localserver/ThreadSafetyTest.java
@@ -204,8 +204,10 @@ public class ThreadSafetyTest {
             assertTrue(stopTestThread.result.equals("OK")); //and then the test tried to shut down it (see (3))
             assertTrue(!service.isRunning());
 
-            stopThread2.start(); // (1)
-            isRunningThread2.start(); // (2)
+            isRunningThread2.start(); // (1)
+            Thread.sleep(10);
+            stopThread2.start(); // (2)
+            Thread.sleep(10);
             runThread2.start(); //(3)
 
             while (runThread2.isAlive() || isRunningThread2.isAlive() || stopThread2.isAlive()) {
@@ -224,8 +226,8 @@ public class ThreadSafetyTest {
                 throw stopTestThread.t;
             }
 
-            assertTrue(stopTestThread2.result.equals("OK")); //the service had not been started firstly (see (1)), it is ok
-            assertTrue(isRunningTestThread2.result.equals(false)); //so it couldn't being running (see (2))
+            assertTrue(isRunningTestThread2.result.equals(false)); //the service wasn't being running (see (1))
+            assertTrue(stopTestThread2.result.equals("OK")); //the service had not been started firstly (see (2)), it is ok
             assertTrue(runTestThread2.result.equals("OK")); //and then it was started (see (3))
             assertTrue(service.isRunning());
         }


### PR DESCRIPTION
#283 fix Changes:
- Work with _java.util.concurrent.locks.ReentrantLock_ was incorect. It was causing deadlocks/hangings in multithreading. Now it is worked out and uses "fair" synchronization.
- Improvement of the service stopping.
- New tests were provided.