### PR TITLE
Update Swipe method of AndroidDriver

### DIFF
--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -164,7 +164,7 @@ public class AndroidDriver<T extends WebElement>
      * @see io.appium.java_client.TouchShortcuts#swipe(int, int, int, int, int)
      */
     @Override public void swipe(int startx, int starty, int endx, int endy, int duration) {
-        doSwipe(startx, starty, endx, endy, duration);
+        doSwipe(startx, starty, endx - startx, endy - starty, duration);
     }
 
     /**


### PR DESCRIPTION
## Change list

Please provide briefly described change list which are you going to propose. 
 AndroidDriver swipe method should have passed "endx" as "endx-startx" and "endy" as "endy-starty" to doSwipe method of AppiumDriver because the moveTo method behave relatively rather than exactly.
IOSDriver had implemented swipe method correctly.
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 

AndroidDriver swipe method should have passed "endx" as "endx-startx" and "endy" as "endy-starty" to doSwipe method of AppiumDriver because the moveTo method behave relatively rather than exactly.
IOSDriver had implemented swipe method correctly.