### PR TITLE
The setValue method was moved to MobileElement.

### DIFF
--- a/src/main/java/io/appium/java_client/MobileElement.java
+++ b/src/main/java/io/appium/java_client/MobileElement.java
@@ -16,6 +16,8 @@
 
 package io.appium.java_client;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
@@ -105,5 +107,17 @@ public abstract class MobileElement
 
     @Override public List<MobileElement> findElementsByAccessibilityId(String using) {
         return super.findElementsByAccessibilityId(using);
+    }
+
+    /**
+     * This method sets the new value of the attribute "value".
+     *
+     * @param value is the new value which should be set
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void setValue(String value) {
+        ImmutableMap.Builder builder = ImmutableMap.builder();
+        builder.put("id", id).put("value", value);
+        execute(MobileCommand.SET_VALUE, builder.build());
     }
 }

--- a/src/main/java/io/appium/java_client/ios/IOSElement.java
+++ b/src/main/java/io/appium/java_client/ios/IOSElement.java
@@ -16,10 +16,7 @@
 
 package io.appium.java_client.ios;
 
-import com.google.common.collect.ImmutableMap;
-
 import io.appium.java_client.FindsByIosUIAutomation;
-import io.appium.java_client.MobileCommand;
 import io.appium.java_client.MobileElement;
 import org.openqa.selenium.WebDriverException;
 
@@ -43,17 +40,5 @@ public class IOSElement extends MobileElement
     @Override public List<MobileElement> findElementsByIosUIAutomation(String using)
         throws WebDriverException {
         return findElements("-ios uiautomation", using);
-    }
-
-    /**
-     * This method sets the new value of the attribute "value".
-     *
-     * @param value is the new value which should be set
-     */
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public void setValue(String value) {
-        ImmutableMap.Builder builder = ImmutableMap.builder();
-        builder.put("id", id).put("value", value);
-        execute(MobileCommand.SET_VALUE, builder.build());
     }
 }

--- a/src/test/java/io/appium/java_client/android/AndroidElementTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidElementTest.java
@@ -74,4 +74,14 @@ public class AndroidElementTest extends BaseAndroidTest {
                         + "new UiSelector().text(\"Radio Group\"));"));
         assertNotNull(radioGroup.getLocation());
     }
+
+    @Test public void setValueTest() {
+        String value = "new value";
+
+        driver.startActivity("io.appium.android.apis", ".view.Controls1");
+        AndroidElement editElement = driver
+            .findElementByAndroidUIAutomator("resourceId(\"io.appium.android.apis:id/edit\")");
+        editElement.setValue(value);
+        assertEquals(value, editElement.getText());
+    }
 }


### PR DESCRIPTION
## Change list

- The `setValue` method was moved to `MobileElement` from the `IOSElement`. It works agains 
text input elements on Android

- The `setValueTest` was added to `AndroidElementTest`.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

As soon as the `/wd/hub/session/:sessionId?/element/:elementId?/value` works against Android now then it makes sense to return it back to the `MobileElement`.

Also read #427
