### PR TITLE
Android setting engine

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -20,13 +20,8 @@ package io.appium.java_client;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import static io.appium.java_client.MobileCommand.GET_SESSION;
-import static io.appium.java_client.MobileCommand.GET_SETTINGS;
-import static io.appium.java_client.MobileCommand.SET_SETTINGS;
-import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 import io.appium.java_client.remote.AppiumCommandExecutor;
 import io.appium.java_client.remote.MobileCapabilityType;
@@ -385,43 +380,6 @@ public abstract class AppiumDriver<T extends WebElement>
         multiTouch.add(action0).add(action1);
 
         multiTouch.perform();
-    }
-
-    /**
-     * Get settings stored for this test session It's probably better to use a
-     * convenience function, rather than use this function directly. Try finding
-     * the method for the specific setting you want to read.
-     *
-     * @return JsonObject, a straight-up hash of settings.
-     */
-    public JsonObject getSettings() {
-        Response response = execute(GET_SETTINGS);
-
-        JsonParser parser = new JsonParser();
-        return  (JsonObject) parser.parse(response.getValue().toString());
-    }
-
-    /**
-     * Set settings for this test session It's probably better to use a
-     * convenience function, rather than use this function directly. Try finding
-     * the method for the specific setting you want to change.
-     *
-     * @param settings Map of setting keys and values.
-     */
-    private void setSettings(ImmutableMap<?, ?> settings) {
-        execute(SET_SETTINGS, prepareArguments("settings", settings));
-    }
-
-    /**
-     * Set a setting for this test session It's probably better to use a
-     * convenience function, rather than use this function directly. Try finding
-     * the method for the specific setting you want to change.
-     *
-     * @param setting AppiumSetting you wish to set.
-     * @param value   value of the setting.
-     */
-    protected void setSetting(AppiumSetting setting, Object value) {
-        setSettings(prepareArguments(setting.toString(), value));
     }
 
     @Override public WebDriver context(String name) {

--- a/src/main/java/io/appium/java_client/AppiumSetting.java
+++ b/src/main/java/io/appium/java_client/AppiumSetting.java
@@ -16,7 +16,7 @@
 
 package io.appium.java_client;
 
-import io.appium.java_client.android.settings.Setting;
+import io.appium.java_client.android.Setting;
 
 /**
  * This enum is deprecated. Was moved to {@link Setting}

--- a/src/main/java/io/appium/java_client/AppiumSetting.java
+++ b/src/main/java/io/appium/java_client/AppiumSetting.java
@@ -16,9 +16,12 @@
 
 package io.appium.java_client;
 
+import io.appium.java_client.android.settings.Setting;
+
 /**
- * Enums defining constants for Appium Settings which can be set and toggled during a test session.
+ * This enum is deprecated. Was moved to {@link Setting}
  */
+@Deprecated
 public enum AppiumSetting {
 
     IGNORE_UNIMPORTANT_VIEWS("ignoreUnimportantViews");

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -47,8 +47,6 @@ public class MobileCommand {
     protected static final String CLOSE_APP = "closeApp";
     protected static final String LOCK = "lock";
     protected static final String COMPLEX_FIND = "complexFind";
-    protected static final String GET_SETTINGS = "getSettings";
-    protected static final String SET_SETTINGS = "setSettings";
     protected static final String GET_DEVICE_TIME = "getDeviceTime";
     protected static final String GET_SESSION = "getSession";
     //iOS
@@ -67,6 +65,8 @@ public class MobileCommand {
     protected static final String TOGGLE_LOCATION_SERVICES = "toggleLocationServices";
     protected static final String UNLOCK = "unlock";
     protected static final String REPLACE_VALUE = "replaceValue";
+    protected static final String GET_SETTINGS = "getSettings";
+    protected static final String SET_SETTINGS = "setSettings";
 
     public static final  Map<String, CommandInfo> commandRepository = createCommandRepository();
 

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -21,10 +21,10 @@ import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotif
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
 
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.AppiumSetting;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
 import io.appium.java_client.android.internal.JsonToAndroidElementConverter;
+import io.appium.java_client.android.settings.Setting;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
@@ -48,7 +48,7 @@ import java.net.URL;
 public class AndroidDriver<T extends WebElement>
     extends AppiumDriver<T>
     implements AndroidDeviceActionShortcuts, HasNetworkConnection, PushesFiles, StartsActivity,
-    FindsByAndroidUIAutomator<T>, LocksAndroidDevice {
+    FindsByAndroidUIAutomator<T>, LocksAndroidDevice, HasSettings {
 
     private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
 
@@ -189,17 +189,13 @@ public class AndroidDriver<T extends WebElement>
         CommandExecutionHelper.execute(this, toggleLocationServicesCommand());
     }
 
+    @Deprecated
     /**
-     * Set the `ignoreUnimportantViews` setting. *Android-only method*.
-     * Sets whether Android devices should use `setCompressedLayoutHeirarchy()`
-     * which ignores all views which are marked IMPORTANT_FOR_ACCESSIBILITY_NO
-     * or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important
-     * by the system), in an attempt to make things less confusing or faster.
-     *
-     * @param compress ignores unimportant views if true, doesn't ignore otherwise.
+     * This method is deprecated. Use {@link #setSetting(Setting, Object)} method
+     * with {@link Setting} and {@link Setting.IgnoreUnimportantViews#value()}
+     * as parameters
      */
-    // Should be moved to the subclass
     public void ignoreUnimportantViews(Boolean compress) {
-        setSetting(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS, compress);
+        setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -24,7 +24,6 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.FindsByAndroidUIAutomator;
 import io.appium.java_client.android.internal.JsonToAndroidElementConverter;
-import io.appium.java_client.android.settings.Setting;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
@@ -187,15 +186,5 @@ public class AndroidDriver<T extends WebElement>
 
     public void toggleLocationServices() {
         CommandExecutionHelper.execute(this, toggleLocationServicesCommand());
-    }
-
-    @Deprecated
-    /**
-     * This method is deprecated. Use {@link #setSetting(Setting, Object)} method
-     * with {@link Setting} and {@link Setting.IgnoreUnimportantViews#value()}
-     * as parameters
-     */
-    public void ignoreUnimportantViews(Boolean compress) {
-        setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.appium.java_client.MobileCommand;
 
+import io.appium.java_client.android.settings.Setting;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.internal.HasIdentity;
 
@@ -289,5 +290,14 @@ public class AndroidMobileCommandHelper extends MobileCommand {
 
         return new AbstractMap.SimpleEntry<>(
                 REPLACE_VALUE, prepareArguments(parameters, values));
+    }
+
+    public static Map.Entry<String, Map<String, ?>> getSettingsCommand () {
+        return new AbstractMap.SimpleEntry<>(GET_SETTINGS, ImmutableMap.<String, Object>of());
+    }
+
+    public static Map.Entry<String, Map<String, ?>> setSettingsCommand (Setting setting, Object value) {
+        return new AbstractMap.SimpleEntry<>(SET_SETTINGS, prepareArguments("settings",
+                prepareArguments(setting.toString(), value)));
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -291,11 +291,11 @@ public class AndroidMobileCommandHelper extends MobileCommand {
                 REPLACE_VALUE, prepareArguments(parameters, values));
     }
 
-    public static Map.Entry<String, Map<String, ?>> getSettingsCommand () {
+    public static Map.Entry<String, Map<String, ?>> getSettingsCommand() {
         return new AbstractMap.SimpleEntry<>(GET_SETTINGS, ImmutableMap.<String, Object>of());
     }
 
-    public static Map.Entry<String, Map<String, ?>> setSettingsCommand (Setting setting, Object value) {
+    public static Map.Entry<String, Map<String, ?>> setSettingsCommand(Setting setting, Object value) {
         return new AbstractMap.SimpleEntry<>(SET_SETTINGS, prepareArguments("settings",
                 prepareArguments(setting.toString(), value)));
     }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 
 import io.appium.java_client.MobileCommand;
 
-import io.appium.java_client.android.settings.Setting;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.internal.HasIdentity;
 

--- a/src/main/java/io/appium/java_client/android/ConfiguratorParameters.java
+++ b/src/main/java/io/appium/java_client/android/ConfiguratorParameters.java
@@ -16,21 +16,20 @@
 
 package io.appium.java_client.android;
 
-/**
- * Enums defining constants for Appium Settings which can be set and toggled during a test session.
- */
-public enum Setting {
+enum ConfiguratorParameters {
+    WAIT_FOR_IDLE_TIMEOUT("setWaitForIdleTimeout"),
+    WAIT_FOR_SELECTOR_TIMEOUT("setWaitForSelectorTimeout"),
+    WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT("setScrollAcknowledgmentTimeout"),
+    WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT("setActionAcknowledgmentTimeout"),
+    KEY_INJECTION_DELAY("setKeyInjectionDelay");
 
-    IGNORE_UNIMPORTANT_VIEWS("ignoreUnimportantViews"),
-    CONFIGURATOR("configurator");
+    private final String name;
 
-    private String name;
-
-    Setting(String name) {
+    ConfiguratorParameters(String name) {
         this.name = name;
     }
 
-    public String toString() {
-        return this.name;
+    String format(int value) {
+        return String.format("{\"method\":\"%s\",\"value\":%d}", name, value);
     }
 }

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -107,8 +107,7 @@ interface HasSettings extends ExecutesMethod {
      */
     default void configuratorSetKeyInjectionDelay(int delay) {
         setSetting(Setting.CONFIGURATOR,
-            ConfiguratorParameters.
-                KEY_INJECTION_DELAY.format(delay));
+            ConfiguratorParameters.KEY_INJECTION_DELAY.format(delay));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -29,7 +29,9 @@ import org.openqa.selenium.remote.Response;
 
 import java.util.Map;
 
-public interface HasSettings extends ExecutesMethod {
+interface HasSettings extends ExecutesMethod {
+
+    static final String configuratorPattern = "{\"method\":\"%s\",\"value\":%d}";
 
     /**
      * Set a setting for this test session It's probably better to use a
@@ -69,5 +71,56 @@ public interface HasSettings extends ExecutesMethod {
      */
     default void ignoreUnimportantViews(Boolean compress) {
         setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
+    }
+
+    /**
+     * invoke {@code setWaitForIdleTimeout} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param timeout in milliseconds, 0 would reset to its default value
+     */
+    default void configuratorSetWaitForIdleTimeout(int timeout) {
+        setSetting(Setting.CONFIGURATOR,
+            ConfiguratorParameters.WAIT_FOR_IDLE_TIMEOUT.format(timeout));
+    }
+
+    /**
+     * invoke {@code setWaitForSelectorTimeout} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param timeout in milliseconds, 0 would reset to its default value
+     */
+    default void configuratorSetWaitForSelectorTimeout(int timeout) {
+        setSetting(Setting.CONFIGURATOR,
+            ConfiguratorParameters.WAIT_FOR_SELECTOR_TIMEOUT.format(timeout));
+    }
+
+    /**
+     * invoke {@code setScrollAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param timeout in milliseconds, 0 would reset to its default value
+     */
+    default void configuratorSetScrollAcknowledgmentTimeout(int timeout) {
+        setSetting(Setting.CONFIGURATOR,
+            ConfiguratorParameters.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT.format(timeout));
+    }
+
+    /**
+     * invoke {@code configuratorSetKeyInjectionDelay} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param delay in milliseconds, 0 would reset to its default value
+     */
+    default void configuratorSetKeyInjectionDelay(int delay) {
+        setSetting(Setting.CONFIGURATOR,
+            ConfiguratorParameters.
+                KEY_INJECTION_DELAY.format(delay));
+    }
+
+    /**
+     * invoke {@code setActionAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param timeout in milliseconds, 0 would reset to its default value
+     */
+    default void configuratorSetActionAcknowledgmentTimeout(int timeout) {
+        setSetting(Setting.CONFIGURATOR,
+            ConfiguratorParameters.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT.format(timeout));
     }
 }

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonParser;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.ExecutesMethod;
 
-import io.appium.java_client.android.settings.Setting;
 import org.openqa.selenium.remote.Response;
 
 import java.util.Map;
@@ -57,5 +56,18 @@ public interface HasSettings extends ExecutesMethod {
 
         JsonParser parser = new JsonParser();
         return  (JsonObject) parser.parse(response.getValue().toString());
+    }
+
+    /**
+     * Set the `ignoreUnimportantViews` setting. *Android-only method*.
+     * Sets whether Android devices should use `setCompressedLayoutHeirarchy()`
+     * which ignores all views which are marked IMPORTANT_FOR_ACCESSIBILITY_NO
+     * or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important
+     * by the system), in an attempt to make things less confusing or faster.
+     *
+     * @param compress ignores unimportant views if true, doesn't ignore otherwise.
+     */
+    default void ignoreUnimportantViews(Boolean compress) {
+        setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
     }
 }

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -30,9 +30,6 @@ import org.openqa.selenium.remote.Response;
 import java.util.Map;
 
 interface HasSettings extends ExecutesMethod {
-
-    static final String configuratorPattern = "{\"method\":\"%s\",\"value\":%d}";
-
     /**
      * Set a setting for this test session It's probably better to use a
      * convenience function, rather than use this function directly. Try finding

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android;
+
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getSettingsCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.setSettingsCommand;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+
+import io.appium.java_client.android.settings.Setting;
+import org.openqa.selenium.remote.Response;
+
+import java.util.Map;
+
+public interface HasSettings extends ExecutesMethod {
+
+    /**
+     * Set a setting for this test session It's probably better to use a
+     * convenience function, rather than use this function directly. Try finding
+     * the method for the specific setting you want to change.
+     *
+     * @param setting Setting you wish to set.
+     * @param value   value of the setting.
+     */
+    default void setSetting(Setting setting, Object value) {
+        CommandExecutionHelper.execute(this, setSettingsCommand(setting, value));
+    }
+
+    /**
+     * Get settings stored for this test session It's probably better to use a
+     * convenience function, rather than use this function directly. Try finding
+     * the method for the specific setting you want to read.
+     *
+     * @return JsonObject, a straight-up hash of settings.
+     */
+    default JsonObject getSettings() {
+        Map.Entry<String, Map<String, ?>> keyValuePair = getSettingsCommand();
+        Response response = execute(keyValuePair.getKey(), keyValuePair.getValue());
+
+        JsonParser parser = new JsonParser();
+        return  (JsonObject) parser.parse(response.getValue().toString());
+    }
+}

--- a/src/main/java/io/appium/java_client/android/Setting.java
+++ b/src/main/java/io/appium/java_client/android/Setting.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.appium.java_client.android.settings;
+package io.appium.java_client.android;
 
 /**
  * Enums defining constants for Appium Settings which can be set and toggled during a test session.
@@ -32,31 +32,4 @@ public enum Setting {
     public String toString() {
         return this.name;
     }
-
-    /**
-     * Contains possible values of the `ignoreUnimportantViews` setting.
-     * It helps to define whether Android devices should use `setCompressedLayoutHeirarchy()`
-     * which ignores all views that are marked IMPORTANT_FOR_ACCESSIBILITY_NO
-     * or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important
-     * by the system), in an attempt to make things less confusing or faster.
-     */
-    public static enum IgnoreUnimportantViews {
-        YES(true),
-        NO(false);
-
-        private final Boolean ignore;
-
-        IgnoreUnimportantViews(Boolean ignore) {
-            this.ignore = ignore;
-        }
-
-        /**
-         * @return value which means to ignore unimportant views if true,
-         * doesn't ignore otherwise.
-         */
-        public Boolean value() {
-            return ignore;
-        }
-    }
-
 }

--- a/src/main/java/io/appium/java_client/android/settings/Setting.java
+++ b/src/main/java/io/appium/java_client/android/settings/Setting.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android.settings;
+
+/**
+ * Enums defining constants for Appium Settings which can be set and toggled during a test session.
+ */
+public enum Setting {
+
+    IGNORE_UNIMPORTANT_VIEWS("ignoreUnimportantViews");
+
+    private String name;
+
+    Setting(String name) {
+        this.name = name;
+    }
+
+    public String toString() {
+        return this.name;
+    }
+
+    /**
+     * Contains possible values of the `ignoreUnimportantViews` setting.
+     * It helps to define whether Android devices should use `setCompressedLayoutHeirarchy()`
+     * which ignores all views that are marked IMPORTANT_FOR_ACCESSIBILITY_NO
+     * or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important
+     * by the system), in an attempt to make things less confusing or faster.
+     */
+    public static enum IgnoreUnimportantViews {
+        YES(true),
+        NO(false);
+
+        private final Boolean ignore;
+
+        IgnoreUnimportantViews(Boolean ignore) {
+            this.ignore = ignore;
+        }
+
+        /**
+         * @return value which means to ignore unimportant views if true,
+         * doesn't ignore otherwise.
+         */
+        public Boolean value() {
+            return ignore;
+        }
+    }
+
+}

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import io.appium.java_client.android.settings.Setting;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import io.appium.java_client.AppiumSetting;
+import io.appium.java_client.android.settings.Setting;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -80,18 +80,6 @@ public class AndroidDriverTest extends BaseAndroidTest {
         } finally {
             FileUtils.forceDelete(temp);
         }
-    }
-
-    @Test public void ignoreUnimportantViews() {
-        driver.ignoreUnimportantViews(true);
-        boolean ignoreViews =
-            driver.getSettings().get(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS.toString())
-                .getAsBoolean();
-        assertTrue(ignoreViews);
-        driver.ignoreUnimportantViews(false);
-        ignoreViews = driver.getSettings().get(AppiumSetting.IGNORE_UNIMPORTANT_VIEWS.toString())
-            .getAsBoolean();
-        assertFalse(ignoreViews);
     }
 
     @Test public void toggleLocationServicesTest() {

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -1,0 +1,24 @@
+package io.appium.java_client.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.appium.java_client.android.settings.Setting;
+import org.junit.Test;
+
+public class SettingTest extends BaseAndroidTest {
+
+    @Test public void ignoreUnimportantViewsTest() {
+        driver.setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS,
+                Setting.IgnoreUnimportantViews.YES.value());
+        boolean ignoreViews =
+                driver.getSettings().get(Setting.IGNORE_UNIMPORTANT_VIEWS.toString())
+                        .getAsBoolean();
+        assertTrue(ignoreViews);
+        driver.setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS,
+                Setting.IgnoreUnimportantViews.NO.value());
+        ignoreViews = driver.getSettings().get(Setting.IGNORE_UNIMPORTANT_VIEWS.toString())
+                .getAsBoolean();
+        assertFalse(ignoreViews);
+    }
+}

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -39,9 +39,9 @@ public class SettingTest extends BaseAndroidTest {
 
     private void assertJSONElementContains(String method, int value) {
         driver.getSettings().get(Setting.CONFIGURATOR.toString());
-        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString()).
-                getAsJsonObject().get("method").getAsString(), method);
-        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString()).
-                getAsJsonObject().get("value").getAsInt(), value);
+        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString())
+                .getAsJsonObject().get("method").getAsString(), method);
+        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString())
+                .getAsJsonObject().get("value").getAsInt(), value);
     }
 }

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -3,20 +3,17 @@ package io.appium.java_client.android;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import io.appium.java_client.android.settings.Setting;
 import org.junit.Test;
 
 public class SettingTest extends BaseAndroidTest {
 
     @Test public void ignoreUnimportantViewsTest() {
-        driver.setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS,
-                Setting.IgnoreUnimportantViews.YES.value());
+        driver.ignoreUnimportantViews(true);
         boolean ignoreViews =
                 driver.getSettings().get(Setting.IGNORE_UNIMPORTANT_VIEWS.toString())
                         .getAsBoolean();
         assertTrue(ignoreViews);
-        driver.setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS,
-                Setting.IgnoreUnimportantViews.NO.value());
+        driver.ignoreUnimportantViews(false);
         ignoreViews = driver.getSettings().get(Setting.IGNORE_UNIMPORTANT_VIEWS.toString())
                 .getAsBoolean();
         assertFalse(ignoreViews);

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -1,5 +1,6 @@
 package io.appium.java_client.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -17,5 +18,30 @@ public class SettingTest extends BaseAndroidTest {
         ignoreViews = driver.getSettings().get(Setting.IGNORE_UNIMPORTANT_VIEWS.toString())
                 .getAsBoolean();
         assertFalse(ignoreViews);
+    }
+
+    @Test public void configuratorTest() {
+        driver.configuratorSetActionAcknowledgmentTimeout(5);
+        assertJSONElementContains("setActionAcknowledgmentTimeout", 5);
+
+        driver.configuratorSetKeyInjectionDelay(4);
+        assertJSONElementContains("setKeyInjectionDelay", 4);
+
+        driver.configuratorSetScrollAcknowledgmentTimeout(3);
+        assertJSONElementContains("setScrollAcknowledgmentTimeout", 3);
+
+        driver.configuratorSetWaitForIdleTimeout(6);
+        assertJSONElementContains("setWaitForIdleTimeout", 6);
+
+        driver.configuratorSetWaitForSelectorTimeout(1);
+        assertJSONElementContains("setWaitForSelectorTimeout", 1);
+    }
+
+    private void assertJSONElementContains(String method, int value) {
+        driver.getSettings().get(Setting.CONFIGURATOR.toString());
+        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString()).
+                getAsJsonObject().get("method").getAsString(), method);
+        assertEquals(driver.getSettings().get(Setting.CONFIGURATOR.toString()).
+                getAsJsonObject().get("value").getAsInt(), value);
     }
 }


### PR DESCRIPTION
## Change list

- `io.appium.java_client.AppiumSetting` became deprecated. It was moved to `io.appium.java_client.android.Setting`.

- the method `io.appium.java_client.AppiumDriver#getSettings()` was completely moved to `io.appium.java_client.android.AndroidDriver`.

- the new interface `io.appium.java_client.android.HasSettings` was added. It has default implementation. And this interface is implemented by AndroidDriver.
Methods:
  - `void setSetting(Setting setting, Object value) `
  - `JsonObject getSettings() `
  - `void ignoreUnimportantViews(Boolean compress)`
  - `void configuratorSetWaitForIdleTimeout(int timeout) `
  - `void configuratorSetWaitForSelectorTimeout(int timeout) `
  - `void configuratorSetScrollAcknowledgmentTimeout(int timeout) `
  - `void configuratorSetKeyInjectionDelay(int delay)`
  - `void configuratorSetActionAcknowledgmentTimeout(int timeout)`
This change was proposed at #410 by @truebit 
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#471