### PR TITLE
The complete #215 fix and addition to #403

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -689,8 +689,8 @@ public abstract class AppiumDriver<T extends WebElement>
      * @return a map with values that hold session details.
      *
      */
-    public Map<String, String> getSessionDetails() {
+    public Map<String, Object> getSessionDetails() {
         Response response = execute(GET_SESSION);
-        return (Map<String, String>) response.getValue();
+        return (Map<String, Object>) response.getValue();
     }
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -18,9 +18,9 @@ package io.appium.java_client.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 
 import io.appium.java_client.AppiumSetting;
 import org.apache.commons.codec.binary.Base64;
@@ -30,6 +30,7 @@ import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.html5.Location;
 
 import java.io.File;
+import java.util.Map;
 
 public class AndroidDriverTest extends BaseAndroidTest {
 
@@ -138,7 +139,12 @@ public class AndroidDriverTest extends BaseAndroidTest {
     }
 
     @Test public void getDeviceUDIDTest() {
-        String deviceSerial = driver.getSessionDetails().get("deviceUDID");
+        String deviceSerial = driver.getSessionDetails().get("deviceUDID").toString();
         assertNotNull(deviceSerial);
+    }
+
+    @Test public void getSessionMapData() {
+        Map<?,?> map = (Map<?, ?>) driver.getSessionDetails().get("desired");
+        assertNotEquals(map.size(), 0);
     }
 }


### PR DESCRIPTION
## Change list

The complete #215 fix and addition to #403:
 - The fix of the bug which has not been caught.
```
  "status": 0,
  "value": {
    "platform": "LINUX",
    "webStorageEnabled": false,
    "takesScreenshot": true,
    "javascriptEnabled": true,
    "databaseEnabled": false,
    "networkConnectionEnabled": true,
    "locationContextEnabled": false,
    "warnings": {
      
    },
    "desired": {
      "app": "\/Users\/saikrisv\/git\/java-client\/java-client\/src\/test\/java\/io\/appium\/java_client\/IntentExample.apk",
      "platformName": "Android",
      "deviceName": "Android Emulator"
    },
    "app": "\/Users\/saikrisv\/git\/java-client\/java-client\/src\/test\/java\/io\/appium\/java_client\/IntentExample.apk",
    "platformName": "Android",
    "deviceName": "192.168.65.101:5555",
    "deviceUDID": "192.168.65.101:5555",
    "platformVersion": "5.0",
    "appPackage": "com.prgguru.android",
    "appWaitPackage": "com.prgguru.android",
    "appActivity": "com.prgguru.android.IntentExampleActivity",
    "appWaitActivity": "com.prgguru.android.IntentExampleActivity"
  },
  "sessionId": "0ac42e16-65c3-40ec-bcf0-fae7d9dd9a4a"
}
```
If invoke 

```
driver.getSessionDetails().get("desired");
```
then it throws 
```
java.lang.ClassCastException: com.google.common.collect.Maps$TransformedEntriesMap cannot be cast to java.lang.String

	at io.appium.java_client.android.AndroidDriverTest.getDeviceUDIDTest(AndroidDriverTest.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

Also it is possible that the result would contain Integer, Boolean and other values. 
The method returns a `Map<String, Object>` now. 

- an additional test was added
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

I was intending to close the #215. At that moment I found a bug.