### PR TITLE
#379 fix #371 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,12 @@
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
             <version>1.3.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.1</version>
+            <version>2.5</version>
         </dependency>
     </dependencies>
     <packaging>jar</packaging>

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -62,7 +62,7 @@ public class MobileCommand {
     public static final String TOGGLE_LOCATION_SERVICES = "toggleLocationServices";
     public static final String GET_DEVICE_TIME = "getDeviceTime";
     public static final String UNLOCK = "unlock";
-    static final  Map<String, CommandInfo> commandRepository = getMobileCommands();
+    public static final  Map<String, CommandInfo> commandRepository = getMobileCommands();
 
     static CommandInfo getC(String url) {
         return new CommandInfo(url, HttpMethod.GET);

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
@@ -84,7 +84,14 @@ enum Strategies {
             return By
                 .partialLinkText(getValue(annotation, this));
         }
-    };
+    },
+    BYNSPREDICATE("nsPredicate") {
+        @Override By getBy(Annotation annotation) {
+            return MobileBy
+                    .IosNsPredicateString(getValue(annotation, this));
+        }
+    }
+    ;
 
     private final String valueName;
 

--- a/src/main/java/io/appium/java_client/pagefactory/iOSFindBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/iOSFindBy.java
@@ -65,4 +65,15 @@ public @interface iOSFindBy {
      * It is a xpath to the target element.
      */
     String xpath() default "";
+
+    /**
+     * This parameter makes perform the searching by iOS NSPredicate.
+     * This locator strategy is available in XCUITest Driver mode.
+     * Documentation to read:
+     * https://github.com/appium/java-client/blob/master/docs/
+     * Installing-xcuitest-driver.md
+     *
+     * https://github.com/appium/appium-xcuitest-driver/blob/master/README.md
+     */
+    String nsPredicate()  default "";
 }


### PR DESCRIPTION
## Change list

#379 fix #371 fix
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
#379 fix:
- the nsPredicate parameter was added to the iOSFindBy annotation

#371 fix
-  the commandRepository field is public now. The modification of  the MobileCommand

Also:
- _net.lingala.zip4j_ _zip4j_ was included to only test-scope dependencies
- _commons-io_ was updated to the v2.5