### PR TITLE
#320 fix

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/Widget.java
+++ b/src/main/java/io/appium/java_client/pagefactory/Widget.java
@@ -61,4 +61,8 @@ public abstract class Widget implements SearchContext, WrapsDriver, WrapsElement
     public WebElement getWrappedElement() {
         return (WebElement) element;
     }
+
+    public Widget getSelfReference() {
+        return this;
+    }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/AndroidOverrideWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/AndroidOverrideWidgetTest.java
@@ -3,6 +3,8 @@ package io.appium.java_client.pagefactory_tests.widgets;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.TimeOutDuration;
+import io.appium.java_client.pagefactory_tests.widgets.android.annotated.AnnotatedAndroidMovie;
+import io.appium.java_client.pagefactory_tests.widgets.android.simple.AndroidMovie;
 import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import org.apache.commons.lang3.StringUtils;
@@ -68,6 +70,7 @@ public class AndroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkSimpleReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AndroidMovie.class));
     }
 
     @Override
@@ -81,6 +84,7 @@ public class AndroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkAnnotatedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedAndroidMovie.class));
     }
 
 
@@ -95,6 +99,7 @@ public class AndroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkExtendedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedAndroidMovie.class));
     }
 
     @Override

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/HtmlOverrideWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/HtmlOverrideWidgetTest.java
@@ -2,6 +2,8 @@ package io.appium.java_client.pagefactory_tests.widgets;
 
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.TimeOutDuration;
+import io.appium.java_client.pagefactory_tests.widgets.html.annotated.AnnotatedHtmlMovie;
+import io.appium.java_client.pagefactory_tests.widgets.html.simple.HtmlMovie;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -45,7 +47,7 @@ public class HtmlOverrideWidgetTest implements WidgetTest{
     @Before
     public void setUp() throws Exception {
         if (driver != null)
-            driver.get("file:///" + new File("src/test/java/io/appium/java_client/RottenTomatoesSnapshot.html").getAbsolutePath());
+            driver.get( new File("src/test/java/io/appium/java_client/RottenTomatoesSnapshot.html").toURI().toString());
     }
 
     @AfterClass
@@ -65,6 +67,7 @@ public class HtmlOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkSimpleReview();
+        assertTrue(movie.getSelfReference().getClass().equals(HtmlMovie.class));
     }
 
     @Override
@@ -78,6 +81,7 @@ public class HtmlOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkAnnotatedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedHtmlMovie.class));
     }
 
 
@@ -92,6 +96,7 @@ public class HtmlOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkExtendedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedHtmlMovie.class));
     }
 
     @Override

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/IOSOverrideWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/IOSOverrideWidgetTest.java
@@ -3,6 +3,8 @@ package io.appium.java_client.pagefactory_tests.widgets;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.TimeOutDuration;
+import io.appium.java_client.pagefactory_tests.widgets.ios.annotated.AnnotatedIOSMovie;
+import io.appium.java_client.pagefactory_tests.widgets.ios.simple.IOSMovie;
 import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import org.apache.commons.lang3.StringUtils;
@@ -68,6 +70,7 @@ public class IOSOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkSimpleReview();
+        assertTrue(movie.getSelfReference().getClass().equals(IOSMovie.class));
     }
 
     @Override
@@ -81,6 +84,7 @@ public class IOSOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkAnnotatedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedIOSMovie.class));
     }
 
 
@@ -95,6 +99,7 @@ public class IOSOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
 
         rottenTomatoes.checkExtendedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedIOSMovie.class));
     }
 
     @Override

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Movie.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Movie.java
@@ -15,4 +15,9 @@ public abstract class Movie extends Widget{
     public abstract Object getPoster();
 
     public abstract void goToReview();
+
+    @Override
+    public Movie getSelfReference() {
+        return (Movie) super.getSelfReference();
+    }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Movies.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Movies.java
@@ -12,4 +12,9 @@ public abstract class Movies extends Widget{
     public abstract int getMovieCount();
 
     public abstract Movie getMovie(int index);
+
+    @Override
+    public Movies getSelfReference() {
+        return (Movies) super.getSelfReference();
+    }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Review.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/Review.java
@@ -16,4 +16,9 @@ public abstract class Review extends Widget{
     public abstract String info();
 
     public abstract Object getPoster();
+
+    @Override
+    public Review getSelfReference() {
+        return (Review) super.getSelfReference();
+    }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/SelendroidOverrideWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/SelendroidOverrideWidgetTest.java
@@ -3,6 +3,8 @@ package io.appium.java_client.pagefactory_tests.widgets;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.TimeOutDuration;
+import io.appium.java_client.pagefactory_tests.widgets.selendroid.annotated.AnnotatedSelendroidMovie;
+import io.appium.java_client.pagefactory_tests.widgets.selendroid.simple.SelendroidMovie;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -72,6 +74,7 @@ public class SelendroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
         driver.getPageSource();  //forcing the refreshing hierarchy
         rottenTomatoes.checkSimpleReview();
+        assertTrue(movie.getSelfReference().getClass().equals(SelendroidMovie.class));
     }
 
     @Override
@@ -85,6 +88,7 @@ public class SelendroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
         driver.getPageSource();  //forcing the refreshing hierarchy
         rottenTomatoes.checkAnnotatedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedSelendroidMovie.class));
     }
 
 
@@ -99,6 +103,7 @@ public class SelendroidOverrideWidgetTest implements WidgetTest{
         movie.goToReview();
         driver.getPageSource();  //forcing the refreshing hierarchy
         rottenTomatoes.checkExtendedReview();
+        assertTrue(movie.getSelfReference().getClass().equals(AnnotatedSelendroidMovie.class));
     }
 
     @Override


### PR DESCRIPTION
Changes:

- #320 fix. The Widget.getSelfReference() was added. This method allows to extract a real widget-object from inside a proxy at some extraordinary situations.

- test modification

This change is the addition to features whis heve been implemented here: https://github.com/appium/java-client/pull/267. There was a problem: 

>This use case has some restrictions;
...
> - for now it is not possible to 
  
```java
  import io.appium.java_client.pagefactory.OverrideWidget;
  ...
  
  //above is the other field declaration
  @OverrideWidget(html = UsersWidgetForHtml.class, 
  androidUIAutomator = UsersWidgetForAndroid.class, iOSUIAutomation = UsersWidgetForIOS .class)
  DefaultAbstractUsersWidget widget;

  //below is the other field/method declaration

  //user's code
  ((UsersWidgetForAndroid) widget).doSpecialWorkForAndroing()
```

>I think that this problem will be resolved next time.

So this commit resolves this issie and related problems this way: 

```java
  import io.appium.java_client.pagefactory.OverrideWidget;
  ...
  
  //above is the other field declaration
  @OverrideWidget(html = UsersWidgetForHtml.class, 
  androidUIAutomator = UsersWidgetForAndroid.class, iOSUIAutomation = UsersWidgetForIOS .class)
  DefaultAbstractUsersWidget widget;

  //below is the other field/method declaration

  //user's code
  ((UsersWidgetForAndroid) widget.getSelfReference()).doSpecialWorkForAndroing()
```

