### PR TITLE
Alert API Implementation for iOS

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -154,7 +154,7 @@ public class MobileCommand {
      * @param value is the parameter value.
      * @return built {@link ImmutableMap}.
      */
-    protected static ImmutableMap<String, Object> prepareArguments(String param,
+    public static ImmutableMap<String, Object> prepareArguments(String param,
                                                                    Object value) {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         builder.put(param, value);
@@ -166,7 +166,7 @@ public class MobileCommand {
      * @param values is the array with parameter values.
      * @return built {@link ImmutableMap}.
      */
-    protected static ImmutableMap<String, Object> prepareArguments(String[] params,
+    public static ImmutableMap<String, Object> prepareArguments(String[] params,
                                                                    Object[] values) {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         for (int i = 0; i < params.length; i++) {

--- a/src/test/java/io/appium/java_client/ios/IOSAlertTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSAlertTest.java
@@ -16,9 +16,11 @@
 
 package io.appium.java_client.ios;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 
 import io.appium.java_client.MobileBy;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -28,13 +30,23 @@ public class IOSAlertTest extends BaseIOSTest {
         driver.findElement(MobileBy
             .IosUIAutomation(".elements().withName(\"show alert\")")).click();
         WebDriverWait wating = new WebDriverWait(driver, 10000);
-        wating.until(alertIsPresent()).accept();
+        wating.until(alertIsPresent());
+        driver.switchTo().alert().accept();
     }
 
     @Test public void dismissAlertTest() {
         driver.findElement(MobileBy
             .IosUIAutomation(".elements().withName(\"show alert\")")).click();
         WebDriverWait wating = new WebDriverWait(driver, 10000);
-        wating.until(alertIsPresent()).dismiss();
+        wating.until(alertIsPresent());
+        driver.switchTo().alert().dismiss();
+    }
+
+    @Test public void getAlertTextTest() {
+        driver.findElement(MobileBy
+            .IosUIAutomation(".elements().withName(\"show alert\")")).click();
+        WebDriverWait wating = new WebDriverWait(driver, 10000);
+        wating.until(alertIsPresent());
+        assertFalse(StringUtils.isBlank(driver.switchTo().alert().getText()));
     }
 }


### PR DESCRIPTION
## Change list

Alert Handling for iOS.Added below methods,
```
1)getAlertText
2)setAlertText(String value)
3)acceptAlert
4)dismissAlert
```

API is here: https://github.com/appium/appium-base-driver/blob/master/lib/mjsonwp/routes.js#L403

API's were not implemented for Android Driver on server side.We can port it to android driver on client side post server implementation.

New W3C API's here: https://github.com/appium/appium-base-driver/blob/master/lib/mjsonwp/routes.js#L414 are not been adapted by Appium (Legacy drivers on server) yet.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

@TikhomirovSergey please review