### PR TITLE
Remove elementRuleMap for proxyForAnElement

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -43,7 +43,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -75,16 +74,6 @@ public class AppiumFieldDecorator implements FieldDecorator {
 
         };
 
-    private static final Map<Class<? extends SearchContext>, Class<? extends WebElement>>
-        elementRuleMap =
-        new HashMap<Class<? extends SearchContext>, Class<? extends WebElement>>() {
-            private static final long serialVersionUID = 1L;
-
-            {
-                put(AndroidDriver.class, AndroidElement.class);
-                put(IOSDriver.class, IOSElement.class);
-            }
-        };
     public static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
     public static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
     private final WebDriver originalDriver;
@@ -231,15 +220,12 @@ public class AppiumFieldDecorator implements FieldDecorator {
 
     private Class<?> getTypeForProxy() {
         Class<? extends SearchContext> driverClass = originalDriver.getClass();
-        Iterable<Map.Entry<Class<? extends SearchContext>, Class<? extends WebElement>>> rules =
-            elementRuleMap.entrySet();
-        //it will return MobileElement subclass when here is something
-        for (Map.Entry<Class<? extends SearchContext>, Class<? extends WebElement>> e : rules) {
-            //that extends AppiumDriver or MobileElement
-            if (e.getKey().isAssignableFrom(driverClass)) {
-                return e.getValue();
-            }
-        } //it is compatible with desktop browser. So at this case it returns RemoteWebElement.class
+        //it will return MobileElement if it is mobile platform
+        if (AndroidDriver.class.isAssignableFrom(driverClass)
+                || IOSDriver.class.isAssignableFrom(driverClass)) {
+            return MobileElement.class;
+        }
+        //it is compatible with desktop browser. So at this case it returns RemoteWebElement.class
         return RemoteWebElement.class;
     }
 


### PR DESCRIPTION
## Change list

Remove elementRuleMap for use AppiumFieldDecorator with сustom mobile element. 
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

If framework have custom elements extended from io.appium.java_client.MobileElement AppiumFieldDecorator can not be usable. (Exception log)[https://gist.github.com/HlebHalkouski/60d0fb9fdada045589aff7eef1dba8a8]
