### PR TITLE
the constructor AppiumDriver(executor, capabilities) became public

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -98,7 +98,18 @@ public abstract class AppiumDriver<T extends WebElement>
     private RemoteLocationContext locationContext;
     private ExecuteMethod executeMethod;
 
-    private AppiumDriver(HttpCommandExecutor executor, Capabilities capabilities,
+    /**
+     * @param executor is an instance of {@link org.openqa.selenium.remote.HttpCommandExecutor}
+     *                 or class that extends it. Default commands or another vendor-specific
+     *                 commands may be specified there.
+     * @param capabilities take a look
+     *                     at {@link org.openqa.selenium.Capabilities}
+     * @param converterClazz is an instance of a class that extends
+     * {@link org.openqa.selenium.remote.internal.JsonToWebElementConverter}. It converts
+     *                       JSON response to an instance of
+     *                       {@link org.openqa.selenium.WebElement}
+     */
+    protected AppiumDriver(HttpCommandExecutor executor, Capabilities capabilities,
         Class<? extends JsonToWebElementConverter> converterClazz) {
         super(executor, capabilities);
         this.executeMethod = new AppiumExecutionMethod(this);

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -64,11 +64,11 @@ public class MobileCommand {
     public static final String UNLOCK = "unlock";
     public static final  Map<String, CommandInfo> commandRepository = getMobileCommands();
 
-    static CommandInfo getC(String url) {
+    public static CommandInfo getC(String url) {
         return new CommandInfo(url, HttpMethod.GET);
     }
 
-    static CommandInfo postC(String url) {
+    public static CommandInfo postC(String url) {
         return new CommandInfo(url, HttpMethod.POST);
     }
 

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 
@@ -73,6 +74,17 @@ public class AndroidDriver<T extends WebElement>
     FindsByAndroidUIAutomator<T> {
 
     private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
+
+    /**
+     * @param executor is an instance of {@link org.openqa.selenium.remote.HttpCommandExecutor}
+     *                 or class that extends it. Default commands or another vendor-specific
+     *                 commands may be specified there.
+     * @param capabilities take a look
+     *                     at {@link org.openqa.selenium.Capabilities}
+     */
+    public AndroidDriver(HttpCommandExecutor executor, Capabilities capabilities) {
+        super(executor, capabilities, JsonToAndroidElementConverter.class);
+    }
 
     /**
      * @param remoteAddress is the address of remotely/locally

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -36,6 +36,7 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.URL;
@@ -58,7 +59,18 @@ public class IOSDriver<T extends WebElement>
         FindsByIosUIAutomation<T>, FindsByIosNsPredicate<T> {
 
     private static final String IOS_PLATFORM = MobilePlatform.IOS;
-    
+
+    /**
+     * @param executor is an instance of {@link org.openqa.selenium.remote.HttpCommandExecutor}
+     *                 or class that extends it. Default commands or another vendor-specific
+     *                 commands may be specified there.
+     * @param capabilities take a look
+     *                     at {@link org.openqa.selenium.Capabilities}
+     */
+    public IOSDriver(HttpCommandExecutor executor, Capabilities capabilities) {
+        super(executor, capabilities, JsonToIOSElementConverter.class);
+    }
+
     /**
      * @param remoteAddress is the address
      *                      of remotely/locally started Appium server


### PR DESCRIPTION
## Change list

Changes:

- constructors like  AppiumDriver(executor, capabilities) were added to AndroidDriver and IOSDriver

- the MobileCommand was modified.  Modifiers of getC(String url) postC(String url) were changed to public.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

This change makes possible to use java_client with solutions of other vendors that require commands which are not supported by default appium. 