### PR TITLE
The GetsNamedTextField interface has become deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ anymore.
 - the ability to start an activity using Android intent actions, intent categories, flags and arguments
 was added to `AndroidDriver`. Thanks to [@saikrishna321](https://github.com/saikrishna321) for the contribution.
 - `scrollTo()` and `scrollToExact()` became deprecated. They are going to be removed in the next release.
+- The interface `io.appium.java_client.ios.GetsNamedTextField` and the declared method `T getNamedTextField(String name)` are 
+deprecated as well. They are going to be removed in the next release.
 - Methods `findElements(String by, String using)` and `findElement(String by, String using)` of `org.openga.selenium.remote.RemoteWebdriver` are public now. Thanks to [@SrinivasanTarget](https://github.com/SrinivasanTarget).
 - the `io.appium.java_client.NetworkConnectionSetting` class was marked deprecated
 - the enum `io.appium.java_client.android.Connection` was added. All supported network bitmasks are defined there.

--- a/src/main/java/io/appium/java_client/ios/GetsNamedTextField.java
+++ b/src/main/java/io/appium/java_client/ios/GetsNamedTextField.java
@@ -18,11 +18,16 @@ package io.appium.java_client.ios;
 
 import org.openqa.selenium.WebElement;
 
+@Deprecated
+/**
+ * This interface is deprecated and it is going to be removed further.
+ */
 public interface GetsNamedTextField<T extends WebElement> {
     /**
      * In iOS apps, named TextFields have the same accessibility Id as their
      * containing TableElement. This is a convenience method for getting the
-     * named TextField, rather than its containing element.
+     * named TextField, rather than its containing element.     *
+     * This method is deprecated and it is going to be removed further.
      *
      * @param name accessiblity id of TextField
      * @return The textfield with the given accessibility id

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -231,9 +231,7 @@ public class IOSDriver<T extends WebElement>
         execute(SHAKE);
     }
 
-    /**
-     * @see GetsNamedTextField#getNamedTextField(String).
-     */
+    @Deprecated
     @SuppressWarnings("unchecked")
     @Override
     public T getNamedTextField(

--- a/src/test/java/io/appium/java_client/ios/IOSGesturesTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSGesturesTest.java
@@ -46,7 +46,7 @@ public class IOSGesturesTest extends BaseIOSTest {
 
     @Test public void horizontalSwipingTest() {
         MobileElement slider = driver.findElementByClassName("UIASlider");
-        slider.swipe(SwipeElementDirection.LEFT, slider.getSize().getWidth()/2, 0, 3000);
+        slider.swipe(SwipeElementDirection.LEFT, slider.getSize().getWidth() / 2, 0, 3000);
         assertEquals("1%", slider.getAttribute("value"));
         slider.swipe(SwipeElementDirection.RIGHT, 2, 0, 3000);
         assertEquals("100%", slider.getAttribute("value"));


### PR DESCRIPTION
## Change list

The GetsNamedTextField interface has become deprecated

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
I think that the using of hardcoded locators is the bad practice. Also I think that user can handle these actions the better way.
