### PR TITLE
removed obselete gson-2.6.2 dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     compile 'commons-validator:commons-validator:1.5.1'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'commons-io:commons-io:2.5'
-    compile 'com.google.code.gson:gson:2.6.2'
     compile 'org.springframework:spring-context:4.3.2.RELEASE'
     compile 'org.aspectj:aspectjweaver:1.8.9'
 


### PR DESCRIPTION
## Change list

Removed dependency from `build.gradle` dependencies list:
`compile 'com.google.code.gson:gson:2.6.2'`
as there already is a later version (`2.7`) included in the dependencies list.
```
    compile 'com.google.code.gson:gson:2.7'            <--------
    compile 'org.apache.httpcomponents:httpclient:4.5.2'
    compile 'com.google.guava:guava:19.0'
    compile 'cglib:cglib:3.2.4'
    compile 'commons-validator:commons-validator:1.5.1'
    compile 'org.apache.commons:commons-lang3:3.4'
    compile 'commons-io:commons-io:2.5'
    compile 'com.google.code.gson:gson:2.6.2'         <--------
    compile 'org.springframework:spring-context:4.3.2.RELEASE'
    compile 'org.aspectj:aspectjweaver:1.8.9'
```
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
-