### PR TITLE
Added homeScreen support.

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -53,6 +53,7 @@ public class MobileCommand {
     protected static final String GET_SESSION = "getSession";
     //iOS
     protected static final String SHAKE = "shake";
+    protected static final String HOME_SCREEN = "homeScreen";
     //Android
     protected static final String CURRENT_ACTIVITY = "currentActivity";
     protected static final String END_TEST_COVERAGE = "endTestCoverage";

--- a/src/main/java/io/appium/java_client/ios/IOSDeviceActionShortcuts.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDeviceActionShortcuts.java
@@ -46,5 +46,12 @@ public interface IOSDeviceActionShortcuts extends DeviceActionShortcuts {
      * Simulate shaking the device.
      */
     void shake();
+    
+    /**
+     * Simulate tapping the home button.
+     */
+    void homeScreen();
+
+
 
 }

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -19,6 +19,8 @@ package io.appium.java_client.ios;
 import static io.appium.java_client.ios.IOSMobileCommandHelper.hideKeyboardCommand;
 import static io.appium.java_client.ios.IOSMobileCommandHelper.lockDeviceCommand;
 import static io.appium.java_client.ios.IOSMobileCommandHelper.shakeCommand;
+import static io.appium.java_client.ios.IOSMobileCommandHelper.homeScreenCommand;
+
 
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.CommandExecutionHelper;
@@ -190,6 +192,13 @@ public class IOSDriver<T extends WebElement>
      */
     @Override public void shake() {
         CommandExecutionHelper.execute(this, shakeCommand());
+    }
+
+    /**
+     * @see IOSDeviceActionShortcuts#homeScreen().
+     */
+    @Override public void homeScreen() {
+        CommandExecutionHelper.execute(this, homeScreenCommand());
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
@@ -81,4 +81,16 @@ public class IOSMobileCommandHelper extends MobileCommand {
         return new AbstractMap.SimpleEntry<String,
             Map<String, ?>>(SHAKE, ImmutableMap.<String, Object>of());
     }
+
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * tapping home button.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
+    public static Map.Entry<String, Map<String, ?>> homeScreenCommand() {
+        return new AbstractMap.SimpleEntry<String,
+            Map<String, ?>>(HOME_SCREEN, ImmutableMap.<String, Object>of());
+    }
 }


### PR DESCRIPTION
## Change list

Added support for the /homescreen endpoint that is part of the new XCUITest driver.  See https://github.com/appium/appium-xcuitest-driver/pull/72 and https://github.com/appium/appium-base-driver/pull/68
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
This method will call the /homescreen endpoint defined in WebDriverAgent https://github.com/facebook/WebDriverAgent

Unlike `runAppInBackground()`, the `homeScreen()` method will background the application until a user calls `launchApp()`.  This allows the user to automate other parts of the simulator before running their tests or as part of their tests.  This is now possible to do in XCUITestDriver. Examples of where this may be useful is when the user wants to modify settings before or during their tests or perform a Spotlight Search for something in their application.

Sample usage

```Java
// Create IOSDriver
IOSDriver<IOSElement> myDriver = new IOSDriver<IOSElement>(remoteAddress, capabilities);
// Simulate tapping the "Home" button on an iOS Device
myDriver.homeScreen();
// Do stuff on home screen
// Resume app
myDriver.launchApp()
```
