### PR TITLE
Fix a tiny XML typo (Installing-the-project.md)

### DIFF
--- a/docs/Installing-the-project.md
+++ b/docs/Installing-the-project.md
@@ -13,7 +13,7 @@ Add the following to pom.xml:
   <groupId>io.appium</groupId>
   <artifactId>java-client</artifactId>
   <version>${version.you.require}</version>
-  <scope>test</test>
+  <scope>test</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
I'm working on a project now using this library and noticed this small typo when trying to prepare my `pom.xml` file. This is a great project—thanks for all your work!