### PR TITLE
#305 fix

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright 2014-2015 Appium Contributors
+Copyright 2014-2016 Appium Contributors

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ If you are using the Eclipse IDE, make sure you are using version Luna or later.
 ##Changelog##
 *3.4.0 (still not released)*
 - Update to Selenium v2.50.0
-- `getAppStrings()` is deprecated now. It is going to be removed. `getAppStringMap()` methods were added and now return a map with the app strings keys and values,
-instead of an string. Thanks to [@rgonalo](https://github.com/rgonalo) for the contribution.
+- `getAppStrings()` methods are deprecated now. They are going to be removed. `getAppStringMap()` methods were added and now return a map with app strings (keys and values)
+instead of a string. Thanks to [@rgonalo](https://github.com/rgonalo) for the contribution.
 - Add `getAppStrings(String language, String stringFile)` method to allow searching app strings in the specified file
 - FIXED of the bug which causes deadlocks of AppiumDriver LocalService in multithreading. Thanks to [saikrishna321](https://github.com/saikrishna321) for the [bug report](https://github.com/appium/java-client/issues/283).
 - FIXED Zoom methods, thanks to [@kkhaidukov](https://github.com/kkhaidukov)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ More can be found in the docs, but here's a quick list of features which this pr
 
 - startActivity()
 - resetApp()
-- getAppStrings()
+- getAppStringMap()
 - pressKeyCode()
 - longPressKeyCode()
 - longPressKey()
@@ -108,11 +108,14 @@ If you are working on this project and use Intellij Idea, you need to change the
 If you are using the Eclipse IDE, make sure you are using version Luna or later.
 
 ##Changelog##
-*4.0.0 (still not released)*
-- `getAppStrings()` methods now return a map with the app strings keys and values, instead of an string
+*3.4.0 (still not released)*
+- Update to Selenium v2.50.0
+- `getAppStrings()` is deprecated now. It is going to be removed. `getAppStringMap()` methods were added and now return a map with the app strings keys and values,
+instead of an string. Thanks to [@rgonalo](https://github.com/rgonalo) for the contribution.
 - Add `getAppStrings(String language, String stringFile)` method to allow searching app strings in the specified file
 - FIXED of the bug which causes deadlocks of AppiumDriver LocalService in multithreading. Thanks to [saikrishna321](https://github.com/saikrishna321) for the [bug report](https://github.com/appium/java-client/issues/283).
-- Fixed Zoom methods, thanks to @kkhaidukov
+- FIXED Zoom methods, thanks to [@kkhaidukov](https://github.com/kkhaidukov)
+- FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x. Take a look at [#305](https://github.com/appium/java-client/issues/305)
 
 *3.3.0*
 - updated the dependency on Selenium to version 2.48.2

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.48.2</version>
+            <version>2.50.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -613,6 +613,17 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
         return response.getValue().toString();
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated. It is going to be removed in the next release.
+     * Be careful.
+     */
+    public String getAppStrings(String language) {
+        Response response = execute(GET_STRINGS,
+                getCommandImmutableMap(LANGUAGE_PARAM, language));
+        return response.getValue().toString();
+    }
+
     /**
      * @return a map with localized strings defined in the app
      *

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -603,13 +603,23 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
         locationContext.setLocation(location);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated. It is going to be removed in the next release.
+     * Be careful.
+     */
+    public String getAppStrings() {
+        Response response = execute(GET_STRINGS);
+        return response.getValue().toString();
+    }
+
     /**
      * @return a map with localized strings defined in the app
      *
-     * @see HasAppStrings#getAppStrings()
+     * @see HasAppStrings#getAppStringMap()
      */
     @Override
-    public Map<String, String> getAppStrings() {
+    public Map<String, String> getAppStringMap() {
         Response response = execute(GET_STRINGS);
         return (Map<String, String>) response.getValue();
     }
@@ -619,10 +629,10 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
      *            strings language code
      * @return a map with localized strings defined in the app
      *
-     * @see HasAppStrings#getAppStrings(String)
+     * @see HasAppStrings#getAppStringMap(String)
      */
     @Override
-    public Map<String, String> getAppStrings(String language) {
+    public Map<String, String> getAppStringMap(String language) {
         Response response = execute(GET_STRINGS,
                 getCommandImmutableMap(LANGUAGE_PARAM, language));
         return (Map<String, String>) response.getValue();
@@ -635,10 +645,10 @@ public abstract class AppiumDriver<RequiredElementType extends WebElement> exten
      *            strings filename
      * @return a map with localized strings defined in the app
      *
-     * @see HasAppStrings#getAppStrings(String, String)
+     * @see HasAppStrings#getAppStringMap(String, String)
      */
     @Override
-    public Map<String, String> getAppStrings(String language, String stringFile) {
+    public Map<String, String> getAppStringMap(String language, String stringFile) {
         String[] parameters = new String[] { LANGUAGE_PARAM, STRING_FILE_PARAM };
         Object[] values = new Object[] { language, stringFile };
         Response response = execute(GET_STRINGS,

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -20,12 +20,19 @@ import java.util.Map;
 
 public interface HasAppStrings {
 
+    @Deprecated
+    /**
+     * This method is deprecated. It is going to be removed in the next release.
+     * Be careful.
+     */
+    public String getAppStrings();
+
     /**
      * Get all defined Strings from an app for the default language
      *
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStrings();
+    Map<String, String> getAppStringMap();
 
     /**
      * Get all defined Strings from an app for the specified language
@@ -34,7 +41,7 @@ public interface HasAppStrings {
      *            strings language code
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStrings(String language);
+    Map<String, String> getAppStringMap(String language);
 
     /**
      * Get all defined Strings from an app for the specified language and
@@ -46,6 +53,6 @@ public interface HasAppStrings {
      *            strings filename
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStrings(String language, String stringFile);
+    Map<String, String> getAppStringMap(String language, String stringFile);
 
 }

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -27,6 +27,13 @@ public interface HasAppStrings {
      */
     public String getAppStrings();
 
+    @Deprecated
+    /**
+     * This method is deprecated. It is going to be removed in the next release.
+     * Be careful.
+     */
+    String getAppStrings(String language);
+
     /**
      * Get all defined Strings from an app for the default language
      *

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -37,14 +37,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class AppiumServiceBuilder extends DriverService.Builder<AppiumDriverLocalService, AppiumServiceBuilder> {
 
     /**
-     * The property of environmental variable used to define
+     * The environmental variable used to define
      * the path to executable appium.js (node server v<=1.4.x) or
      * main.js (node server v>=1.5.x)
      */
     public static final String APPIUM_PATH = "APPIUM_BINARY_PATH";
 
     /**
-     * The property of environmental variable used to define
+     * The environmental variable used to define
      * the path to executable NodeJS file (node.exe for WIN and
      * node for Linux/MacOS X)
      */
@@ -59,7 +59,7 @@ public final class AppiumServiceBuilder extends DriverService.Builder<AppiumDriv
     private static final String APPIUM_JS = "appium.js";
     private static final String MAIN_JS = "main.js";
 
-    private static final String ERROR_TEXT_WHEN_DEFAULT_APPIUM_NODE_IS_NOT_FOUND = "There is no installed nodes! Please " +
+    private static final String ERROR_NODE_NOT_FOUND = "There is no installed nodes! Please " +
             "install node via NPM (https://www.npmjs.com/package/appium#using-node-js) or download and " +
             "install Appium app (http://appium.io/downloads.html)";
 
@@ -126,7 +126,7 @@ public final class AppiumServiceBuilder extends DriverService.Builder<AppiumDriv
             if (StringUtils.isBlank(instancePath) || !(defaultAppiumNode = new File(instancePath + File.separator +
                     APPIUM_FOLDER)).exists()) {
                 String errorOutput = commandLine.getStdOut();
-                throw new InvalidServerInstanceException(ERROR_TEXT_WHEN_DEFAULT_APPIUM_NODE_IS_NOT_FOUND,
+                throw new InvalidServerInstanceException(ERROR_NODE_NOT_FOUND,
                         new IOException(errorOutput));
             }
 
@@ -141,7 +141,7 @@ public final class AppiumServiceBuilder extends DriverService.Builder<AppiumDriv
                 return newResult;
             }
 
-            throw new InvalidServerInstanceException(ERROR_TEXT_WHEN_DEFAULT_APPIUM_NODE_IS_NOT_FOUND,
+            throw new InvalidServerInstanceException(ERROR_NODE_NOT_FOUND,
                     new IOException("Could not find file neither " + APPIUM_NODE_MASK_OLD + " nor " + APPIUM_NODE_MASK + " in the " +
                     defaultAppiumNode + " directory"));
         }

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -57,7 +57,7 @@ public final class AppiumServiceBuilder extends DriverService.Builder<AppiumDriv
     private static final String LIB_FOLDER = "lib";
 
     private static final String APPIUM_JS = "appium.js";
-    private static final String MAIN_JS = "appium.js";
+    private static final String MAIN_JS = "main.js";
 
     private static final String ERROR_TEXT_WHEN_DEFAULT_APPIUM_NODE_IS_NOT_FOUND = "There is no installed nodes! Please " +
             "install node via NPM (https://www.npmjs.com/package/appium#using-node-js) or download and " +

--- a/src/main/java/io/appium/java_client/service/local/InvalidServerInstanceException.java
+++ b/src/main/java/io/appium/java_client/service/local/InvalidServerInstanceException.java
@@ -24,8 +24,4 @@ public class InvalidServerInstanceException extends RuntimeException {
     public InvalidServerInstanceException(String messege, Throwable t){
         super(MESSAGE_PREFIX + messege, t);
     }
-
-    public InvalidServerInstanceException(String messege){
-        super(MESSAGE_PREFIX + messege);
-    }
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -82,13 +82,13 @@ public class AndroidDriverTest {
 
   @Test
   public void getStringsTest() {
-    Map<String, String> strings = driver.getAppStrings();
+    Map<String, String> strings = driver.getAppStringMap();
     assertTrue(strings.size() > 100);
   }
 
   @Test
   public void getStringsWithLanguageTest() {
-    Map<String, String> strings = driver.getAppStrings("en");
+    Map<String, String> strings = driver.getAppStringMap("en");
     assertTrue(strings.size() > 100);
   }
 

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -71,25 +71,25 @@ public class IOSDriverTest {
 
   @Test
   public void getStringsTest() {
-    Map<String, String> strings = driver.getAppStrings();
+    Map<String, String> strings = driver.getAppStringMap();
     assertTrue(strings.size() > 10);
   }
 
   @Test
   public void getStringsWithLanguageTest() {
-    Map<String, String> strings = driver.getAppStrings("en");
+    Map<String, String> strings = driver.getAppStringMap("en");
     assertTrue(strings.size() > 10);
   }
 
   @Test
   public void getStringsWithLanguageAndStringFileTest() {
-    Map<String, String> strings = driver.getAppStrings("en", "Localizable.strings");
+    Map<String, String> strings = driver.getAppStringMap("en", "Localizable.strings");
     assertTrue(strings.size() > 10);
   }
 
   @Test
   public void getStringsWithUnknownStringFileTest() {
-    Map<String, String> strings = driver.getAppStrings("en", "Unknown.strings");
+    Map<String, String> strings = driver.getAppStringMap("en", "Unknown.strings");
     assertTrue(strings.size() > 10);
   }
 


### PR DESCRIPTION
Change list:
- The #305 fix;
- update to Selenium 2.50.0
- changes of HasAppStrings interface. The old 'getAppStrings()' was returned with __Deprecated__ mark. Appium java client has wide user community. So let's care about users and let them prepare for serious API change. New methods were renamed to 'getAppStringMap'. @rgonalo Are you ok with this change?