### PR TITLE
new gradle plugins block + fatJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+  id "org.owasp.dependencycheck" version "1.4.5"
+  id "com.github.johnrengelman.shadow" version "1.2.4"
+}
+
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
@@ -15,19 +20,6 @@ repositories {
         url "http://repo.maven.apache.org/maven2"
     }
 }
-
-buildscript {
-    repositories {
-        maven {
-            url "http://repo.maven.apache.org/maven2"
-        }
-    }
-    dependencies {
-        classpath "org.owasp:dependency-check-gradle:1.4.0"
-    }
-}
-
-apply plugin: "org.owasp.dependencycheck"
 
 configurations {
     ecj

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-plugins {
-  id "org.owasp.dependencycheck" version "1.4.5"
-  id "com.github.johnrengelman.shadow" version "1.2.4"
-}
-
 apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'eclipse'
@@ -20,6 +15,22 @@ repositories {
         url "http://repo.maven.apache.org/maven2"
     }
 }
+
+buildscript {
+    jcenter()
+    repositories {
+        maven {
+            url "http://repo.maven.apache.org/maven2"
+        }
+    }
+    dependencies {
+        classpath "org.owasp:dependency-check-gradle:1.4.0"
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    }
+}
+
+apply plugin: "org.owasp.dependencycheck"
+apply plugin: 'com.github.johnrengelman.shadow'
 
 configurations {
     ecj

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ repositories {
 }
 
 buildscript {
-    jcenter()
     repositories {
+        jcenter()
         maven {
             url "http://repo.maven.apache.org/maven2"
         }


### PR DESCRIPTION
To build fatJar, apply this PR patch and simply call `./gradlew shadowJar`

## Change list
* Adding support for the new gradle plugins block
* Using the shadow plugin to create a fatJar for appium java client.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [X] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

* Usage of plugins block makes buildscript terse
* Allowing building fatJars helps makes life easy for cmd line usage.
