### PR TITLE
Convenient access to commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>2.53.0</version>
+            <version>2.53.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>cglib</groupId>

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -537,7 +537,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @param settings Map of setting keys and values.
      */
     private void setSettings(ImmutableMap<?, ?> settings) {
-        execute(SET_SETTINGS, MobileCommand.prepareArguments("settings", settings));
+        execute(SET_SETTINGS, prepareArguments("settings", settings));
     }
 
     /**
@@ -549,7 +549,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @param value   value of the setting.
      */
     protected void setSetting(AppiumSetting setting, Object value) {
-        setSettings(MobileCommand.prepareArguments(setting.toString(), value));
+        setSettings(prepareArguments(setting.toString(), value));
     }
 
     @Override public WebDriver context(String name) {
@@ -619,7 +619,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @see HasAppStrings#getAppStringMap(String).
      */
     @Override public Map<String, String> getAppStringMap(String language) {
-        Response response = execute(GET_STRINGS, MobileCommand.prepareArguments("language", language));
+        Response response = execute(GET_STRINGS, prepareArguments("language", language));
         return (Map<String, String>) response.getValue();
     }
 

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -18,6 +18,7 @@
 package io.appium.java_client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import static io.appium.java_client.MobileCommand.CLOSE_APP;
 import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
@@ -46,7 +47,6 @@ import io.appium.java_client.remote.MobileCapabilityType;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Dimension;
@@ -187,34 +187,6 @@ public abstract class AppiumDriver<T extends WebElement>
         DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
         dc.setCapability(MobileCapabilityType.PLATFORM_NAME, newPlatform);
         return dc;
-    }
-
-    /**
-     * @param param is a parameter name.
-     * @param value is the parameter value.
-     * @return built {@link ImmutableMap}.
-     */
-    protected static ImmutableMap<String, Object> getCommandImmutableMap(String param,
-        Object value) {
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-        builder.put(param, value);
-        return builder.build();
-    }
-
-    /**
-     * @param params is the array with parameter names.
-     * @param values is the array with parameter values.
-     * @return built {@link ImmutableMap}.
-     */
-    protected static ImmutableMap<String, Object> getCommandImmutableMap(String[] params,
-        Object[] values) {
-        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-        for (int i = 0; i < params.length; i++) {
-            if (!StringUtils.isBlank(params[i]) && (values[i] != null)) {
-                builder.put(params[i], values[i]);
-            }
-        }
-        return builder.build();
     }
 
     @SuppressWarnings("unused")
@@ -572,7 +544,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @param settings Map of setting keys and values.
      */
     private void setSettings(ImmutableMap<?, ?> settings) {
-        execute(SET_SETTINGS, getCommandImmutableMap("settings", settings));
+        execute(SET_SETTINGS, MobileCommand.prepareArguments("settings", settings));
     }
 
     /**
@@ -584,7 +556,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @param value   value of the setting.
      */
     protected void setSetting(AppiumSetting setting, Object value) {
-        setSettings(getCommandImmutableMap(setting.toString(), value));
+        setSettings(MobileCommand.prepareArguments(setting.toString(), value));
     }
 
     @Override public WebDriver context(String name) {
@@ -654,7 +626,7 @@ public abstract class AppiumDriver<T extends WebElement>
      * @see HasAppStrings#getAppStringMap(String).
      */
     @Override public Map<String, String> getAppStringMap(String language) {
-        Response response = execute(GET_STRINGS, getCommandImmutableMap("language", language));
+        Response response = execute(GET_STRINGS, MobileCommand.prepareArguments("language", language));
         return (Map<String, String>) response.getValue();
     }
 
@@ -667,7 +639,7 @@ public abstract class AppiumDriver<T extends WebElement>
     @Override public Map<String, String> getAppStringMap(String language, String stringFile) {
         String[] parameters = new String[] {"language", "stringFile"};
         Object[] values = new Object[] {language, stringFile};
-        Response response = execute(GET_STRINGS, getCommandImmutableMap(parameters, values));
+        Response response = execute(GET_STRINGS, prepareArguments(parameters, values));
         return (Map<String, String>) response.getValue();
     }
 

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -18,7 +18,6 @@
 package io.appium.java_client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import static io.appium.java_client.MobileCommand.CLOSE_APP;
 import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
@@ -36,6 +35,7 @@ import static io.appium.java_client.MobileCommand.PULL_FOLDER;
 import static io.appium.java_client.MobileCommand.REMOVE_APP;
 import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
 import static io.appium.java_client.MobileCommand.SET_SETTINGS;
+import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -57,7 +57,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.html5.Location;
 
-import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ErrorHandler;
@@ -67,7 +66,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.html5.RemoteLocationContext;
 import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.remote.http.HttpMethod;
 import org.openqa.selenium.remote.internal.JsonToWebElementConverter;
 
 import java.lang.reflect.Constructor;
@@ -187,11 +185,6 @@ public abstract class AppiumDriver<T extends WebElement>
         DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
         dc.setCapability(MobileCapabilityType.PLATFORM_NAME, newPlatform);
         return dc;
-    }
-
-    @SuppressWarnings("unused")
-    private static CommandInfo deleteC(String url) {
-        return new CommandInfo(url, HttpMethod.DELETE);
     }
 
     @Override public List<T> findElements(By by) {

--- a/src/main/java/io/appium/java_client/CommandExecutionHelper.java
+++ b/src/main/java/io/appium/java_client/CommandExecutionHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client;
+
+import org.openqa.selenium.remote.Response;
+
+import java.util.Map;
+
+public final class CommandExecutionHelper {
+
+    public static <T extends Object> T execute(MobileElement element,
+        Map.Entry<String, Map<String, ?>> keyValuePair) {
+        return handleResponse(element.execute(keyValuePair.getKey(), keyValuePair.getValue()));
+    }
+
+    public static <T extends Object> T execute(MobileDriver driver,
+        Map.Entry<String, Map<String, ?>> keyValuePair) {
+        return handleResponse(driver.execute(keyValuePair.getKey(), keyValuePair.getValue()));
+    }
+
+    private static <T extends Object> T handleResponse(Response responce) {
+        if (responce != null) {
+            return (T) responce.getValue();
+        }
+        return null;
+    }
+ }

--- a/src/main/java/io/appium/java_client/CommandExecutionHelper.java
+++ b/src/main/java/io/appium/java_client/CommandExecutionHelper.java
@@ -38,4 +38,4 @@ public final class CommandExecutionHelper {
         }
         return null;
     }
- }
+}

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -118,14 +118,32 @@ public class MobileCommand {
         }
     };
 
+    /**
+     * This methods forms GET commands.
+     *
+     * @param url is the command URL
+     * @return an instance of {@link org.openqa.selenium.remote.CommandInfo}
+     */
     public static CommandInfo getC(String url) {
         return new CommandInfo(url, HttpMethod.GET);
     }
 
+    /**
+     * This methods forms POST commands.
+     *
+     * @param url is the command URL
+     * @return an instance of {@link org.openqa.selenium.remote.CommandInfo}
+     */
     public static CommandInfo postC(String url) {
         return new CommandInfo(url, HttpMethod.POST);
     }
 
+    /**
+     * This methods forms DELETE commands.
+     *
+     * @param url is the command URL
+     * @return an instance of {@link org.openqa.selenium.remote.CommandInfo}
+     */
     public static CommandInfo deleteC(String url) {
         return new CommandInfo(url, HttpMethod.DELETE);
     }

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -68,55 +68,56 @@ public class MobileCommand {
     protected static final String UNLOCK = "unlock";
     protected static final String REPLACE_VALUE = "replaceValue";
 
-    public static final  Map<String, CommandInfo> commandRepository =
-        new HashMap<String, CommandInfo>() {
-            {
-                put(RESET, postC("/session/:sessionId/appium/app/reset"));
-                put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"));
-                put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"));
-                put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"));
-                put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"));
-                put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"));
-                put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"));
-                put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"));
-                put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"));
-                put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"));
-                put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"));
-                put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"));
-                put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"));
-                put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"));
-                put(LOCK, postC("/session/:sessionId/appium/device/lock"));
-                put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"));
-                put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"));
-                put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
-                put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
-                put(GET_SESSION,getC("/session/:sessionId/"));
-                //iOS
-                put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
-                //Android
-                put(CURRENT_ACTIVITY,
-                        getC("/session/:sessionId/appium/device/current_activity"));
-                put(END_TEST_COVERAGE,
-                        postC("/session/:sessionId/appium/app/end_test_coverage"));
-                put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"));
-                put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"));
-                put(LONG_PRESS_KEY_CODE,
-                        postC("/session/:sessionId/appium/device/long_press_keycode"));
-                put(OPEN_NOTIFICATIONS,
-                        postC("/session/:sessionId/appium/device/open_notifications"));
-                put(PRESS_KEY_CODE,
-                        postC("/session/:sessionId/appium/device/press_keycode"));
-                put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"));
-                put(SET_NETWORK_CONNECTION,
-                        postC("/session/:sessionId/network_connection"));
-                put(START_ACTIVITY,
-                        postC("/session/:sessionId/appium/device/start_activity"));
-                put(TOGGLE_LOCATION_SERVICES,
-                        postC("/session/:sessionId/appium/device/toggle_location_services"));
-                put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
-                put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
-            }
-    };
+    public static final  Map<String, CommandInfo> commandRepository = createCommandRepository();
+
+    private static Map<String, CommandInfo> createCommandRepository() {
+        HashMap<String, CommandInfo> result = new HashMap<String, CommandInfo>();
+        result.put(RESET, postC("/session/:sessionId/appium/app/reset"));
+        result.put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"));
+        result.put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"));
+        result.put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"));
+        result.put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"));
+        result.put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"));
+        result.put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"));
+        result.put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"));
+        result.put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"));
+        result.put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"));
+        result.put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"));
+        result.put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"));
+        result.put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"));
+        result.put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"));
+        result.put(LOCK, postC("/session/:sessionId/appium/device/lock"));
+        result.put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"));
+        result.put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"));
+        result.put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
+        result.put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
+        result.put(GET_SESSION,getC("/session/:sessionId/"));
+        //iOS
+        result.put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
+        //Android
+        result.put(CURRENT_ACTIVITY,
+            getC("/session/:sessionId/appium/device/current_activity"));
+        result.put(END_TEST_COVERAGE,
+            postC("/session/:sessionId/appium/app/end_test_coverage"));
+        result.put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"));
+        result.put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"));
+        result.put(LONG_PRESS_KEY_CODE,
+            postC("/session/:sessionId/appium/device/long_press_keycode"));
+        result.put(OPEN_NOTIFICATIONS,
+            postC("/session/:sessionId/appium/device/open_notifications"));
+        result.put(PRESS_KEY_CODE,
+            postC("/session/:sessionId/appium/device/press_keycode"));
+        result.put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"));
+        result.put(SET_NETWORK_CONNECTION,
+            postC("/session/:sessionId/network_connection"));
+        result.put(START_ACTIVITY,
+            postC("/session/:sessionId/appium/device/start_activity"));
+        result.put(TOGGLE_LOCATION_SERVICES,
+            postC("/session/:sessionId/appium/device/toggle_location_services"));
+        result.put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
+        result.put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
+        return result;
+    }
 
     /**
      * This methods forms GET commands.

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -69,53 +69,53 @@ public class MobileCommand {
     protected static final String REPLACE_VALUE = "replaceValue";
 
     public static final  Map<String, CommandInfo> commandRepository =
-        new HashMap<String, CommandInfo>(){
-        {
-            put(RESET, postC("/session/:sessionId/appium/app/reset"));
-            put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"));
-            put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"));
-            put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"));
-            put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"));
-            put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"));
-            put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"));
-            put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"));
-            put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"));
-            put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"));
-            put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"));
-            put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"));
-            put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"));
-            put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"));
-            put(LOCK, postC("/session/:sessionId/appium/device/lock"));
-            put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"));
-            put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"));
-            put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
-            put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
-            put(GET_SESSION,getC("/session/:sessionId/"));
-            //iOS
-            put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
-            //Android
-            put(CURRENT_ACTIVITY,
-                    getC("/session/:sessionId/appium/device/current_activity"));
-            put(END_TEST_COVERAGE,
-                    postC("/session/:sessionId/appium/app/end_test_coverage"));
-            put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"));
-            put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"));
-            put(LONG_PRESS_KEY_CODE,
-                    postC("/session/:sessionId/appium/device/long_press_keycode"));
-            put(OPEN_NOTIFICATIONS,
-                    postC("/session/:sessionId/appium/device/open_notifications"));
-            put(PRESS_KEY_CODE,
-                    postC("/session/:sessionId/appium/device/press_keycode"));
-            put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"));
-            put(SET_NETWORK_CONNECTION,
-                    postC("/session/:sessionId/network_connection"));
-            put(START_ACTIVITY,
-                    postC("/session/:sessionId/appium/device/start_activity"));
-            put(TOGGLE_LOCATION_SERVICES,
-                    postC("/session/:sessionId/appium/device/toggle_location_services"));
-            put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
-            put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
-        }
+        new HashMap<String, CommandInfo>() {
+            {
+                put(RESET, postC("/session/:sessionId/appium/app/reset"));
+                put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"));
+                put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"));
+                put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"));
+                put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"));
+                put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"));
+                put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"));
+                put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"));
+                put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"));
+                put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"));
+                put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"));
+                put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"));
+                put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"));
+                put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"));
+                put(LOCK, postC("/session/:sessionId/appium/device/lock"));
+                put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"));
+                put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"));
+                put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
+                put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
+                put(GET_SESSION,getC("/session/:sessionId/"));
+                //iOS
+                put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
+                //Android
+                put(CURRENT_ACTIVITY,
+                        getC("/session/:sessionId/appium/device/current_activity"));
+                put(END_TEST_COVERAGE,
+                        postC("/session/:sessionId/appium/app/end_test_coverage"));
+                put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"));
+                put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"));
+                put(LONG_PRESS_KEY_CODE,
+                        postC("/session/:sessionId/appium/device/long_press_keycode"));
+                put(OPEN_NOTIFICATIONS,
+                        postC("/session/:sessionId/appium/device/open_notifications"));
+                put(PRESS_KEY_CODE,
+                        postC("/session/:sessionId/appium/device/press_keycode"));
+                put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"));
+                put(SET_NETWORK_CONNECTION,
+                        postC("/session/:sessionId/network_connection"));
+                put(START_ACTIVITY,
+                        postC("/session/:sessionId/appium/device/start_activity"));
+                put(TOGGLE_LOCATION_SERVICES,
+                        postC("/session/:sessionId/appium/device/toggle_location_services"));
+                put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
+                put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
+            }
     };
 
     /**

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -126,6 +126,10 @@ public class MobileCommand {
         return new CommandInfo(url, HttpMethod.POST);
     }
 
+    public static CommandInfo deleteC(String url) {
+        return new CommandInfo(url, HttpMethod.DELETE);
+    }
+
     /**
      * @param param is a parameter name.
      * @param value is the parameter value.

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -18,9 +18,11 @@ package io.appium.java_client;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -28,42 +30,93 @@ import java.util.Map;
  * wire protocol.
  */
 public class MobileCommand {
+    //General
+    protected static final String RESET = "reset";
+    protected static final String GET_STRINGS = "getStrings";
+    protected static final String SET_VALUE = "setValue";
+    protected static final String PULL_FILE = "pullFile";
+    protected static final String PULL_FOLDER = "pullFolder";
+    protected static final String HIDE_KEYBOARD = "hideKeyboard";
+    protected static final String RUN_APP_IN_BACKGROUND = "runAppInBackground";
+    protected static final String PERFORM_TOUCH_ACTION = "performTouchAction";
+    protected static final String PERFORM_MULTI_TOUCH = "performMultiTouch";
+    protected static final String IS_APP_INSTALLED = "isAppInstalled";
+    protected static final String INSTALL_APP = "installApp";
+    protected static final String REMOVE_APP = "removeApp";
+    protected static final String LAUNCH_APP = "launchApp";
+    protected static final String CLOSE_APP = "closeApp";
+    protected static final String LOCK = "lock";
+    protected static final String COMPLEX_FIND = "complexFind";
+    protected static final String GET_SETTINGS = "getSettings";
+    protected static final String SET_SETTINGS = "setSettings";
+    protected static final String GET_DEVICE_TIME = "getDeviceTime";
+    protected static final String GET_SESSION = "getSession";
+    //iOS
+    protected static final String SHAKE = "shake";
+    //Android
+    protected static final String CURRENT_ACTIVITY = "currentActivity";
+    protected static final String END_TEST_COVERAGE = "endTestCoverage";
+    protected static final String GET_NETWORK_CONNECTION = "getNetworkConnection";
+    protected static final String IS_LOCKED = "isLocked";
+    protected static final String LONG_PRESS_KEY_CODE = "longPressKeyCode";
+    protected static final String OPEN_NOTIFICATIONS = "openNotifications";
+    protected static final String PRESS_KEY_CODE = "pressKeyCode";
+    protected static final String PUSH_FILE = "pushFile";
+    protected static final String SET_NETWORK_CONNECTION = "setNetworkConnection";
+    protected static final String START_ACTIVITY = "startActivity";
+    protected static final String TOGGLE_LOCATION_SERVICES = "toggleLocationServices";
+    protected static final String UNLOCK = "unlock";
+    protected static final String REPLACE_VALUE = "replaceValue";
 
-    public static final String RESET = "reset";
-    public static final String GET_STRINGS = "getStrings";
-    public static final String PRESS_KEY_CODE = "pressKeyCode";
-    public static final String LONG_PRESS_KEY_CODE = "longPressKeyCode";
-    public static final String CURRENT_ACTIVITY = "currentActivity";
-    public static final String SET_VALUE = "setValue";
-    public static final String REPLACE_VALUE = "replaceValue";
-    public static final String PULL_FILE = "pullFile";
-    public static final String PUSH_FILE = "pushFile";
-    public static final String PULL_FOLDER = "pullFolder";
-    public static final String HIDE_KEYBOARD = "hideKeyboard";
-    public static final String RUN_APP_IN_BACKGROUND = "runAppInBackground";
-    public static final String PERFORM_TOUCH_ACTION = "performTouchAction";
-    public static final String PERFORM_MULTI_TOUCH = "performMultiTouch";
-    public static final String IS_APP_INSTALLED = "isAppInstalled";
-    public static final String INSTALL_APP = "installApp";
-    public static final String REMOVE_APP = "removeApp";
-    public static final String LAUNCH_APP = "launchApp";
-    public static final String CLOSE_APP = "closeApp";
-    public static final String END_TEST_COVERAGE = "endTestCoverage";
-    public static final String LOCK = "lock";
-    public static final String IS_LOCKED = "isLocked";
-    public static final String SHAKE = "shake";
-    public static final String COMPLEX_FIND = "complexFind";
-    public static final String OPEN_NOTIFICATIONS = "openNotifications";
-    public static final String GET_NETWORK_CONNECTION = "getNetworkConnection";
-    public static final String SET_NETWORK_CONNECTION = "setNetworkConnection";
-    public static final String GET_SETTINGS = "getSettings";
-    public static final String SET_SETTINGS = "setSettings";
-    public static final String START_ACTIVITY = "startActivity";
-    public static final String TOGGLE_LOCATION_SERVICES = "toggleLocationServices";
-    public static final String GET_DEVICE_TIME = "getDeviceTime";
-    public static final String UNLOCK = "unlock";
-    public static final String GET_SESSION = "getSession";
-    public static final  Map<String, CommandInfo> commandRepository = getMobileCommands();
+    public static final  Map<String, CommandInfo> commandRepository =
+        new HashMap<String, CommandInfo>(){
+        {
+            put(RESET, postC("/session/:sessionId/appium/app/reset"));
+            put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"));
+            put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"));
+            put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"));
+            put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"));
+            put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"));
+            put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"));
+            put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"));
+            put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"));
+            put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"));
+            put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"));
+            put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"));
+            put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"));
+            put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"));
+            put(LOCK, postC("/session/:sessionId/appium/device/lock"));
+            put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"));
+            put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"));
+            put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
+            put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
+            put(GET_SESSION,getC("/session/:sessionId/"));
+            //iOS
+            put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
+            //Android
+            put(CURRENT_ACTIVITY,
+                    getC("/session/:sessionId/appium/device/current_activity"));
+            put(END_TEST_COVERAGE,
+                    postC("/session/:sessionId/appium/app/end_test_coverage"));
+            put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"));
+            put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"));
+            put(LONG_PRESS_KEY_CODE,
+                    postC("/session/:sessionId/appium/device/long_press_keycode"));
+            put(OPEN_NOTIFICATIONS,
+                    postC("/session/:sessionId/appium/device/open_notifications"));
+            put(PRESS_KEY_CODE,
+                    postC("/session/:sessionId/appium/device/press_keycode"));
+            put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"));
+            put(SET_NETWORK_CONNECTION,
+                    postC("/session/:sessionId/network_connection"));
+            put(START_ACTIVITY,
+                    postC("/session/:sessionId/appium/device/start_activity"));
+            put(TOGGLE_LOCATION_SERVICES,
+                    postC("/session/:sessionId/appium/device/toggle_location_services"));
+            put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
+            put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
+        }
+    };
 
     public static CommandInfo getC(String url) {
         return new CommandInfo(url, HttpMethod.GET);
@@ -73,48 +126,31 @@ public class MobileCommand {
         return new CommandInfo(url, HttpMethod.POST);
     }
 
-    private static Map<String, CommandInfo> getMobileCommands() {
-        if (commandRepository != null) {
-            return commandRepository;
+    /**
+     * @param param is a parameter name.
+     * @param value is the parameter value.
+     * @return built {@link ImmutableMap}.
+     */
+    protected static ImmutableMap<String, Object> prepareArguments(String param,
+                                                                   Object value) {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        builder.put(param, value);
+        return builder.build();
+    }
+
+    /**
+     * @param params is the array with parameter names.
+     * @param values is the array with parameter values.
+     * @return built {@link ImmutableMap}.
+     */
+    protected static ImmutableMap<String, Object> prepareArguments(String[] params,
+                                                                   Object[] values) {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        for (int i = 0; i < params.length; i++) {
+            if (!StringUtils.isBlank(params[i]) && (values[i] != null)) {
+                builder.put(params[i], values[i]);
+            }
         }
-
-        ImmutableMap.Builder<String, CommandInfo> builder = ImmutableMap.builder();
-        builder.put(RESET, postC("/session/:sessionId/appium/app/reset"))
-            .put(GET_STRINGS, postC("/session/:sessionId/appium/app/strings"))
-            .put(PRESS_KEY_CODE, postC("/session/:sessionId/appium/device/press_keycode"))
-            .put(LONG_PRESS_KEY_CODE, postC("/session/:sessionId/appium/device/long_press_keycode"))
-            .put(CURRENT_ACTIVITY, getC("/session/:sessionId/appium/device/current_activity"))
-            .put(SET_VALUE, postC("/session/:sessionId/appium/element/:id/value"))
-            .put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"))
-            .put(PULL_FILE, postC("/session/:sessionId/appium/device/pull_file"))
-            .put(PULL_FOLDER, postC("/session/:sessionId/appium/device/pull_folder"))
-            .put(HIDE_KEYBOARD, postC("/session/:sessionId/appium/device/hide_keyboard"))
-            .put(PUSH_FILE, postC("/session/:sessionId/appium/device/push_file"))
-            .put(RUN_APP_IN_BACKGROUND, postC("/session/:sessionId/appium/app/background"))
-            .put(PERFORM_TOUCH_ACTION, postC("/session/:sessionId/touch/perform"))
-            .put(PERFORM_MULTI_TOUCH, postC("/session/:sessionId/touch/multi/perform"))
-            .put(IS_APP_INSTALLED, postC("/session/:sessionId/appium/device/app_installed"))
-            .put(INSTALL_APP, postC("/session/:sessionId/appium/device/install_app"))
-            .put(REMOVE_APP, postC("/session/:sessionId/appium/device/remove_app"))
-            .put(LAUNCH_APP, postC("/session/:sessionId/appium/app/launch"))
-            .put(CLOSE_APP, postC("/session/:sessionId/appium/app/close"))
-            .put(END_TEST_COVERAGE, postC("/session/:sessionId/appium/app/end_test_coverage"))
-            .put(LOCK, postC("/session/:sessionId/appium/device/lock"))
-            .put(IS_LOCKED, postC("/session/:sessionId/appium/device/is_locked"))
-            .put(SHAKE, postC("/session/:sessionId/appium/device/shake"))
-            .put(COMPLEX_FIND, postC("/session/:sessionId/appium/app/complex_find"))
-            .put(OPEN_NOTIFICATIONS, postC("/session/:sessionId/appium/device/open_notifications"))
-            .put(GET_NETWORK_CONNECTION, getC("/session/:sessionId/network_connection"))
-            .put(SET_NETWORK_CONNECTION, postC("/session/:sessionId/network_connection"))
-            .put(GET_SETTINGS, getC("/session/:sessionId/appium/settings"))
-            .put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"))
-            .put(START_ACTIVITY, postC("/session/:sessionId/appium/device/start_activity"))
-            .put(TOGGLE_LOCATION_SERVICES,
-                postC("/session/:sessionId/appium/device/toggle_location_services"))
-            .put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"))
-            .put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"))
-            .put(GET_SESSION,getC("/session/:sessionId/"));
-
         return builder.build();
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -19,8 +19,8 @@ package io.appium.java_client.android;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import static io.appium.java_client.android.AndroidMobileCommandHelper.currentActivityCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.getNetworkConnectionCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getNetworkConnectionCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.isLockedCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.lockDeviceCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.longPressKeyCodeCommand;

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -16,26 +16,25 @@
 
 package io.appium.java_client.android;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.appium.java_client.MobileCommand.CURRENT_ACTIVITY;
-import static io.appium.java_client.MobileCommand.END_TEST_COVERAGE;
-import static io.appium.java_client.MobileCommand.GET_NETWORK_CONNECTION;
-import static io.appium.java_client.MobileCommand.IS_LOCKED;
-import static io.appium.java_client.MobileCommand.LOCK;
-import static io.appium.java_client.MobileCommand.LONG_PRESS_KEY_CODE;
-import static io.appium.java_client.MobileCommand.OPEN_NOTIFICATIONS;
-import static io.appium.java_client.MobileCommand.PRESS_KEY_CODE;
-import static io.appium.java_client.MobileCommand.PUSH_FILE;
-import static io.appium.java_client.MobileCommand.SET_NETWORK_CONNECTION;
-import static io.appium.java_client.MobileCommand.START_ACTIVITY;
-import static io.appium.java_client.MobileCommand.TOGGLE_LOCATION_SERVICES;
-import static io.appium.java_client.MobileCommand.UNLOCK;
 
-import com.google.common.collect.ImmutableMap;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.currentActivityCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getNetworkConnectionCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.isLockedCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.lockDeviceCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.longPressKeyCodeCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.pressKeyCodeCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.pushFileCommandCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.setConnectionCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.unlockCommand;
 
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.AppiumSetting;
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
 import io.appium.java_client.android.internal.JsonToAndroidElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
@@ -43,12 +42,10 @@ import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
-import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 
 import java.io.File;
@@ -195,7 +192,7 @@ public class AndroidDriver<T extends WebElement>
      * @param key code for the key pressed on the device.
      */
     @Override public void pressKeyCode(int key) {
-        execute(PRESS_KEY_CODE, getCommandImmutableMap("keycode", key));
+        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key));
     }
 
     /**
@@ -206,9 +203,7 @@ public class AndroidDriver<T extends WebElement>
      * @see AndroidDeviceActionShortcuts#pressKeyCode(int, Integer).
      */
     @Override public void pressKeyCode(int key, Integer metastate) {
-        String[] parameters = new String[] {"keycode", "metastate"};
-        Object[] values = new Object[] {key, metastate};
-        execute(PRESS_KEY_CODE, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key, metastate));
     }
 
     /**
@@ -217,7 +212,7 @@ public class AndroidDriver<T extends WebElement>
      * @param key code for the long key pressed on the device.
      */
     @Override public void longPressKeyCode(int key) {
-        execute(LONG_PRESS_KEY_CODE, getCommandImmutableMap("keycode", key));
+        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key));
     }
 
     /**
@@ -228,21 +223,15 @@ public class AndroidDriver<T extends WebElement>
      * @see AndroidDeviceActionShortcuts#pressKeyCode(int, Integer)
      */
     @Override public void longPressKeyCode(int key, Integer metastate) {
-        String[] parameters = new String[] {"keycode", "metastate"};
-        Object[] values = new Object[] {key, metastate};
-        execute(LONG_PRESS_KEY_CODE, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key, metastate));
     }
 
     @Override public void setConnection(Connection connection) {
-        String[] parameters = new String[] {"name", "parameters"};
-        Object[] values =
-            new Object[] {"network_connection", ImmutableMap.of("type", connection.bitMask)};
-        execute(SET_NETWORK_CONNECTION, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, setConnectionCommand(connection));
     }
 
     @Override public Connection getConnection() {
-        Response response = execute(GET_NETWORK_CONNECTION);
-        int bitMask = Integer.parseInt(response.getValue().toString());
+        long bitMask = CommandExecutionHelper.execute(this, getNetworkConnectionCommand());
         Connection[] types = Connection.values();
 
         for (Connection connection: types) {
@@ -255,9 +244,7 @@ public class AndroidDriver<T extends WebElement>
     }
 
     @Override public void pushFile(String remotePath, byte[] base64Data) {
-        String[] parameters = new String[] {"path", "data"};
-        Object[] values = new Object[] {remotePath, base64Data};
-        execute(PUSH_FILE, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, pushFileCommandCommand(remotePath, base64Data));
     }
 
     @Override public void pushFile(String remotePath, File file) throws IOException {
@@ -276,31 +263,9 @@ public class AndroidDriver<T extends WebElement>
         String intentCategory, String intentFlags,
         String optionalIntentArguments,boolean stopApp )
         throws IllegalArgumentException {
-
-        checkArgument((!StringUtils.isBlank(appPackage)
-                && !StringUtils.isBlank(appActivity)),
-            String.format("'%s' and '%s' are required.", "appPackage", "appActivity"));
-
-        appWaitPackage = !StringUtils.isBlank(appWaitPackage) ? appWaitPackage : "";
-        appWaitActivity = !StringUtils.isBlank(appWaitActivity) ? appWaitActivity : "";
-        intentAction = !StringUtils.isBlank(intentAction) ? intentAction : "";
-        intentCategory = !StringUtils.isBlank(intentCategory) ? intentCategory : "";
-        intentFlags = !StringUtils.isBlank(intentFlags) ? intentFlags : "";
-        optionalIntentArguments = !StringUtils.isBlank(optionalIntentArguments)
-            ? optionalIntentArguments : "";
-
-        ImmutableMap<String, ?> parameters = ImmutableMap
-            .<String, Object>builder().put("appPackage", appPackage)
-            .put("appActivity", appActivity)
-            .put("appWaitPackage", appWaitPackage)
-            .put("appWaitActivity", appWaitActivity)
-            .put("dontStopAppOnReset", !stopApp)
-            .put("intentAction", intentAction)
-            .put("intentCategory", intentCategory)
-            .put("intentFlags", intentFlags)
-            .put("optionalIntentArguments", optionalIntentArguments)
-            .build();
-        execute(START_ACTIVITY, parameters);
+        CommandExecutionHelper.execute(this, startActivityCommand(appPackage, appActivity,
+            appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags,
+            optionalIntentArguments, stopApp));
     }
 
 
@@ -344,9 +309,7 @@ public class AndroidDriver<T extends WebElement>
      * @param path   path to .ec file.
      */
     public void endTestCoverage(String intent, String path) {
-        String[] parameters = new String[] {"intent", "path"};
-        Object[] values = new Object[] {intent, path};
-        execute(END_TEST_COVERAGE, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, endTestCoverageCommand(intent, path));
     }
 
     /**
@@ -355,15 +318,14 @@ public class AndroidDriver<T extends WebElement>
      * @return a current activity being run on the mobile device.
      */
     public String currentActivity() {
-        Response response = execute(CURRENT_ACTIVITY);
-        return response.getValue().toString();
+        return CommandExecutionHelper.execute(this, currentActivityCommand());
     }
 
     /**
      * Open the notification shade, on Android devices.
      */
     public void openNotifications() {
-        execute(OPEN_NOTIFICATIONS);
+        CommandExecutionHelper.execute(this, openNotificationsCommand());
     }
 
     /**
@@ -372,12 +334,11 @@ public class AndroidDriver<T extends WebElement>
      * @return true if device is locked. False otherwise
      */
     public boolean isLocked() {
-        Response response = execute(IS_LOCKED);
-        return Boolean.parseBoolean(response.getValue().toString());
+        return CommandExecutionHelper.execute(this, isLockedCommand());
     }
 
     public void toggleLocationServices() {
-        execute(TOGGLE_LOCATION_SERVICES);
+        CommandExecutionHelper.execute(this, toggleLocationServicesCommand());
     }
 
     /**
@@ -398,35 +359,33 @@ public class AndroidDriver<T extends WebElement>
      * @throws WebDriverException This method is not
      *     applicable with browser/webview UI.
      */
-    @SuppressWarnings("unchecked")
     @Override
     public T findElementByAndroidUIAutomator(String using)
         throws WebDriverException {
-        return (T) findElement("-android uiautomator", using);
+        return findElement("-android uiautomator", using);
     }
 
     /**
      * @throws WebDriverException This method is not
      *      applicable with browser/webview UI.
      */
-    @SuppressWarnings("unchecked")
     @Override
     public List<T> findElementsByAndroidUIAutomator(String using)
         throws WebDriverException {
-        return (List<T>) findElements("-android uiautomator", using);
+        return findElements("-android uiautomator", using);
     }
 
     /**
      * This method locks a device.
      */
     public void lockDevice() {
-        execute(LOCK, ImmutableMap.of("seconds", 0));
+        CommandExecutionHelper.execute(this, lockDeviceCommand());
     }
 
     /**
      * This method unlocks a device.
      */
     public void unlockDevice() {
-        execute(UNLOCK);
+        CommandExecutionHelper.execute(this, unlockCommand());
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidElement.java
+++ b/src/main/java/io/appium/java_client/android/AndroidElement.java
@@ -16,10 +16,10 @@
 
 package io.appium.java_client.android;
 
-import com.google.common.collect.ImmutableMap;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.replaceElementValueCommand;
 
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
-import io.appium.java_client.MobileCommand;
 import io.appium.java_client.MobileElement;
 
 import org.openqa.selenium.WebDriverException;
@@ -50,9 +50,7 @@ public class AndroidElement extends MobileElement
      * This method replace current text value.
      * @param value a new value
      */
-    @SuppressWarnings({"rawtypes", "unchecked"}) public void replaceValue(String value) {
-        ImmutableMap.Builder builder = ImmutableMap.builder();
-        builder.put("id", getId()).put("value", new String[] {value});
-        execute(MobileCommand.REPLACE_VALUE, builder.build());
+    public void replaceValue(String value) {
+        CommandExecutionHelper.execute(this, replaceElementValueCommand(this, value));
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -19,7 +19,9 @@ package io.appium.java_client.android;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.MobileCommand;
+
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.internal.HasIdentity;
 
@@ -205,7 +207,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      *                                start activity [Optional]
      * @return a key-value pair. The key is the command name. The value is a
      * {@link java.util.Map} command arguments.
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException when any required argument is empty
      */
     public static Map.Entry<String, Map<String, ?>> startActivityCommand(String appPackage,
         String appActivity,

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -27,16 +27,32 @@ import java.util.AbstractMap;
 import java.util.Map;
 
 /**
- * The repository of Android-specific mobile commands defined in the Mobile JSON
- * wire protocol.
+ * This util class helps to prepare parameters of Android-specific JSONWP
+ * commands.
  */
 public class AndroidMobileCommandHelper extends MobileCommand {
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * getting of the current activity.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> currentActivityCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(CURRENT_ACTIVITY, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * ending of the test coverage.
+     *
+     * @param intent intent to broadcast.
+     * @param path   path to .ec file.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> endTestCoverageCommand(String intent,
         String path) {
         String[] parameters = new String[] {"intent", "path"};
@@ -45,21 +61,52 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(END_TEST_COVERAGE, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * getting of a network connection value.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> getNetworkConnectionCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(GET_NETWORK_CONNECTION, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * checking of the device state (is it locked or not).
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> isLockedCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(IS_LOCKED, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * key event invocation.
+     *
+     * @param key code for the key pressed on the device.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> pressKeyCodeCommand(int key) {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(PRESS_KEY_CODE, prepareArguments("keycode", key));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * key event invocation.
+     *
+     * @param key       code for the key pressed on the Android device.
+     * @param metastate metastate for the keypress.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> pressKeyCodeCommand(int key,
         Integer metastate) {
         String[] parameters = new String[] {"keycode", "metastate"};
@@ -68,11 +115,28 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(PRESS_KEY_CODE, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * long key event invocation.
+     *
+     * @param key code for the long key pressed on the device.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> longPressKeyCodeCommand(int key) {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments("keycode", key));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * long key event invocation.
+     *
+     * @param key       code for the long key pressed on the Android device.
+     * @param metastate metastate for the long key press.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> longPressKeyCodeCommand(int key,
         Integer metastate) {
         String[] parameters = new String[] {"keycode", "metastate"};
@@ -81,11 +145,27 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * notification opening.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> openNotificationsCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(OPEN_NOTIFICATIONS, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * file pushing
+     *
+     * @param remotePath Path to file to write data to on remote device
+     * @param base64Data Base64 encoded byte array of data to write to remote device
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>>  pushFileCommandCommand(String remotePath,
         byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
@@ -94,6 +174,14 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(PUSH_FILE, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * setting of device network connection.
+     *
+     * @param connection The bitmask of the desired connection
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> setConnectionCommand(Connection connection) {
         String[] parameters = new String[] {"name", "parameters"};
         Object[] values =
@@ -102,6 +190,23 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(SET_NETWORK_CONNECTION, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * activity starting.
+     *
+     * @param appPackage      The package containing the activity. [Required]
+     * @param appActivity     The activity to start. [Required]
+     * @param appWaitPackage  Automation will begin after this package starts. [Optional]
+     * @param appWaitActivity Automation will begin after this activity starts. [Optional]
+     * @param intentAction  Intent action which will be used to start activity [Optional]
+     * @param intentCategory  Intent category which will be used to start activity [Optional]
+     * @param intentFlags  Flags that will be used to start activity [Optional]
+     * @param optionalIntentArguments Additional intent arguments that will be used to
+     *                                start activity [Optional]
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     * @throws IllegalArgumentException
+     */
     public static Map.Entry<String, Map<String, ?>> startActivityCommand(String appPackage,
         String appActivity,
         String appWaitPackage,
@@ -137,21 +242,51 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             Map<String, ?>>(START_ACTIVITY, parameters);
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * toggling of  location services.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> toggleLocationServicesCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(TOGGLE_LOCATION_SERVICES, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * device unlocking.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> unlockCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(UNLOCK, ImmutableMap.<String, Object>of());
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * device locking.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(LOCK, prepareArguments("seconds", 0));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the element
+     * value replacement. It is used against input elements
+     *
+     * @param hasIdentityObject an instance which contains an element ID
+     * @param value a new value
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>>  replaceElementValueCommand(
         HasIdentity hasIdentityObject, String value) {
         String[] parameters = new String[] {"id", "value"};

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -210,35 +210,32 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * @throws IllegalArgumentException when any required argument is empty
      */
     public static Map.Entry<String, Map<String, ?>> startActivityCommand(String appPackage,
-        String appActivity,
-        String appWaitPackage,
-        String appWaitActivity, String intentAction,
-        String intentCategory, String intentFlags,
-        String optionalIntentArguments,boolean stopApp )
-        throws IllegalArgumentException {
+        String appActivity, String appWaitPackage, String appWaitActivity,
+        String intentAction, String intentCategory, String intentFlags,
+        String optionalIntentArguments, boolean stopApp) throws IllegalArgumentException {
 
         checkArgument((!StringUtils.isBlank(appPackage)
                 && !StringUtils.isBlank(appActivity)),
             String.format("'%s' and '%s' are required.", "appPackage", "appActivity"));
 
-        appWaitPackage = !StringUtils.isBlank(appWaitPackage) ? appWaitPackage : "";
-        appWaitActivity = !StringUtils.isBlank(appWaitActivity) ? appWaitActivity : "";
-        intentAction = !StringUtils.isBlank(intentAction) ? intentAction : "";
-        intentCategory = !StringUtils.isBlank(intentCategory) ? intentCategory : "";
-        intentFlags = !StringUtils.isBlank(intentFlags) ? intentFlags : "";
-        optionalIntentArguments = !StringUtils.isBlank(optionalIntentArguments)
+        String targetWaitPackage = !StringUtils.isBlank(appWaitPackage) ? appWaitPackage : "";
+        String targetWaitActivity = !StringUtils.isBlank(appWaitActivity) ? appWaitActivity : "";
+        String targetIntentAction = !StringUtils.isBlank(intentAction) ? intentAction : "";
+        String targetIntentCategory = !StringUtils.isBlank(intentCategory) ? intentCategory : "";
+        String targetIntentFlags = !StringUtils.isBlank(intentFlags) ? intentFlags : "";
+        String targetOptionalIntentArguments = !StringUtils.isBlank(optionalIntentArguments)
             ? optionalIntentArguments : "";
 
         ImmutableMap<String, ?> parameters = ImmutableMap
             .<String, Object>builder().put("appPackage", appPackage)
             .put("appActivity", appActivity)
-            .put("appWaitPackage", appWaitPackage)
-            .put("appWaitActivity", appWaitActivity)
+            .put("appWaitPackage", targetWaitPackage)
+            .put("appWaitActivity", targetWaitActivity)
             .put("dontStopAppOnReset", !stopApp)
-            .put("intentAction", intentAction)
-            .put("intentCategory", intentCategory)
-            .put("intentFlags", intentFlags)
-            .put("optionalIntentArguments", optionalIntentArguments)
+            .put("intentAction", targetIntentAction)
+            .put("intentCategory", targetIntentCategory)
+            .put("intentFlags", targetIntentFlags)
+            .put("optionalIntentArguments", targetOptionalIntentArguments)
             .build();
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(START_ACTIVITY, parameters);

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
+import io.appium.java_client.MobileCommand;
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.internal.HasIdentity;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+/**
+ * The repository of Android-specific mobile commands defined in the Mobile JSON
+ * wire protocol.
+ */
+public class AndroidMobileCommandHelper extends MobileCommand {
+
+    public static Map.Entry<String, Map<String, ?>> currentActivityCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(CURRENT_ACTIVITY, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>> endTestCoverageCommand(String intent,
+        String path) {
+        String[] parameters = new String[] {"intent", "path"};
+        Object[] values = new Object[] {intent, path};
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(END_TEST_COVERAGE, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> getNetworkConnectionCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(GET_NETWORK_CONNECTION, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>> isLockedCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(IS_LOCKED, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>> pressKeyCodeCommand(int key) {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(PRESS_KEY_CODE, prepareArguments("keycode", key));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> pressKeyCodeCommand(int key,
+        Integer metastate) {
+        String[] parameters = new String[] {"keycode", "metastate"};
+        Object[] values = new Object[] {key, metastate};
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(PRESS_KEY_CODE, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> longPressKeyCodeCommand(int key) {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments("keycode", key));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> longPressKeyCodeCommand(int key,
+        Integer metastate) {
+        String[] parameters = new String[] {"keycode", "metastate"};
+        Object[] values = new Object[] {key, metastate};
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> openNotificationsCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(OPEN_NOTIFICATIONS, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>>  pushFileCommandCommand(String remotePath,
+        byte[] base64Data) {
+        String[] parameters = new String[] {"path", "data"};
+        Object[] values = new Object[] {remotePath, base64Data};
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(PUSH_FILE, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> setConnectionCommand(Connection connection) {
+        String[] parameters = new String[] {"name", "parameters"};
+        Object[] values =
+            new Object[] {"network_connection", ImmutableMap.of("type", connection.bitMask)};
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(SET_NETWORK_CONNECTION, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> startActivityCommand(String appPackage,
+        String appActivity,
+        String appWaitPackage,
+        String appWaitActivity, String intentAction,
+        String intentCategory, String intentFlags,
+        String optionalIntentArguments,boolean stopApp )
+        throws IllegalArgumentException {
+
+        checkArgument((!StringUtils.isBlank(appPackage)
+                && !StringUtils.isBlank(appActivity)),
+            String.format("'%s' and '%s' are required.", "appPackage", "appActivity"));
+
+        appWaitPackage = !StringUtils.isBlank(appWaitPackage) ? appWaitPackage : "";
+        appWaitActivity = !StringUtils.isBlank(appWaitActivity) ? appWaitActivity : "";
+        intentAction = !StringUtils.isBlank(intentAction) ? intentAction : "";
+        intentCategory = !StringUtils.isBlank(intentCategory) ? intentCategory : "";
+        intentFlags = !StringUtils.isBlank(intentFlags) ? intentFlags : "";
+        optionalIntentArguments = !StringUtils.isBlank(optionalIntentArguments)
+            ? optionalIntentArguments : "";
+
+        ImmutableMap<String, ?> parameters = ImmutableMap
+            .<String, Object>builder().put("appPackage", appPackage)
+            .put("appActivity", appActivity)
+            .put("appWaitPackage", appWaitPackage)
+            .put("appWaitActivity", appWaitActivity)
+            .put("dontStopAppOnReset", !stopApp)
+            .put("intentAction", intentAction)
+            .put("intentCategory", intentCategory)
+            .put("intentFlags", intentFlags)
+            .put("optionalIntentArguments", optionalIntentArguments)
+            .build();
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(START_ACTIVITY, parameters);
+    }
+
+    public static Map.Entry<String, Map<String, ?>> toggleLocationServicesCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(TOGGLE_LOCATION_SERVICES, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>> unlockCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(UNLOCK, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(LOCK, prepareArguments("seconds", 0));
+    }
+
+    public static Map.Entry<String, Map<String, ?>>  replaceElementValueCommand(
+        HasIdentity hasIdentityObject, String value) {
+        String[] parameters = new String[] {"id", "value"};
+        Object[] values =
+            new Object[] {hasIdentityObject.getId(), value};
+
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(REPLACE_VALUE, prepareArguments(parameters, values));
+    }
+}

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -16,13 +16,12 @@
 
 package io.appium.java_client.ios;
 
-import static io.appium.java_client.MobileCommand.HIDE_KEYBOARD;
-import static io.appium.java_client.MobileCommand.LOCK;
-import static io.appium.java_client.MobileCommand.SHAKE;
-
-import com.google.common.collect.ImmutableMap;
+import static io.appium.java_client.ios.IOSMobileCommandHelper.hideKeyboardCommand;
+import static io.appium.java_client.ios.IOSMobileCommandHelper.lockDeviceCommand;
+import static io.appium.java_client.ios.IOSMobileCommandHelper.shakeCommand;
 
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByIosUIAutomation;
 import io.appium.java_client.ios.internal.JsonToIOSElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
@@ -176,44 +175,40 @@ public class IOSDriver<T extends WebElement>
      * @see IOSDeviceActionShortcuts#hideKeyboard(String, String).
      */
     @Override public void hideKeyboard(String strategy, String keyName) {
-        String[] parameters = new String[] {"strategy", "key"};
-        Object[] values = new Object[] {strategy, keyName};
-        execute(HIDE_KEYBOARD, getCommandImmutableMap(parameters, values));
+        CommandExecutionHelper.execute(this, hideKeyboardCommand(strategy, keyName));
     }
 
     /**
      * @see IOSDeviceActionShortcuts#hideKeyboard(String).
      */
     @Override public void hideKeyboard(String keyName) {
-        execute(HIDE_KEYBOARD, ImmutableMap.of("keyName", keyName));
+        CommandExecutionHelper.execute(this, hideKeyboardCommand(keyName));
     }
 
     /**
      * @see IOSDeviceActionShortcuts#shake().
      */
     @Override public void shake() {
-        execute(SHAKE);
+        CommandExecutionHelper.execute(this, shakeCommand());
     }
 
     /**
      * @throws WebDriverException
      *     This method is not applicable with browser/webview UI.
      */
-    @SuppressWarnings("unchecked")
     @Override
     public T findElementByIosUIAutomation(String using)
         throws WebDriverException {
-        return (T) findElement("-ios uiautomation", using);
+        return findElement("-ios uiautomation", using);
     }
 
     /**
      * @throws WebDriverException This method is not applicable with browser/webview UI.
      */
-    @SuppressWarnings("unchecked")
     @Override
     public List<T> findElementsByIosUIAutomation(String using)
         throws WebDriverException {
-        return (List<T>) findElements("-ios uiautomation", using);
+        return findElements("-ios uiautomation", using);
     }
 
     /**
@@ -223,6 +218,6 @@ public class IOSDriver<T extends WebElement>
      * @param seconds number of seconds to lock the screen for
      */
     public void lockDevice(int seconds) {
-        execute(LOCK, ImmutableMap.of("seconds", seconds));
+        CommandExecutionHelper.execute(this, lockDeviceCommand(seconds));
     }
 }

--- a/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.ios;
+
+import com.google.common.collect.ImmutableMap;
+import io.appium.java_client.MobileCommand;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+public class IOSMobileCommandHelper extends MobileCommand {
+
+    public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String keyName) {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(HIDE_KEYBOARD, prepareArguments("keyName", keyName));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String strategy, String keyName) {
+        String[] parameters = new String[] {"strategy", "key"};
+        Object[] values = new Object[] {strategy, keyName};
+        return new AbstractMap.SimpleEntry<String,
+                Map<String, ?>>(HIDE_KEYBOARD, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand(int seconds) {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(LOCK, prepareArguments("seconds", seconds));
+    }
+
+    public static Map.Entry<String, Map<String, ?>>  shakeCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(SHAKE, ImmutableMap.<String, Object>of());
+    }
+}

--- a/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
@@ -24,23 +24,58 @@ import java.util.Map;
 
 public class IOSMobileCommandHelper extends MobileCommand {
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * keyboard hiding.
+     *
+     * @param keyName The button pressed by the mobile driver to attempt hiding the
+     *                keyboard.
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String keyName) {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(HIDE_KEYBOARD, prepareArguments("keyName", keyName));
     }
 
-    public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String strategy, String keyName) {
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * keyboard hiding.
+     *
+     * @param strategy HideKeyboardStrategy.
+     * @param keyName  a String, representing the text displayed on the button of the
+     *                 keyboard you want to press. For example: "Done".
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
+    public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String strategy,
+        String keyName) {
         String[] parameters = new String[] {"strategy", "key"};
         Object[] values = new Object[] {strategy, keyName};
         return new AbstractMap.SimpleEntry<String,
                 Map<String, ?>>(HIDE_KEYBOARD, prepareArguments(parameters, values));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * device locking.
+     *
+     * @param seconds seconds number of seconds to lock the screen for
+     * @return  a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand(int seconds) {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(LOCK, prepareArguments("seconds", seconds));
     }
 
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * device shaking.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
     public static Map.Entry<String, Map<String, ?>>  shakeCommand() {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(SHAKE, ImmutableMap.<String, Object>of());

--- a/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
@@ -17,6 +17,7 @@
 package io.appium.java_client.ios;
 
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.MobileCommand;
 
 import java.util.AbstractMap;


### PR DESCRIPTION
## Change list

- update to Selenium 2.53.1

- the new class `CommandExecutionHelper`

- the new class `AndroidMobileCommandHelper`

- the new class `IOSMobileCommandHelper`

- `MobileCommand.commandRepository` is mutable now. Additional commands could be defined via
`MobileCommand.commandRepository.put(String, CommandInfo)` there.

- source code reafactoring

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

There are projects which based on Appium (modifications, additional customized automation layers and so on). In order to make client convenient these chandes were made:

- the ability to define additional commands directly was provided. 
`MobileCommand.commandRepository.put(String, CommandInfo)`

- access to mobile OS-specific commands and execution was made easier

- was added the ability to implement specific exctentions of the accessing to additional commands and execition. 

