### PR TITLE
Migration to Java 8. API with default implementation.

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -19,18 +19,10 @@ package io.appium.java_client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import static io.appium.java_client.MobileCommand.CLOSE_APP;
-import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
 import static io.appium.java_client.MobileCommand.GET_SESSION;
 import static io.appium.java_client.MobileCommand.GET_SETTINGS;
-import static io.appium.java_client.MobileCommand.HIDE_KEYBOARD;
-import static io.appium.java_client.MobileCommand.INSTALL_APP;
-import static io.appium.java_client.MobileCommand.IS_APP_INSTALLED;
-import static io.appium.java_client.MobileCommand.LAUNCH_APP;
 import static io.appium.java_client.MobileCommand.PERFORM_MULTI_TOUCH;
 import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
-import static io.appium.java_client.MobileCommand.REMOVE_APP;
-import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
 import static io.appium.java_client.MobileCommand.SET_SETTINGS;
 import static io.appium.java_client.MobileCommand.prepareArguments;
 
@@ -72,7 +64,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.xml.bind.DatatypeConverter;
 
 /**
 * @param <T> the required type of class which implement {@link org.openqa.selenium.WebElement}.
@@ -230,72 +221,6 @@ public abstract class AppiumDriver<T extends WebElement>
 
     @Override public ExecuteMethod getExecuteMethod() {
         return executeMethod;
-    }
-
-    /**
-     * @see InteractsWithApps#resetApp().
-     */
-    @Override public void resetApp() {
-        execute(MobileCommand.RESET);
-    }
-
-    /**
-     * @see InteractsWithApps#isAppInstalled(String).
-     */
-    @Override public boolean isAppInstalled(String bundleId) {
-        Response response = execute(IS_APP_INSTALLED, ImmutableMap.of("bundleId", bundleId));
-
-        return Boolean.parseBoolean(response.getValue().toString());
-    }
-
-    /**
-     * @see InteractsWithApps#installApp(String).
-     */
-    @Override public void installApp(String appPath) {
-        execute(INSTALL_APP, ImmutableMap.of("appPath", appPath));
-    }
-
-    /**
-     * @see InteractsWithApps#removeApp(String).
-     */
-    @Override public void removeApp(String bundleId) {
-        execute(REMOVE_APP, ImmutableMap.of("bundleId", bundleId));
-    }
-
-    /**
-     * @see InteractsWithApps#launchApp().
-     */
-    @Override public void launchApp() {
-        execute(LAUNCH_APP);
-    }
-
-    /**
-     * @see InteractsWithApps#closeApp().
-     */
-    @Override public void closeApp() {
-        execute(CLOSE_APP);
-    }
-
-    /**
-     * @see InteractsWithApps#runAppInBackground(int).
-     */
-    @Override public void runAppInBackground(int seconds) {
-        execute(RUN_APP_IN_BACKGROUND, ImmutableMap.of("seconds", seconds));
-    }
-
-    /**
-     * @see DeviceActionShortcuts#getDeviceTime().
-     */
-    @Override public String getDeviceTime() {
-        Response response = execute(GET_DEVICE_TIME);
-        return response.getValue().toString();
-    }
-
-    /**
-     * @see DeviceActionShortcuts#hideKeyboard().
-     */
-    @Override public void hideKeyboard() {
-        execute(HIDE_KEYBOARD);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -21,12 +21,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import static io.appium.java_client.MobileCommand.GET_SESSION;
 import static io.appium.java_client.MobileCommand.GET_SETTINGS;
-import static io.appium.java_client.MobileCommand.PERFORM_MULTI_TOUCH;
-import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
 import static io.appium.java_client.MobileCommand.SET_SETTINGS;
 import static io.appium.java_client.MobileCommand.prepareArguments;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -221,28 +218,6 @@ public abstract class AppiumDriver<T extends WebElement>
 
     @Override public ExecuteMethod getExecuteMethod() {
         return executeMethod;
-    }
-
-    /**
-     * @see PerformsTouchActions#performTouchAction(TouchAction).
-     */
-    @SuppressWarnings("rawtypes")
-    @Override public TouchAction performTouchAction(
-        TouchAction touchAction) {
-        ImmutableMap<String, ImmutableList> parameters = touchAction.getParameters();
-        execute(PERFORM_TOUCH_ACTION, parameters);
-        return touchAction;
-    }
-
-    /**
-     * @see PerformsTouchActions#performMultiTouchAction(MultiTouchAction).
-     */
-    @Override
-    @SuppressWarnings({"rawtypes"})
-    public void performMultiTouchAction(
-        MultiTouchAction multiAction) {
-        ImmutableMap<String, ImmutableList> parameters = multiAction.getParameters();
-        execute(PERFORM_MULTI_TOUCH, parameters);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -23,15 +23,12 @@ import static io.appium.java_client.MobileCommand.CLOSE_APP;
 import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
 import static io.appium.java_client.MobileCommand.GET_SESSION;
 import static io.appium.java_client.MobileCommand.GET_SETTINGS;
-import static io.appium.java_client.MobileCommand.GET_STRINGS;
 import static io.appium.java_client.MobileCommand.HIDE_KEYBOARD;
 import static io.appium.java_client.MobileCommand.INSTALL_APP;
 import static io.appium.java_client.MobileCommand.IS_APP_INSTALLED;
 import static io.appium.java_client.MobileCommand.LAUNCH_APP;
 import static io.appium.java_client.MobileCommand.PERFORM_MULTI_TOUCH;
 import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
-import static io.appium.java_client.MobileCommand.PULL_FILE;
-import static io.appium.java_client.MobileCommand.PULL_FOLDER;
 import static io.appium.java_client.MobileCommand.REMOVE_APP;
 import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
 import static io.appium.java_client.MobileCommand.SET_SETTINGS;
@@ -231,10 +228,6 @@ public abstract class AppiumDriver<T extends WebElement>
         return super.findElementsByAccessibilityId(using);
     }
 
-    @Override protected Response execute(String command) {
-        return super.execute(command, ImmutableMap.<String, Object>of());
-    }
-
     @Override public ExecuteMethod getExecuteMethod() {
         return executeMethod;
     }
@@ -303,27 +296,6 @@ public abstract class AppiumDriver<T extends WebElement>
      */
     @Override public void hideKeyboard() {
         execute(HIDE_KEYBOARD);
-    }
-
-    /**
-     * @see InteractsWithFiles#pullFile(String).
-     */
-    @Override public byte[] pullFile(String remotePath) {
-        Response response = execute(PULL_FILE, ImmutableMap.of("path", remotePath));
-        String base64String = response.getValue().toString();
-
-        return DatatypeConverter.parseBase64Binary(base64String);
-    }
-
-    /**
-     * @see InteractsWithFiles#pullFolder(String).
-     */
-    @Override
-    public byte[] pullFolder(String remotePath) {
-        Response response = execute(PULL_FOLDER, ImmutableMap.of("path", remotePath));
-        String base64String = response.getValue().toString();
-
-        return DatatypeConverter.parseBase64Binary(base64String);
     }
 
     /**
@@ -602,38 +574,6 @@ public abstract class AppiumDriver<T extends WebElement>
 
     @Override public void setLocation(Location location) {
         locationContext.setLocation(location);
-    }
-
-    /**
-     * @return a map with localized strings defined in the app.
-     * @see HasAppStrings#getAppStringMap().
-     */
-    @Override public Map<String, String> getAppStringMap() {
-        Response response = execute(GET_STRINGS);
-        return (Map<String, String>) response.getValue();
-    }
-
-    /**
-     * @param language strings language code.
-     * @return a map with localized strings defined in the app.
-     * @see HasAppStrings#getAppStringMap(String).
-     */
-    @Override public Map<String, String> getAppStringMap(String language) {
-        Response response = execute(GET_STRINGS, prepareArguments("language", language));
-        return (Map<String, String>) response.getValue();
-    }
-
-    /**
-     * @param language   strings language code.
-     * @param stringFile strings filename.
-     * @return a map with localized strings defined in the app.
-     * @see HasAppStrings#getAppStringMap(String, String).
-     */
-    @Override public Map<String, String> getAppStringMap(String language, String stringFile) {
-        String[] parameters = new String[] {"language", "stringFile"};
-        Object[] values = new Object[] {language, stringFile};
-        Response response = execute(GET_STRINGS, prepareArguments(parameters, values));
-        return (Map<String, String>) response.getValue();
     }
 
     private TouchAction createTap(WebElement element, int duration) {

--- a/src/main/java/io/appium/java_client/CommandExecutionHelper.java
+++ b/src/main/java/io/appium/java_client/CommandExecutionHelper.java
@@ -27,6 +27,10 @@ public final class CommandExecutionHelper {
         return handleResponse(executesMethod.execute(keyValuePair.getKey(), keyValuePair.getValue()));
     }
 
+    public static <T extends Object> T execute(ExecutesMethod executesMethod, String command) {
+        return handleResponse(executesMethod.execute(command));
+    }
+
     private static <T extends Object> T handleResponse(Response responce) {
         if (responce != null) {
             return (T) responce.getValue();

--- a/src/main/java/io/appium/java_client/CommandExecutionHelper.java
+++ b/src/main/java/io/appium/java_client/CommandExecutionHelper.java
@@ -22,14 +22,9 @@ import java.util.Map;
 
 public final class CommandExecutionHelper {
 
-    public static <T extends Object> T execute(MobileElement element,
+    public static <T extends Object> T execute(ExecutesMethod executesMethod,
         Map.Entry<String, Map<String, ?>> keyValuePair) {
-        return handleResponse(element.execute(keyValuePair.getKey(), keyValuePair.getValue()));
-    }
-
-    public static <T extends Object> T execute(MobileDriver driver,
-        Map.Entry<String, Map<String, ?>> keyValuePair) {
-        return handleResponse(driver.execute(keyValuePair.getKey(), keyValuePair.getValue()));
+        return handleResponse(executesMethod.execute(keyValuePair.getKey(), keyValuePair.getValue()));
     }
 
     private static <T extends Object> T handleResponse(Response responce) {

--- a/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
+++ b/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client;
 
+import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
@@ -38,6 +39,10 @@ abstract class DefaultGenericMobileDriver<T extends WebElement> extends RemoteWe
 
     @Override public Response execute(String driverCommand, Map<String, ?> parameters) {
         return super.execute(driverCommand, parameters);
+    }
+
+    @Override public Response execute(String command) {
+        return super.execute(command, ImmutableMap.<String, Object>of());
     }
 
     @Override public List findElements(By by) {
@@ -136,20 +141,6 @@ abstract class DefaultGenericMobileDriver<T extends WebElement> extends RemoteWe
 
     public List findElementsByXPath(String using) {
         return super.findElementsByXPath(using);
-    }
-
-    /**
-    * @throws WebDriverException This method is not applicable with browser/webview UI.
-    */
-    @Override public T findElementByAccessibilityId(String using) throws WebDriverException {
-        return (T) findElement(MobileSelector.ACCESSIBILITY.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException This method is not applicable with browser/webview UI.
-     */
-    @Override public List findElementsByAccessibilityId(String using) throws WebDriverException {
-        return (List<T>) findElements(MobileSelector.ACCESSIBILITY.toString(), using);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/DefaultGenericMobileElement.java
+++ b/src/main/java/io/appium/java_client/DefaultGenericMobileElement.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client;
 
+import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -27,10 +28,14 @@ import java.util.Map;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 abstract class DefaultGenericMobileElement<T extends WebElement> extends RemoteWebElement
-    implements FindsByAccessibilityId<T>, TouchableElement<T> {
+    implements TouchableElement<T> {
 
     @Override public Response execute(String driverCommand, Map<String, ?> parameters) {
         return super.execute(driverCommand, parameters);
+    }
+
+    @Override public Response execute(String command) {
+        return super.execute(command, ImmutableMap.<String, Object>of());
     }
 
     @Override public List findElements(By by) {
@@ -129,14 +134,6 @@ abstract class DefaultGenericMobileElement<T extends WebElement> extends RemoteW
 
     public List findElementsByXPath(String using) {
         return super.findElementsByXPath(using);
-    }
-
-    @Override public T findElementByAccessibilityId(String using) {
-        return (T) findElement(MobileSelector.ACCESSIBILITY.toString(), using);
-    }
-
-    @Override public List findElementsByAccessibilityId(String using) {
-        return findElements(MobileSelector.ACCESSIBILITY.toString(), using);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/DeviceActionShortcuts.java
+++ b/src/main/java/io/appium/java_client/DeviceActionShortcuts.java
@@ -16,8 +16,12 @@
 
 package io.appium.java_client;
 
+import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
+import static io.appium.java_client.MobileCommand.HIDE_KEYBOARD;
 
-public interface DeviceActionShortcuts {
+import org.openqa.selenium.remote.Response;
+
+public interface DeviceActionShortcuts extends ExecutesMethod {
 
     /**
      * Hides the keyboard if it is showing.
@@ -25,11 +29,16 @@ public interface DeviceActionShortcuts {
      * Defaults to the "tapOutside" strategy (taps outside the keyboard).
      * Switch to using hideKeyboard(HideKeyboardStrategy.PRESS_KEY, "Done") if this doesn't work.
      */
-    void hideKeyboard();
+    default void hideKeyboard() {
+        execute(HIDE_KEYBOARD);
+    }
 
     /*
         Gets device date and time for both iOS(Supports only real device) and Android devices
      */
-    String getDeviceTime();
+    default String getDeviceTime() {
+        Response response = execute(GET_DEVICE_TIME);
+        return response.getValue().toString();
+    }
 
 }

--- a/src/main/java/io/appium/java_client/ExecutesMethod.java
+++ b/src/main/java/io/appium/java_client/ExecutesMethod.java
@@ -16,26 +16,25 @@
 
 package io.appium.java_client;
 
-import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.Response;
 
-import java.util.List;
+import java.util.Map;
 
-public interface FindsByAndroidUIAutomator<T extends WebElement> extends FindsByFluentSelector<T> {
+public interface ExecutesMethod {
+    /**
+     * Executes JSONWP command and returns a response
+     *
+     * @param driverCommand a JSONWP command
+     * @param parameters map of command parameters
+     * @return a result response
+     */
+    Response execute(String driverCommand, Map<String, ?> parameters);
 
     /**
-     * @throws WebDriverException This method is not
-     *      applicable with browser/webview UI.
+     * Executes JSONWP command and returns a response
+     *
+     * @param driverCommand a JSONWP command
+     * @return a result response
      */
-    default T findElementByAndroidUIAutomator(String using) {
-        return findElement(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException This method is not
-     *     applicable with browser/webview UI.
-     */
-    default List<T> findElementsByAndroidUIAutomator(String using) {
-        return findElements(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
-    }
+    Response execute(String driverCommand);
 }

--- a/src/main/java/io/appium/java_client/FindsByAccessibilityId.java
+++ b/src/main/java/io/appium/java_client/FindsByAccessibilityId.java
@@ -16,12 +16,25 @@
 
 package io.appium.java_client;
 
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-public interface FindsByAccessibilityId<T extends WebElement> {
-    T findElementByAccessibilityId(String using);
+public interface FindsByAccessibilityId<T extends WebElement> extends FindsByFluentSelector<T> {
+    /**
+     * @throws WebDriverException This method is not
+     *      applicable with browser/webview UI.
+     */
+    default T findElementByAccessibilityId(String using) {
+        return findElement(MobileSelector.ACCESSIBILITY.toString(), using);
+    }
 
-    List<T> findElementsByAccessibilityId(String using);
+    /**
+     * @throws WebDriverException This method is not
+     *      applicable with browser/webview UI.
+     */
+    default List<T> findElementsByAccessibilityId(String using) {
+        return findElements(MobileSelector.ACCESSIBILITY.toString(), using);
+    }
 }

--- a/src/main/java/io/appium/java_client/FindsByIosNSPredicate.java
+++ b/src/main/java/io/appium/java_client/FindsByIosNSPredicate.java
@@ -20,9 +20,13 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-public interface FindsByIosNSPredicate<T extends WebElement> {
+public interface FindsByIosNSPredicate<T extends WebElement> extends FindsByFluentSelector<T> {
 
-    T findElementByIosNsPredicate(String using);
+    default T findElementByIosNsPredicate(String using) {
+        return findElement(MobileSelector.IOS_PREDICATE_STRING.toString(), using);
+    }
 
-    List<T> findElementsByIosNsPredicate(String using);
+    default List<T> findElementsByIosNsPredicate(String using) {
+        return findElements(MobileSelector.IOS_PREDICATE_STRING.toString(), using);
+    }
 }

--- a/src/main/java/io/appium/java_client/FindsByIosUIAutomation.java
+++ b/src/main/java/io/appium/java_client/FindsByIosUIAutomation.java
@@ -16,13 +16,25 @@
 
 package io.appium.java_client;
 
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-public interface FindsByIosUIAutomation<T extends WebElement> {
+public interface FindsByIosUIAutomation<T extends WebElement> extends FindsByFluentSelector<T> {
+    /**
+     * @throws WebDriverException
+     *     This method is not applicable with browser/webview UI.
+     */
+    default T findElementByIosUIAutomation(String using) {
+        return findElement(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
+    }
 
-    T findElementByIosUIAutomation(String using);
-
-    List<T> findElementsByIosUIAutomation(String using);
+    /**
+     * @throws WebDriverException
+     *     This method is not applicable with browser/webview UI.
+     */
+    default List<T> findElementsByIosUIAutomation(String using) {
+        return findElements(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
+    }
 }

--- a/src/main/java/io/appium/java_client/FindsByWindowsAutomation.java
+++ b/src/main/java/io/appium/java_client/FindsByWindowsAutomation.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
-public interface FindsByWindowsAutomation<T extends WebElement>  {
+public interface FindsByWindowsAutomation<T extends WebElement> extends FindsByFluentSelector<T> {
 
     /**
      * Finds the first of elements that match the Windows UIAutomation selector supplied.
@@ -29,7 +29,9 @@ public interface FindsByWindowsAutomation<T extends WebElement>  {
      * @param selector a Windows UIAutomation selector
      * @return The first element that matches the given selector
      */
-    T findElementByWindowsUIAutomation(String selector);
+    default T findElementByWindowsUIAutomation(String selector) {
+        return findElement(MobileSelector.WINDOWS_UI_AUTOMATION.toString(), selector);
+    }
 
     /**
      * Finds a list of elements that match the Windows UIAutomation selector supplied.
@@ -37,5 +39,7 @@ public interface FindsByWindowsAutomation<T extends WebElement>  {
      * @param selector a Windows UIAutomation selector
      * @return a list of elements that match the given selector
      */
-    List<T> findElementsByWindowsUIAutomation(String selector);
+    default List<T> findElementsByWindowsUIAutomation(String selector) {
+        return findElements(MobileSelector.WINDOWS_UI_AUTOMATION.toString(), selector);
+    }
 }

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -16,12 +16,11 @@
 
 package io.appium.java_client;
 
-import org.openqa.selenium.remote.Response;
-
-import java.util.Map;
-
 import static io.appium.java_client.MobileCommand.GET_STRINGS;
 import static io.appium.java_client.MobileCommand.prepareArguments;
+
+import java.util.AbstractMap;
+import java.util.Map;
 
 public interface HasAppStrings extends ExecutesMethod {
     /**
@@ -30,8 +29,7 @@ public interface HasAppStrings extends ExecutesMethod {
      * @return a map with localized strings defined in the app
      */
     default Map<String, String> getAppStringMap() {
-        Response response = execute(GET_STRINGS);
-        return (Map<String, String>) response.getValue();
+        return CommandExecutionHelper.execute(this, GET_STRINGS);
     }
 
     /**
@@ -41,8 +39,8 @@ public interface HasAppStrings extends ExecutesMethod {
      * @return a map with localized strings defined in the app
      */
     default Map<String, String> getAppStringMap(String language) {
-        Response response = execute(GET_STRINGS, prepareArguments("language", language));
-        return (Map<String, String>) response.getValue();
+        return CommandExecutionHelper.execute(this, new AbstractMap.SimpleEntry<>(GET_STRINGS,
+                prepareArguments("language", language)));
     }
 
     /**
@@ -56,8 +54,8 @@ public interface HasAppStrings extends ExecutesMethod {
     default Map<String, String> getAppStringMap(String language, String stringFile) {
         String[] parameters = new String[] {"language", "stringFile"};
         Object[] values = new Object[] {language, stringFile};
-        Response response = execute(GET_STRINGS, prepareArguments(parameters, values));
-        return (Map<String, String>) response.getValue();
+        return CommandExecutionHelper.execute(this,
+                new AbstractMap.SimpleEntry<>(GET_STRINGS, prepareArguments(parameters, values)));
     }
 
 }

--- a/src/main/java/io/appium/java_client/HasAppStrings.java
+++ b/src/main/java/io/appium/java_client/HasAppStrings.java
@@ -16,15 +16,23 @@
 
 package io.appium.java_client;
 
+import org.openqa.selenium.remote.Response;
+
 import java.util.Map;
 
-public interface HasAppStrings {
+import static io.appium.java_client.MobileCommand.GET_STRINGS;
+import static io.appium.java_client.MobileCommand.prepareArguments;
+
+public interface HasAppStrings extends ExecutesMethod {
     /**
      * Get all defined Strings from an app for the default language.
      *
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStringMap();
+    default Map<String, String> getAppStringMap() {
+        Response response = execute(GET_STRINGS);
+        return (Map<String, String>) response.getValue();
+    }
 
     /**
      * Get all defined Strings from an app for the specified language.
@@ -32,7 +40,10 @@ public interface HasAppStrings {
      * @param language strings language code
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStringMap(String language);
+    default Map<String, String> getAppStringMap(String language) {
+        Response response = execute(GET_STRINGS, prepareArguments("language", language));
+        return (Map<String, String>) response.getValue();
+    }
 
     /**
      * Get all defined Strings from an app for the specified language and
@@ -42,6 +53,11 @@ public interface HasAppStrings {
      * @param stringFile strings filename
      * @return a map with localized strings defined in the app
      */
-    Map<String, String> getAppStringMap(String language, String stringFile);
+    default Map<String, String> getAppStringMap(String language, String stringFile) {
+        String[] parameters = new String[] {"language", "stringFile"};
+        Object[] values = new Object[] {language, stringFile};
+        Response response = execute(GET_STRINGS, prepareArguments(parameters, values));
+        return (Map<String, String>) response.getValue();
+    }
 
 }

--- a/src/main/java/io/appium/java_client/InteractsWithApps.java
+++ b/src/main/java/io/appium/java_client/InteractsWithApps.java
@@ -16,18 +16,35 @@
 
 package io.appium.java_client;
 
-public interface InteractsWithApps {
+import static io.appium.java_client.MobileCommand.CLOSE_APP;
+import static io.appium.java_client.MobileCommand.INSTALL_APP;
+import static io.appium.java_client.MobileCommand.IS_APP_INSTALLED;
+import static io.appium.java_client.MobileCommand.LAUNCH_APP;
+import static io.appium.java_client.MobileCommand.prepareArguments;
+import static io.appium.java_client.MobileCommand.RESET;
+import static io.appium.java_client.MobileCommand.REMOVE_APP;
+import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.AbstractMap;
+
+public interface InteractsWithApps extends ExecutesMethod {
     /**
      * Launch the app which was provided in the capabilities at session creation.
      */
-    void launchApp();
+    default void launchApp() {
+        execute(LAUNCH_APP);
+    }
 
     /**
      * Install an app on the mobile device.
      *
      * @param appPath path to app to install.
      */
-    void installApp(String appPath);
+    default void installApp(String appPath) {
+        execute(INSTALL_APP, ImmutableMap.of("appPath", appPath));
+    }
 
     /**
      * Checks if an app is installed on the device.
@@ -35,12 +52,17 @@ public interface InteractsWithApps {
      * @param bundleId bundleId of the app.
      * @return True if app is installed, false otherwise.
      */
-    boolean isAppInstalled(String bundleId);
+    default boolean isAppInstalled(String bundleId) {
+        return CommandExecutionHelper.execute(this,
+                new AbstractMap.SimpleEntry<>(IS_APP_INSTALLED, prepareArguments("bundleId", bundleId)));
+    }
 
     /**
      * Reset the currently running app for this session.
      */
-    void resetApp();
+    default void resetApp() {
+        execute(RESET);
+    }
 
     /**
      * Runs the current app as a background app for the number of seconds
@@ -49,18 +71,24 @@ public interface InteractsWithApps {
      *
      * @param seconds Number of seconds to run App in background.
      */
-    void runAppInBackground(int seconds);
+    default void runAppInBackground(int seconds) {
+        execute(RUN_APP_IN_BACKGROUND, ImmutableMap.of("seconds", seconds));
+    }
 
     /**
      * Remove the specified app from the device (uninstall).
      *
      * @param bundleId the bunble identifier (or app id) of the app to remove.
      */
-    void removeApp(String bundleId);
+    default void removeApp(String bundleId) {
+        execute(REMOVE_APP, ImmutableMap.of("bundleId", bundleId));
+    }
 
     /**
      * Close the app which was provided in the capabilities at session creation.
      */
-    void closeApp();
+    default void closeApp() {
+        execute(CLOSE_APP);
+    }
 
 }

--- a/src/main/java/io/appium/java_client/InteractsWithFiles.java
+++ b/src/main/java/io/appium/java_client/InteractsWithFiles.java
@@ -16,13 +16,13 @@
 
 package io.appium.java_client;
 
+import static io.appium.java_client.MobileCommand.PULL_FILE;
+import static io.appium.java_client.MobileCommand.PULL_FOLDER;
+
 import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.remote.Response;
 
 import javax.xml.bind.DatatypeConverter;
-
-import static io.appium.java_client.MobileCommand.PULL_FILE;
-import static io.appium.java_client.MobileCommand.PULL_FOLDER;
 
 public interface InteractsWithFiles extends ExecutesMethod {
 

--- a/src/main/java/io/appium/java_client/InteractsWithFiles.java
+++ b/src/main/java/io/appium/java_client/InteractsWithFiles.java
@@ -16,7 +16,15 @@
 
 package io.appium.java_client;
 
-public interface InteractsWithFiles {
+import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.remote.Response;
+
+import javax.xml.bind.DatatypeConverter;
+
+import static io.appium.java_client.MobileCommand.PULL_FILE;
+import static io.appium.java_client.MobileCommand.PULL_FOLDER;
+
+public interface InteractsWithFiles extends ExecutesMethod {
 
     /**
      * @param remotePath On Android and iOS, this is either the path to the file
@@ -25,7 +33,12 @@ public interface InteractsWithFiles {
      *                   the application's .app directory
      * @return A byte array of Base64 encoded data.
      */
-    byte[] pullFile(String remotePath);
+    default byte[] pullFile(String remotePath) {
+        Response response = execute(PULL_FILE, ImmutableMap.of("path", remotePath));
+        String base64String = response.getValue().toString();
+
+        return DatatypeConverter.parseBase64Binary(base64String);
+    }
 
     /**
      * Pull a folder from the simulator/device. Does not work on iOS Real
@@ -38,6 +51,11 @@ public interface InteractsWithFiles {
      * @return A byte array of Base64 encoded data, representing a ZIP ARCHIVE
      * of the contents of the requested folder.
      */
-    byte[] pullFolder(String remotePath);
+    default byte[] pullFolder(String remotePath) {
+        Response response = execute(PULL_FOLDER, ImmutableMap.of("path", remotePath));
+        String base64String = response.getValue().toString();
+
+        return DatatypeConverter.parseBase64Binary(base64String);
+    }
 
 }

--- a/src/main/java/io/appium/java_client/MobileDriver.java
+++ b/src/main/java/io/appium/java_client/MobileDriver.java
@@ -37,9 +37,7 @@ import java.util.Map;
 public interface MobileDriver<T extends WebElement> extends WebDriver, PerformsTouchActions, ContextAware, Rotatable,
     FindsByAccessibilityId<T>, LocationContext, DeviceActionShortcuts, TouchShortcuts,
     InteractsWithFiles, InteractsWithApps, HasAppStrings, FindsByClassName, FindsByCssSelector, FindsById,
-        FindsByLinkText, FindsByName, FindsByTagName, FindsByXPath, FindsByFluentSelector<T> {
-
-    Response execute(String driverCommand, Map<String, ?> parameters);
+        FindsByLinkText, FindsByName, FindsByTagName, FindsByXPath, FindsByFluentSelector<T>, ExecutesMethod {
 
     List<T> findElements(By by);
 

--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -16,7 +16,13 @@
 
 package io.appium.java_client;
 
-public interface PerformsTouchActions {
+import static io.appium.java_client.MobileCommand.PERFORM_MULTI_TOUCH;
+import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public interface PerformsTouchActions extends ExecutesMethod {
     /**
      * Performs a chain of touch actions, which together can be considered an
      * entire gesture. See the Webriver 3 spec
@@ -28,7 +34,11 @@ public interface PerformsTouchActions {
      *                    touch actions to perform
      * @return the same touch action object
      */
-    public TouchAction performTouchAction(TouchAction touchAction);
+    default TouchAction performTouchAction(TouchAction touchAction) {
+        ImmutableMap<String, ImmutableList> parameters = touchAction.getParameters();
+        execute(PERFORM_TOUCH_ACTION, parameters);
+        return touchAction;
+    }
 
     /**
      * Performs multiple TouchAction gestures at the same time, to simulate
@@ -39,5 +49,8 @@ public interface PerformsTouchActions {
      *
      * @param multiAction the MultiTouchAction object to perform.
      */
-    public void performMultiTouchAction(MultiTouchAction multiAction);
+    default void performMultiTouchAction(MultiTouchAction multiAction) {
+        ImmutableMap<String, ImmutableList> parameters = multiAction.getParameters();
+        execute(PERFORM_MULTI_TOUCH, parameters);
+    }
 }

--- a/src/main/java/io/appium/java_client/TouchableElement.java
+++ b/src/main/java/io/appium/java_client/TouchableElement.java
@@ -34,7 +34,8 @@ import java.util.List;
  */
 public interface TouchableElement<T extends WebElement> extends WebElement, FindsByClassName,
         FindsByCssSelector, FindsById,
-        FindsByLinkText, FindsByName, FindsByTagName, FindsByXPath, FindsByFluentSelector<T> {
+        FindsByLinkText, FindsByName, FindsByTagName, FindsByXPath, FindsByFluentSelector<T>, FindsByAccessibilityId<T>,
+        ExecutesMethod {
 
     List<T> findElements(By by);
 

--- a/src/main/java/io/appium/java_client/android/AndroidDeviceActionShortcuts.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDeviceActionShortcuts.java
@@ -16,6 +16,10 @@
 
 package io.appium.java_client.android;
 
+import static io.appium.java_client.android.AndroidMobileCommandHelper.longPressKeyCodeCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.pressKeyCodeCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.DeviceActionShortcuts;
 
 public interface AndroidDeviceActionShortcuts extends DeviceActionShortcuts {
@@ -25,7 +29,9 @@ public interface AndroidDeviceActionShortcuts extends DeviceActionShortcuts {
      *
      * @param key code for the key pressed on the device.
      */
-    void pressKeyCode(int key);
+    default void pressKeyCode(int key) {
+        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key));
+    }
 
     /**
      * Send a key event along with an Android metastate to an Android device.
@@ -36,14 +42,18 @@ public interface AndroidDeviceActionShortcuts extends DeviceActionShortcuts {
      * @see AndroidKeyCode
      * @see AndroidKeyMetastate
      */
-    void pressKeyCode(int key, Integer metastate);
+    default void pressKeyCode(int key, Integer metastate) {
+        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key, metastate));
+    }
 
     /**
      * Send a long key event to the device.
      *
      * @param key code for the key pressed on the device.
      */
-    void longPressKeyCode(int key);
+    default void longPressKeyCode(int key) {
+        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key));
+    }
 
     /**
      * Send a long key event along with an Android metastate to an Android device.
@@ -54,5 +64,7 @@ public interface AndroidDeviceActionShortcuts extends DeviceActionShortcuts {
      * @see AndroidKeyCode
      * @see AndroidKeyMetastate
      */
-    void longPressKeyCode(int key, Integer metastate);
+    default void longPressKeyCode(int key, Integer metastate) {
+        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key, metastate));
+    }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -16,20 +16,9 @@
 
 package io.appium.java_client.android;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import static io.appium.java_client.android.AndroidMobileCommandHelper.currentActivityCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.getNetworkConnectionCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.isLockedCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.lockDeviceCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.longPressKeyCodeCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.pressKeyCodeCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.pushFileCommandCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.setConnectionCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.unlockCommand;
 
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.AppiumSetting;
@@ -39,16 +28,11 @@ import io.appium.java_client.android.internal.JsonToAndroidElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.http.HttpClient;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 
 /**
@@ -64,7 +48,7 @@ import java.net.URL;
 public class AndroidDriver<T extends WebElement>
     extends AppiumDriver<T>
     implements AndroidDeviceActionShortcuts, HasNetworkConnection, PushesFiles, StartsActivity,
-    FindsByAndroidUIAutomator<T> {
+    FindsByAndroidUIAutomator<T>, LocksAndroidDevice {
 
     private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
 
@@ -185,77 +169,6 @@ public class AndroidDriver<T extends WebElement>
     }
 
     /**
-     * Send a key event to the device.
-     *
-     * @param key code for the key pressed on the device.
-     */
-    @Override public void pressKeyCode(int key) {
-        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key));
-    }
-
-    /**
-     * @param key       code for the key pressed on the Android device.
-     * @param metastate metastate for the keypress.
-     * @see AndroidKeyCode
-     * @see AndroidKeyMetastate
-     * @see AndroidDeviceActionShortcuts#pressKeyCode(int, Integer).
-     */
-    @Override public void pressKeyCode(int key, Integer metastate) {
-        CommandExecutionHelper.execute(this, pressKeyCodeCommand(key, metastate));
-    }
-
-    /**
-     * Send a long key event to the device.
-     *
-     * @param key code for the long key pressed on the device.
-     */
-    @Override public void longPressKeyCode(int key) {
-        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key));
-    }
-
-    /**
-     * @param key       code for the long key pressed on the Android device.
-     * @param metastate metastate for the long key press.
-     * @see AndroidKeyCode
-     * @see AndroidKeyMetastate
-     * @see AndroidDeviceActionShortcuts#pressKeyCode(int, Integer)
-     */
-    @Override public void longPressKeyCode(int key, Integer metastate) {
-        CommandExecutionHelper.execute(this, longPressKeyCodeCommand(key, metastate));
-    }
-
-    @Override public void setConnection(Connection connection) {
-        CommandExecutionHelper.execute(this, setConnectionCommand(connection));
-    }
-
-    @Override public Connection getConnection() {
-        long bitMask = CommandExecutionHelper.execute(this, getNetworkConnectionCommand());
-        Connection[] types = Connection.values();
-
-        for (Connection connection: types) {
-            if (connection.bitMask == bitMask) {
-                return connection;
-            }
-        }
-        throw new WebDriverException("The unknown network connection "
-            + "type has been returned. The bitmask is " + bitMask);
-    }
-
-    @Override public void pushFile(String remotePath, byte[] base64Data) {
-        CommandExecutionHelper.execute(this, pushFileCommandCommand(remotePath, base64Data));
-    }
-
-    @Override public void pushFile(String remotePath, File file) throws IOException {
-        checkNotNull(file, "A reference to file should not be NULL");
-        if (!file.exists()) {
-            throw new IOException("The given file "
-                + file.getAbsolutePath() + " doesn't exist");
-        }
-        pushFile(remotePath,
-            Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
-    }
-
-    /**
      * Get test-coverage data.
      *
      * @param intent intent to broadcast.
@@ -266,28 +179,10 @@ public class AndroidDriver<T extends WebElement>
     }
 
     /**
-     * Get the current activity being run on the mobile device.
-     *
-     * @return a current activity being run on the mobile device.
-     */
-    public String currentActivity() {
-        return CommandExecutionHelper.execute(this, currentActivityCommand());
-    }
-
-    /**
      * Open the notification shade, on Android devices.
      */
     public void openNotifications() {
         CommandExecutionHelper.execute(this, openNotificationsCommand());
-    }
-
-    /**
-     * Check if the device is locked.
-     *
-     * @return true if device is locked. False otherwise
-     */
-    public boolean isLocked() {
-        return CommandExecutionHelper.execute(this, isLockedCommand());
     }
 
     public void toggleLocationServices() {
@@ -306,19 +201,5 @@ public class AndroidDriver<T extends WebElement>
     // Should be moved to the subclass
     public void ignoreUnimportantViews(Boolean compress) {
         setSetting(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS, compress);
-    }
-
-    /**
-     * This method locks a device.
-     */
-    public void lockDevice() {
-        CommandExecutionHelper.execute(this, lockDeviceCommand());
-    }
-
-    /**
-     * This method unlocks a device.
-     */
-    public void unlockDevice() {
-        CommandExecutionHelper.execute(this, unlockCommand());
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -28,7 +28,6 @@ import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotif
 import static io.appium.java_client.android.AndroidMobileCommandHelper.pressKeyCodeCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.pushFileCommandCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.setConnectionCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.unlockCommand;
 
@@ -36,7 +35,6 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.AppiumSetting;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
-import io.appium.java_client.MobileSelector;
 import io.appium.java_client.android.internal.JsonToAndroidElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -52,7 +50,6 @@ import org.openqa.selenium.remote.http.HttpClient;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
 
 /**
  * @param <T> the required type of class which implement {@link org.openqa.selenium.WebElement}.
@@ -258,51 +255,6 @@ public class AndroidDriver<T extends WebElement>
             Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
     }
 
-    @Override public void startActivity(String appPackage, String appActivity,
-        String appWaitPackage,
-        String appWaitActivity, String intentAction,
-        String intentCategory, String intentFlags,
-        String optionalIntentArguments,boolean stopApp )
-        throws IllegalArgumentException {
-        CommandExecutionHelper.execute(this, startActivityCommand(appPackage, appActivity,
-            appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags,
-            optionalIntentArguments, stopApp));
-    }
-
-
-    @Override
-    public void startActivity(String appPackage, String appActivity,
-        String appWaitPackage, String appWaitActivity, boolean stopApp)
-        throws IllegalArgumentException {
-        this.startActivity(appPackage,appActivity,appWaitPackage,
-            appWaitActivity,null,null,null,null,stopApp);
-
-    }
-
-    @Override public void startActivity(String appPackage, String appActivity,
-        String appWaitPackage,
-        String appWaitActivity) throws IllegalArgumentException {
-
-        this.startActivity(appPackage, appActivity,
-            appWaitPackage, appWaitActivity,null,null,null,null,true);
-    }
-
-    @Override public void startActivity(String appPackage, String appActivity)
-        throws IllegalArgumentException {
-        this.startActivity(appPackage, appActivity, null, null,
-            null,null,null,null,true);
-    }
-
-    @Override public void startActivity(String appPackage, String appActivity,
-        String appWaitPackage, String appWaitActivity,
-        String intentAction,String intentCategory,
-        String intentFlags,String intentOptionalArgs)
-        throws IllegalArgumentException {
-        this.startActivity(appPackage,appActivity,
-            appWaitPackage,appWaitActivity,
-            intentAction,intentCategory,intentFlags,intentOptionalArgs,true);
-    }
-
     /**
      * Get test-coverage data.
      *
@@ -354,26 +306,6 @@ public class AndroidDriver<T extends WebElement>
     // Should be moved to the subclass
     public void ignoreUnimportantViews(Boolean compress) {
         setSetting(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS, compress);
-    }
-
-    /**
-     * @throws WebDriverException This method is not
-     *     applicable with browser/webview UI.
-     */
-    @Override
-    public T findElementByAndroidUIAutomator(String using)
-        throws WebDriverException {
-        return findElement(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException This method is not
-     *      applicable with browser/webview UI.
-     */
-    @Override
-    public List<T> findElementsByAndroidUIAutomator(String using)
-        throws WebDriverException {
-        return findElements(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidElement.java
+++ b/src/main/java/io/appium/java_client/android/AndroidElement.java
@@ -21,32 +21,9 @@ import static io.appium.java_client.android.AndroidMobileCommandHelper.replaceEl
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
 import io.appium.java_client.MobileElement;
-import io.appium.java_client.MobileSelector;
-
-import org.openqa.selenium.WebDriverException;
-
-import java.util.List;
-
 
 public class AndroidElement extends MobileElement
     implements FindsByAndroidUIAutomator<MobileElement> {
-
-    /**
-     * @throws WebDriverException This method is not applicable with browser/webview UI.
-     */
-    @Override public MobileElement findElementByAndroidUIAutomator(String using)
-        throws WebDriverException {
-        return findElement(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException This method is not applicable with browser/webview UI.
-     */
-    @Override public List<MobileElement> findElementsByAndroidUIAutomator(String using)
-        throws WebDriverException {
-        return findElements(MobileSelector.ANDROID_UI_AUTOMATOR.toString(), using);
-    }
-
     /**
      * This method replace current text value.
      * @param value a new value

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -42,8 +42,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> currentActivityCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(CURRENT_ACTIVITY, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(
+                CURRENT_ACTIVITY, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -59,8 +59,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         String path) {
         String[] parameters = new String[] {"intent", "path"};
         Object[] values = new Object[] {intent, path};
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(END_TEST_COVERAGE, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                END_TEST_COVERAGE, prepareArguments(parameters, values));
     }
 
     /**
@@ -71,8 +71,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> getNetworkConnectionCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(GET_NETWORK_CONNECTION, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(
+                GET_NETWORK_CONNECTION, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -83,8 +83,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> isLockedCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(IS_LOCKED, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(
+                IS_LOCKED, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -96,8 +96,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> pressKeyCodeCommand(int key) {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(PRESS_KEY_CODE, prepareArguments("keycode", key));
+        return new AbstractMap.SimpleEntry<>(
+                PRESS_KEY_CODE, prepareArguments("keycode", key));
     }
 
     /**
@@ -113,8 +113,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         Integer metastate) {
         String[] parameters = new String[] {"keycode", "metastate"};
         Object[] values = new Object[] {key, metastate};
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(PRESS_KEY_CODE, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                PRESS_KEY_CODE, prepareArguments(parameters, values));
     }
 
     /**
@@ -126,8 +126,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> longPressKeyCodeCommand(int key) {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments("keycode", key));
+        return new AbstractMap.SimpleEntry<>(
+                LONG_PRESS_KEY_CODE, prepareArguments("keycode", key));
     }
 
     /**
@@ -143,8 +143,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         Integer metastate) {
         String[] parameters = new String[] {"keycode", "metastate"};
         Object[] values = new Object[] {key, metastate};
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(LONG_PRESS_KEY_CODE, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                LONG_PRESS_KEY_CODE, prepareArguments(parameters, values));
     }
 
     /**
@@ -155,8 +155,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> openNotificationsCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(OPEN_NOTIFICATIONS, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(
+                OPEN_NOTIFICATIONS, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -172,8 +172,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
         Object[] values = new Object[] {remotePath, base64Data};
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(PUSH_FILE, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
     }
 
     /**
@@ -188,8 +187,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         String[] parameters = new String[] {"name", "parameters"};
         Object[] values =
             new Object[] {"network_connection", ImmutableMap.of("type", connection.bitMask)};
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(SET_NETWORK_CONNECTION, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                SET_NETWORK_CONNECTION, prepareArguments(parameters, values));
     }
 
     /**
@@ -237,8 +236,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             .put("intentFlags", targetIntentFlags)
             .put("optionalIntentArguments", targetOptionalIntentArguments)
             .build();
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(START_ACTIVITY, parameters);
+        return new AbstractMap.SimpleEntry<>(START_ACTIVITY, parameters);
     }
 
     /**
@@ -249,8 +247,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> toggleLocationServicesCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(TOGGLE_LOCATION_SERVICES, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(TOGGLE_LOCATION_SERVICES, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -261,8 +258,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> unlockCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(UNLOCK, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(UNLOCK, ImmutableMap.<String, Object>of());
     }
 
     /**
@@ -273,8 +269,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(LOCK, prepareArguments("seconds", 0));
+        return new AbstractMap.SimpleEntry<>(LOCK, prepareArguments("seconds", 0));
     }
 
     /**
@@ -292,7 +287,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         Object[] values =
             new Object[] {hasIdentityObject.getId(), value};
 
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(REPLACE_VALUE, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                REPLACE_VALUE, prepareArguments(parameters, values));
     }
 }

--- a/src/main/java/io/appium/java_client/android/HasNetworkConnection.java
+++ b/src/main/java/io/appium/java_client/android/HasNetworkConnection.java
@@ -16,14 +16,23 @@
 
 package io.appium.java_client.android;
 
-public interface HasNetworkConnection {
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getNetworkConnectionCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.setConnectionCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+import org.openqa.selenium.WebDriverException;
+
+public interface HasNetworkConnection extends ExecutesMethod {
 
     /**
      * Set the network connection of the device.
      *
      * @param connection The bitmask of the desired connection
      */
-    void setConnection(Connection connection);
+    default void setConnection(Connection connection) {
+        CommandExecutionHelper.execute(this, setConnectionCommand(connection));
+    }
 
 
     /**
@@ -32,5 +41,16 @@ public interface HasNetworkConnection {
      * @return Connection object will let you inspect the status
      *     of None, AirplaneMode, Wifi, Data and All connections
      */
-    Connection getConnection();
+    default Connection getConnection() {
+        long bitMask = CommandExecutionHelper.execute(this, getNetworkConnectionCommand());
+        Connection[] types = Connection.values();
+
+        for (Connection connection: types) {
+            if (connection.bitMask == bitMask) {
+                return connection;
+            }
+        }
+        throw new WebDriverException("The unknown network connection "
+            + "type has been returned. The bitmask is " + bitMask);
+    }
 }

--- a/src/main/java/io/appium/java_client/android/LocksAndroidDevice.java
+++ b/src/main/java/io/appium/java_client/android/LocksAndroidDevice.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android;
+
+import static io.appium.java_client.android.AndroidMobileCommandHelper.isLockedCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.lockDeviceCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.unlockCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+
+public interface LocksAndroidDevice extends ExecutesMethod {
+    /**
+     * Check if the device is locked.
+     *
+     * @return true if device is locked. False otherwise
+     */
+    default boolean isLocked() {
+        return CommandExecutionHelper.execute(this, isLockedCommand());
+    }
+
+    /**
+     * This method locks a device.
+     */
+    default void lockDevice() {
+        CommandExecutionHelper.execute(this, lockDeviceCommand());
+    }
+
+    /**
+     * This method unlocks a device.
+     */
+    default void unlockDevice() {
+        CommandExecutionHelper.execute(this, unlockCommand());
+    }
+}

--- a/src/main/java/io/appium/java_client/android/PushesFiles.java
+++ b/src/main/java/io/appium/java_client/android/PushesFiles.java
@@ -16,12 +16,19 @@
 
 package io.appium.java_client.android;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.pushFileCommandCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
 import io.appium.java_client.InteractsWithFiles;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 
-public interface PushesFiles extends InteractsWithFiles {
+public interface PushesFiles extends InteractsWithFiles, ExecutesMethod {
 
     /**
      * Saves base64 encoded data as a file on the remote mobile device.
@@ -29,7 +36,9 @@ public interface PushesFiles extends InteractsWithFiles {
      * @param remotePath Path to file to write data to on remote device
      * @param base64Data Base64 encoded byte array of data to write to remote device
      */
-    void pushFile(String remotePath, byte[] base64Data);
+    default void pushFile(String remotePath, byte[] base64Data) {
+        CommandExecutionHelper.execute(this, pushFileCommandCommand(remotePath, base64Data));
+    }
 
     /**
      * Saves given file as a file on the remote mobile device.
@@ -38,6 +47,14 @@ public interface PushesFiles extends InteractsWithFiles {
      * @param file is a file to write to remote device
      * @throws IOException when there are problems with a file or current file system
      */
-    void pushFile(String remotePath, File file) throws IOException;
+    default void pushFile(String remotePath, File file) throws IOException {
+        checkNotNull(file, "A reference to file should not be NULL");
+        if (!file.exists()) {
+            throw new IOException("The given file "
+                + file.getAbsolutePath() + " doesn't exist");
+        }
+        pushFile(remotePath,
+            Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
+    }
 
 }

--- a/src/main/java/io/appium/java_client/android/StartsActivity.java
+++ b/src/main/java/io/appium/java_client/android/StartsActivity.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client.android;
 
+import static io.appium.java_client.android.AndroidMobileCommandHelper.currentActivityCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
 
 import io.appium.java_client.CommandExecutionHelper;
@@ -112,5 +113,14 @@ public interface StartsActivity extends ExecutesMethod {
         CommandExecutionHelper.execute(this, startActivityCommand(appPackage, appActivity,
             appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags,
             optionalIntentArguments, stopApp));
+    }
+
+    /**
+     * Get the current activity being run on the mobile device.
+     *
+     * @return a current activity being run on the mobile device.
+     */
+    default String currentActivity() {
+        return CommandExecutionHelper.execute(this, currentActivityCommand());
     }
 }

--- a/src/main/java/io/appium/java_client/android/StartsActivity.java
+++ b/src/main/java/io/appium/java_client/android/StartsActivity.java
@@ -16,7 +16,12 @@
 
 package io.appium.java_client.android;
 
-public interface StartsActivity {
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+
+import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
+
+public interface StartsActivity extends ExecutesMethod {
     /**
      * This method should start arbitrary activity during a test. If the activity belongs to
      * another application, that application is started and the activity is opened.
@@ -27,8 +32,11 @@ public interface StartsActivity {
      * @param appWaitActivity Automation will begin after this activity starts. [Optional]
      * @param stopApp         If true, target app will be stopped. [Optional]
      */
-    void startActivity(String appPackage, String appActivity, String appWaitPackage,
-        String appWaitActivity, boolean stopApp) throws IllegalArgumentException;
+    default void startActivity(String appPackage, String appActivity, String appWaitPackage,
+        String appWaitActivity, boolean stopApp) throws IllegalArgumentException {
+        this.startActivity(appPackage,appActivity,appWaitPackage,
+            appWaitActivity,null,null,null,null,stopApp);
+    }
 
     /**
      * This method should start arbitrary activity during a test. If the activity belongs to
@@ -39,8 +47,11 @@ public interface StartsActivity {
      * @param appWaitPackage  Automation will begin after this package starts. [Optional]
      * @param appWaitActivity Automation will begin after this activity starts. [Optional]
      */
-    void startActivity(String appPackage, String appActivity, String appWaitPackage,
-        String appWaitActivity) throws IllegalArgumentException;
+    default void startActivity(String appPackage, String appActivity, String appWaitPackage,
+        String appWaitActivity) throws IllegalArgumentException {
+        this.startActivity(appPackage, appActivity,
+            appWaitPackage, appWaitActivity,null,null,null,null,true);
+    }
 
     /**
      * This method should start arbitrary activity during a test. If the activity belongs to
@@ -49,7 +60,10 @@ public interface StartsActivity {
      * @param appPackage  The package containing the activity. [Required]
      * @param appActivity The activity to start. [Required]
      */
-    void startActivity(String appPackage, String appActivity) throws IllegalArgumentException;
+    default void startActivity(String appPackage, String appActivity) throws IllegalArgumentException {
+        this.startActivity(appPackage, appActivity, null, null,
+            null,null,null,null,true);
+    }
 
     /**
      * This method should start arbitrary activity during a test. If the activity belongs to
@@ -65,11 +79,15 @@ public interface StartsActivity {
      * @param intentOptionalArgs Additional intent arguments that will be used to
      *                                start activity [Optional]
      */
-    void startActivity(String appPackage, String appActivity,
-                       String appWaitPackage, String appWaitActivity,
-                       String intentAction, String intentCategory,
-                                 String intentFlags, String intentOptionalArgs)
-            throws IllegalArgumentException;
+    default void startActivity(String appPackage, String appActivity,
+        String appWaitPackage, String appWaitActivity,
+        String intentAction, String intentCategory,
+        String intentFlags, String intentOptionalArgs)
+        throws IllegalArgumentException {
+        this.startActivity(appPackage,appActivity,
+            appWaitPackage,appWaitActivity,
+            intentAction,intentCategory,intentFlags,intentOptionalArgs,true);
+    }
 
     /**
      * This method should start arbitrary activity during a test. If the activity belongs to
@@ -86,10 +104,13 @@ public interface StartsActivity {
      *                                start activity [Optional]
      * @param stopApp         If true, target app will be stopped. [Optional]
      */
-    void startActivity(String appPackage, String appActivity, String appWaitPackage,
-                       String appWaitActivity, String intentAction,
-                       String intentCategory, String intentFlags,
-                       String optionalIntentArguments,boolean stopApp )
-            throws IllegalArgumentException;
-
+    default void startActivity(String appPackage, String appActivity, String appWaitPackage,
+        String appWaitActivity, String intentAction,
+        String intentCategory, String intentFlags,
+        String optionalIntentArguments,boolean stopApp )
+        throws IllegalArgumentException {
+        CommandExecutionHelper.execute(this, startActivityCommand(appPackage, appActivity,
+            appWaitPackage, appWaitActivity, intentAction, intentCategory, intentFlags,
+            optionalIntentArguments, stopApp));
+    }
 }

--- a/src/main/java/io/appium/java_client/android/StartsActivity.java
+++ b/src/main/java/io/appium/java_client/android/StartsActivity.java
@@ -16,10 +16,10 @@
 
 package io.appium.java_client.android;
 
+import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
+
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.ExecutesMethod;
-
-import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
 
 public interface StartsActivity extends ExecutesMethod {
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSDeviceActionShortcuts.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDeviceActionShortcuts.java
@@ -16,7 +16,11 @@
 
 package io.appium.java_client.ios;
 
+import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.DeviceActionShortcuts;
+
+import static io.appium.java_client.ios.IOSMobileCommandHelper.hideKeyboardCommand;
+import static io.appium.java_client.ios.IOSMobileCommandHelper.shakeCommand;
 
 public interface IOSDeviceActionShortcuts extends DeviceActionShortcuts {
 
@@ -27,7 +31,9 @@ public interface IOSDeviceActionShortcuts extends DeviceActionShortcuts {
      * @param keyName The button pressed by the mobile driver to attempt hiding the
      *                keyboard.
      */
-    void hideKeyboard(String keyName);
+    default void hideKeyboard(String keyName) {
+        CommandExecutionHelper.execute(this, hideKeyboardCommand(keyName));
+    }
 
     /**
      * Hides the keyboard if it is showing. Available strategies are PRESS_KEY
@@ -40,11 +46,15 @@ public interface IOSDeviceActionShortcuts extends DeviceActionShortcuts {
      * @param keyName  a String, representing the text displayed on the button of the
      *                 keyboard you want to press. For example: "Done".
      */
-    void hideKeyboard(String strategy, String keyName);
+    default void hideKeyboard(String strategy, String keyName) {
+        CommandExecutionHelper.execute(this, hideKeyboardCommand(strategy, keyName));
+    }
 
     /**
      * Simulate shaking the device.
      */
-    void shake();
+    default void shake() {
+        CommandExecutionHelper.execute(this, shakeCommand());
+    }
 
 }

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -17,12 +17,8 @@
 package io.appium.java_client.ios;
 
 import static io.appium.java_client.MobileCommand.prepareArguments;
-import static io.appium.java_client.ios.IOSMobileCommandHelper.hideKeyboardCommand;
-import static io.appium.java_client.ios.IOSMobileCommandHelper.lockDeviceCommand;
-import static io.appium.java_client.ios.IOSMobileCommandHelper.shakeCommand;
 
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByIosUIAutomation;
 import io.appium.java_client.ios.internal.JsonToIOSElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
@@ -54,7 +50,7 @@ import java.net.URL;
 public class IOSDriver<T extends WebElement>
     extends AppiumDriver<T>
     implements IOSDeviceActionShortcuts,
-        FindsByIosUIAutomation<T> {
+        FindsByIosUIAutomation<T>, LocksIOSDevice {
 
     private static final String IOS_PLATFORM = MobilePlatform.IOS;
 
@@ -172,37 +168,6 @@ public class IOSDriver<T extends WebElement>
      */
     @Override public void swipe(int startx, int starty, int endx, int endy, int duration) {
         doSwipe(startx, starty, endx - startx, endy - starty, duration);
-    }
-
-    /**
-     * @see IOSDeviceActionShortcuts#hideKeyboard(String, String).
-     */
-    @Override public void hideKeyboard(String strategy, String keyName) {
-        CommandExecutionHelper.execute(this, hideKeyboardCommand(strategy, keyName));
-    }
-
-    /**
-     * @see IOSDeviceActionShortcuts#hideKeyboard(String).
-     */
-    @Override public void hideKeyboard(String keyName) {
-        CommandExecutionHelper.execute(this, hideKeyboardCommand(keyName));
-    }
-
-    /**
-     * @see IOSDeviceActionShortcuts#shake().
-     */
-    @Override public void shake() {
-        CommandExecutionHelper.execute(this, shakeCommand());
-    }
-
-    /**
-     * Lock the device (bring it to the lock screen) for a given number of
-     * seconds.
-     *
-     * @param seconds number of seconds to lock the screen for
-     */
-    public void lockDevice(int seconds) {
-        CommandExecutionHelper.execute(this, lockDeviceCommand(seconds));
     }
 
     @Override public TargetLocator switchTo() {

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -24,14 +24,12 @@ import static io.appium.java_client.ios.IOSMobileCommandHelper.shakeCommand;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByIosUIAutomation;
-import io.appium.java_client.MobileSelector;
 import io.appium.java_client.ios.internal.JsonToIOSElementConverter;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
@@ -40,7 +38,6 @@ import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.security.Credentials;
 
 import java.net.URL;
-import java.util.List;
 
 
 /**
@@ -196,25 +193,6 @@ public class IOSDriver<T extends WebElement>
      */
     @Override public void shake() {
         CommandExecutionHelper.execute(this, shakeCommand());
-    }
-
-    /**
-     * @throws WebDriverException
-     *     This method is not applicable with browser/webview UI.
-     */
-    @Override
-    public T findElementByIosUIAutomation(String using)
-        throws WebDriverException {
-        return findElement(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException This method is not applicable with browser/webview UI.
-     */
-    @Override
-    public List<T> findElementsByIosUIAutomation(String using)
-        throws WebDriverException {
-        return findElements(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSElement.java
+++ b/src/main/java/io/appium/java_client/ios/IOSElement.java
@@ -18,28 +18,7 @@ package io.appium.java_client.ios;
 
 import io.appium.java_client.FindsByIosUIAutomation;
 import io.appium.java_client.MobileElement;
-import io.appium.java_client.MobileSelector;
-import org.openqa.selenium.WebDriverException;
-
-import java.util.List;
 
 public class IOSElement extends MobileElement
     implements FindsByIosUIAutomation<MobileElement> {
-    /**
-     * @throws WebDriverException
-     * This method is not applicable with browser/webview UI.
-     */
-    @Override public MobileElement findElementByIosUIAutomation(String using)
-        throws WebDriverException {
-        return findElement(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
-    }
-
-    /**
-     * @throws WebDriverException
-     * This method is not applicable with browser/webview UI.
-     */
-    @Override public List<MobileElement> findElementsByIosUIAutomation(String using)
-        throws WebDriverException {
-        return findElements(MobileSelector.IOS_UI_AUTOMATION.toString(), using);
-    }
 }

--- a/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/ios/IOSMobileCommandHelper.java
@@ -35,8 +35,8 @@ public class IOSMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>> hideKeyboardCommand(String keyName) {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(HIDE_KEYBOARD, prepareArguments("keyName", keyName));
+        return new AbstractMap.SimpleEntry<>(
+                HIDE_KEYBOARD, prepareArguments("keyName", keyName));
     }
 
     /**
@@ -53,8 +53,8 @@ public class IOSMobileCommandHelper extends MobileCommand {
         String keyName) {
         String[] parameters = new String[] {"strategy", "key"};
         Object[] values = new Object[] {strategy, keyName};
-        return new AbstractMap.SimpleEntry<String,
-                Map<String, ?>>(HIDE_KEYBOARD, prepareArguments(parameters, values));
+        return new AbstractMap.SimpleEntry<>(
+                HIDE_KEYBOARD, prepareArguments(parameters, values));
     }
 
     /**
@@ -66,8 +66,8 @@ public class IOSMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand(int seconds) {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(LOCK, prepareArguments("seconds", seconds));
+        return new AbstractMap.SimpleEntry<>(
+                LOCK, prepareArguments("seconds", seconds));
     }
 
     /**
@@ -78,7 +78,7 @@ public class IOSMobileCommandHelper extends MobileCommand {
      * {@link java.util.Map} command arguments.
      */
     public static Map.Entry<String, Map<String, ?>>  shakeCommand() {
-        return new AbstractMap.SimpleEntry<String,
-            Map<String, ?>>(SHAKE, ImmutableMap.<String, Object>of());
+        return new AbstractMap.SimpleEntry<>(
+                SHAKE, ImmutableMap.<String, Object>of());
     }
 }

--- a/src/main/java/io/appium/java_client/ios/LocksIOSDevice.java
+++ b/src/main/java/io/appium/java_client/ios/LocksIOSDevice.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.ios;
+
+import static io.appium.java_client.ios.IOSMobileCommandHelper.lockDeviceCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+
+public interface LocksIOSDevice extends ExecutesMethod {
+    /**
+     * Lock the device (bring it to the lock screen) for a given number of
+     * seconds.
+     *
+     * @param seconds number of seconds to lock the screen for
+     */
+    default void lockDevice(int seconds) {
+        CommandExecutionHelper.execute(this, lockDeviceCommand(seconds));
+    }
+}

--- a/src/test/java/io/appium/java_client/events/FewInstancesTest.java
+++ b/src/test/java/io/appium/java_client/events/FewInstancesTest.java
@@ -1,8 +1,8 @@
 package io.appium.java_client.events;
 
-import static com.thoughtworks.selenium.SeleneseTestCase.assertNotEquals;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotEquals;
 
 import io.appium.java_client.events.listeners.AlertListener;
 import io.appium.java_client.events.listeners.ContextListener;


### PR DESCRIPTION
## Change list

Epic: #399 

- each one interface extends the `io.appium.java_client.ExecutesMethod`
- both `AppiumDriver` and `MobileElement` implement `io.appium.java_client.ExecutesMethod`
- Current API has default implementation
- `AppiumDriver`, `MobileElement` and subclasses just declare interfaces are implemented. 
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

We have few targets: 

- We are going to support Windows Mobile automation. Some interesting things were found. It supports some functions which were declared as Android-specific. As well it may support some functions which were declared as iOS-only as well. So we need for very flexible API which allows to implement it easily and without copy-paste.

- Some users need to use Android/iOS specific functions eventually. Now it should be possible in very pretty way: 

```java
import io.appium.java_client.android.StartsActivity;
...

private AppiumDriver<?> driver;

...
       StartsActivity startsActivity = new StartsActivity() {
            @Override
            public Response execute(String driverCommand, Map<String, ?> parameters) {
                return driver.execute(driverCommand, parameters);
            }

            @Override
            public Response execute(String driverCommand) {
                return driver.execute(driverCommand);
            }
        };
        startsActivity.startActivity("yourPackage", "yourActivity");
```

If somebody wants to use only Selenium and Appium interfaces when even this is possible: 

```java
import io.appium.java_client.ExecutesMethod;

public class ExtendedRemoteWebDriver extends RemoteWebDriver implements ExecutesMethod {
...
}

_______________________________________________________________________________________________

import io.appium.java_client.android.StartsActivity;
...

private ExtendedRemoteWebDriver driver;

...
       StartsActivity startsActivity = new StartsActivity() {
            @Override
            public Response execute(String driverCommand, Map<String, ?> parameters) {
                return driver.execute(driverCommand, parameters);
            }

            @Override
            public Response execute(String driverCommand) {
                return driver.execute(driverCommand);
            }
        };
        startsActivity.startActivity("yourPackage", "yourActivity");
```
