### PR TITLE
add apis to read the performance data

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -48,6 +48,10 @@ public class MobileCommand {
     protected static final String GET_DEVICE_TIME;
     protected static final String GET_SESSION;
 
+    protected static final String GET_PERFORMANCE_DATA;
+    protected static final String GET_SUPPORTED_PERFORMANCE_DATA_TYPES;
+
+
     protected static final String HIDE_KEYBOARD;
     protected static final String LOCK;
     //iOS
@@ -91,6 +95,9 @@ public class MobileCommand {
         CLOSE_APP = "closeApp";
         GET_DEVICE_TIME = "getDeviceTime";
         GET_SESSION = "getSession";
+
+        GET_PERFORMANCE_DATA = "getPerformanceData";
+        GET_SUPPORTED_PERFORMANCE_DATA_TYPES = "getSuppportedPerformanceDataTypes";
 
         HIDE_KEYBOARD = "hideKeyboard";
         LOCK = "lock";
@@ -136,6 +143,11 @@ public class MobileCommand {
         commandRepository.put(SET_SETTINGS, postC("/session/:sessionId/appium/settings"));
         commandRepository.put(GET_DEVICE_TIME, getC("/session/:sessionId/appium/device/system_time"));
         commandRepository.put(GET_SESSION,getC("/session/:sessionId/"));
+        commandRepository.put(GET_SUPPORTED_PERFORMANCE_DATA_TYPES,
+            postC("/session/:sessionId/appium/performanceData/types"));
+        commandRepository.put(GET_PERFORMANCE_DATA,
+            postC("/session/:sessionId/appium/getPerformanceData"));
+
         //iOS
         commandRepository.put(SHAKE, postC("/session/:sessionId/appium/device/shake"));
         commandRepository.put(TOUCH_ID, postC("/session/:sessionId/appium/simulator/touch_id"));

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -17,6 +17,8 @@
 package io.appium.java_client.android;
 
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getPerformanceDataCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getSupportedPerformanceDataTypesCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
 
@@ -31,9 +33,11 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
+import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.URL;
+import java.util.List;
 
 /**
  * @param <T> the required type of class which implement {@link org.openqa.selenium.WebElement}.
@@ -150,6 +154,51 @@ public class AndroidDriver<T extends WebElement>
      */
     public AndroidDriver(Capabilities desiredCapabilities) {
         super(substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+    }
+
+    /**
+     * returns the information type of the system state which is supported to read
+     * as like cpu, memory, network traffic, and battery.
+     * @return output - array like below
+     *                  [cpuinfo, batteryinfo, networkinfo, memoryinfo]
+     *
+     */
+    public List<String> getSupportedPerformanceDataTypes() {
+        return CommandExecutionHelper.execute(this, getSupportedPerformanceDataTypesCommand());
+    }
+
+    /**
+     * returns the resource usage information of the application. the resource is one of the system state
+     * which means cpu, memory, network traffic, and battery.
+     *
+     * @param packageName the package name of the application
+     * @param dataType the type of system state which wants to read.
+     *                 It should be one of the supported performance data types,
+     *                 the return value of the function "getSupportedPerformanceDataTypes"
+     * @param dataReadTimeout the number of attempts to read
+     * @return table of the performance data, The first line of the table represents the type of data.
+     *          The remaining lines represent the values of the data.
+     *          in case of battery info : [[power], [23]]
+     *          in case of memory info :
+     *              [[totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty,
+     *                        totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize],
+     *                        [18360, 8296, 6132, null, null, 42588, 8406, 7024, null, null, 26519, 10344]]
+     *          in case of network info :
+     *              [[bucketStart, activeTime, rxBytes, rxPackets, txBytes, txPackets, operations, bucketDuration,],
+     *                        [1478091600000, null, 1099075, 610947, 928, 114362, 769, 0, 3600000],
+     *                        [1478095200000, null, 1306300, 405997, 509, 46359, 370, 0, 3600000]]
+     *          in case of network info :
+     *              [[st, activeTime, rb, rp, tb, tp, op, bucketDuration],
+     *                        [1478088000, null, null, 32115296, 34291, 2956805, 25705, 0, 3600],
+     *                        [1478091600, null, null, 2714683, 11821, 1420564, 12650, 0, 3600],
+     *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
+     *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
+     *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
+     * @throws if the performance data type is not supported, thows Error
+     */
+    public List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout) {
+        return CommandExecutionHelper.execute(this,
+                                                getPerformanceDataCommand(packageName, dataType, dataReadTimeout));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -193,9 +193,10 @@ public class AndroidDriver<T extends WebElement>
      *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
      *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
      *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
-     * @throws if the performance data type is not supported, thows Error
+     * @throws Exception if the performance data type is not supported, thows Error
      */
-    public List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout) {
+    public List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout)
+            throws Exception {
         return CommandExecutionHelper.execute(this,
                                                 getPerformanceDataCommand(packageName, dataType, dataReadTimeout));
     }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -33,7 +33,6 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
-import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.URL;

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -50,7 +50,8 @@ import java.util.List;
 public class AndroidDriver<T extends WebElement>
     extends AppiumDriver<T>
     implements PressesKeyCode, HasNetworkConnection, PushesFiles, StartsActivity,
-        FindsByAndroidUIAutomator<T>, LocksAndroidDevice, HasSettings, HasDeviceDetails {
+        FindsByAndroidUIAutomator<T>, LocksAndroidDevice, HasSettings, HasDeviceDetails,
+            HasSupportedPerformanceDataType {
 
     private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
 

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -17,8 +17,6 @@
 package io.appium.java_client.android;
 
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.getPerformanceDataCommand;
-import static io.appium.java_client.android.AndroidMobileCommandHelper.getSupportedPerformanceDataTypesCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
 
@@ -36,7 +34,6 @@ import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.http.HttpClient;
 
 import java.net.URL;
-import java.util.List;
 
 /**
  * @param <T> the required type of class which implement {@link org.openqa.selenium.WebElement}.

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -157,52 +157,6 @@ public class AndroidDriver<T extends WebElement>
     }
 
     /**
-     * returns the information type of the system state which is supported to read
-     * as like cpu, memory, network traffic, and battery.
-     * @return output - array like below
-     *                  [cpuinfo, batteryinfo, networkinfo, memoryinfo]
-     *
-     */
-    public List<String> getSupportedPerformanceDataTypes() {
-        return CommandExecutionHelper.execute(this, getSupportedPerformanceDataTypesCommand());
-    }
-
-    /**
-     * returns the resource usage information of the application. the resource is one of the system state
-     * which means cpu, memory, network traffic, and battery.
-     *
-     * @param packageName the package name of the application
-     * @param dataType the type of system state which wants to read.
-     *                 It should be one of the supported performance data types,
-     *                 the return value of the function "getSupportedPerformanceDataTypes"
-     * @param dataReadTimeout the number of attempts to read
-     * @return table of the performance data, The first line of the table represents the type of data.
-     *          The remaining lines represent the values of the data.
-     *          in case of battery info : [[power], [23]]
-     *          in case of memory info :
-     *              [[totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty,
-     *                        totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize],
-     *                        [18360, 8296, 6132, null, null, 42588, 8406, 7024, null, null, 26519, 10344]]
-     *          in case of network info :
-     *              [[bucketStart, activeTime, rxBytes, rxPackets, txBytes, txPackets, operations, bucketDuration,],
-     *                        [1478091600000, null, 1099075, 610947, 928, 114362, 769, 0, 3600000],
-     *                        [1478095200000, null, 1306300, 405997, 509, 46359, 370, 0, 3600000]]
-     *          in case of network info :
-     *              [[st, activeTime, rb, rp, tb, tp, op, bucketDuration],
-     *                        [1478088000, null, null, 32115296, 34291, 2956805, 25705, 0, 3600],
-     *                        [1478091600, null, null, 2714683, 11821, 1420564, 12650, 0, 3600],
-     *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
-     *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
-     *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
-     * @throws Exception if the performance data type is not supported, thows Error
-     */
-    public List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout)
-            throws Exception {
-        return CommandExecutionHelper.execute(this,
-                                                getPerformanceDataCommand(packageName, dataType, dataReadTimeout));
-    }
-
-    /**
      * This method is deprecated. It is going to be removed
      */
     @Override public void swipe(int startx, int starty, int endx, int endy, int duration) {

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.internal.HasIdentity;
 
 import java.util.AbstractMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -61,6 +62,55 @@ public class AndroidMobileCommandHelper extends MobileCommand {
         Object[] values = new Object[] {intent, path};
         return new AbstractMap.SimpleEntry<>(
                 END_TEST_COVERAGE, prepareArguments(parameters, values));
+    }
+
+    /**
+     * returns the information type of the system state which is supported to read
+     * as like cpu, memory, network traffic, and battery.
+     * @return output - array like below
+     *                  [cpuinfo, batteryinfo, networkinfo, memoryinfo]
+     *
+     */
+    public static Map.Entry<String, Map<String, ?>> getSupportedPerformanceDataTypesCommand() {
+        return new AbstractMap.SimpleEntry<>(
+            GET_SUPPORTED_PERFORMANCE_DATA_TYPES, ImmutableMap.<String, Object>of());
+    }
+
+    /**
+     * returns the resource usage information of the application. the resource is one of the system state
+     * which means cpu, memory, network traffic, and battery.
+     *
+     * @param packageName the package name of the application
+     * @param dataType the type of system state which wants to read.
+     *                 It should be one of the supported performance data types,
+     *                 the return value of the function "getSupportedPerformanceDataTypes"
+     * @param dataReadTimeout the number of attempts to read
+     * @return table of the performance data, The first line of the table represents the type of data.
+     *          The remaining lines represent the values of the data.
+     *          in case of battery info : [[power], [23]]
+     *          in case of memory info :
+     *              [[totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty,
+     *                        totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize],
+     *                        [18360, 8296, 6132, null, null, 42588, 8406, 7024, null, null, 26519, 10344]]
+     *          in case of network info :
+     *              [[bucketStart, activeTime, rxBytes, rxPackets, txBytes, txPackets, operations, bucketDuration,],
+     *                        [1478091600000, null, 1099075, 610947, 928, 114362, 769, 0, 3600000],
+     *                        [1478095200000, null, 1306300, 405997, 509, 46359, 370, 0, 3600000]]
+     *          in case of network info :
+     *              [[st, activeTime, rb, rp, tb, tp, op, bucketDuration],
+     *                        [1478088000, null, null, 32115296, 34291, 2956805, 25705, 0, 3600],
+     *                        [1478091600, null, null, 2714683, 11821, 1420564, 12650, 0, 3600],
+     *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
+     *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
+     *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
+     * @throws if the performance data type is not supported, thows Error
+     */
+    public static Map.Entry<String, Map<String, ?>> getPerformanceDataCommand(
+                    String packageName, String dataType, int dataReadTimeout) {
+        String[] parameters = new String[] {"packageName", "dataType", "dataReadTimeout"};
+        Object[] values = new Object[] {packageName, dataType, dataReadTimeout};
+        return new AbstractMap.SimpleEntry<>(
+            GET_PERFORMANCE_DATA, prepareArguments(parameters, values));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.internal.HasIdentity;
 
 import java.util.AbstractMap;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -102,10 +102,10 @@ public class AndroidMobileCommandHelper extends MobileCommand {
      *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
      *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
      *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
-     * @throws if the performance data type is not supported, thows Error
+     * @throws Exception if the performance data type is not supported, thows Error
      */
     public static Map.Entry<String, Map<String, ?>> getPerformanceDataCommand(
-                    String packageName, String dataType, int dataReadTimeout) {
+                    String packageName, String dataType, int dataReadTimeout) throws Exception {
         String[] parameters = new String[] {"packageName", "dataType", "dataReadTimeout"};
         Object[] values = new Object[] {packageName, dataType, dataReadTimeout};
         return new AbstractMap.SimpleEntry<>(

--- a/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
+++ b/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
@@ -9,7 +9,7 @@ import io.appium.java_client.ExecutesMethod;
 import java.util.List;
 
 /**
- * Created by hwangheeseon on 2017. 2. 2..
+ *
  */
 public interface HasSupportedPerformanceDataType extends ExecutesMethod {
 

--- a/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
+++ b/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
@@ -12,10 +12,47 @@ import java.util.List;
  * Created by hwangheeseon on 2017. 2. 2..
  */
 public interface HasSupportedPerformanceDataType extends ExecutesMethod {
+
+    /**
+     * returns the information type of the system state which is supported to read
+     * as like cpu, memory, network traffic, and battery.
+     * @return output - array like below
+     *                  [cpuinfo, batteryinfo, networkinfo, memoryinfo]
+     *
+     */
     default List<String> getSupportedPerformanceDataTypes() {
         return CommandExecutionHelper.execute(this, getSupportedPerformanceDataTypesCommand());
     }
 
+    /**
+     * returns the resource usage information of the application. the resource is one of the system state
+     * which means cpu, memory, network traffic, and battery.
+     *
+     * @param packageName the package name of the application
+     * @param dataType the type of system state which wants to read.
+     *                 It should be one of the supported performance data types,
+     *                 the return value of the function "getSupportedPerformanceDataTypes"
+     * @param dataReadTimeout the number of attempts to read
+     * @return table of the performance data, The first line of the table represents the type of data.
+     *          The remaining lines represent the values of the data.
+     *          in case of battery info : [[power], [23]]
+     *          in case of memory info :
+     *              [[totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty,
+     *                        totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize],
+     *                        [18360, 8296, 6132, null, null, 42588, 8406, 7024, null, null, 26519, 10344]]
+     *          in case of network info :
+     *              [[bucketStart, activeTime, rxBytes, rxPackets, txBytes, txPackets, operations, bucketDuration,],
+     *                        [1478091600000, null, 1099075, 610947, 928, 114362, 769, 0, 3600000],
+     *                        [1478095200000, null, 1306300, 405997, 509, 46359, 370, 0, 3600000]]
+     *          in case of network info :
+     *              [[st, activeTime, rb, rp, tb, tp, op, bucketDuration],
+     *                        [1478088000, null, null, 32115296, 34291, 2956805, 25705, 0, 3600],
+     *                        [1478091600, null, null, 2714683, 11821, 1420564, 12650, 0, 3600],
+     *                        [1478095200, null, null, 10079213, 19962, 2487705, 20015, 0, 3600],
+     *                        [1478098800, null, null, 4444433, 10227, 1430356, 10493, 0, 3600]]
+     *          in case of cpu info : [[user, kernel], [0.9, 1.3]]
+     * @throws Exception if the performance data type is not supported, thows Error
+     */
     default List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout)
             throws Exception {
         return CommandExecutionHelper.execute(this,

--- a/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
+++ b/src/main/java/io/appium/java_client/android/HasSupportedPerformanceDataType.java
@@ -1,0 +1,24 @@
+package io.appium.java_client.android;
+
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getPerformanceDataCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.getSupportedPerformanceDataTypesCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
+
+import java.util.List;
+
+/**
+ * Created by hwangheeseon on 2017. 2. 2..
+ */
+public interface HasSupportedPerformanceDataType extends ExecutesMethod {
+    default List<String> getSupportedPerformanceDataTypes() {
+        return CommandExecutionHelper.execute(this, getSupportedPerformanceDataTypesCommand());
+    }
+
+    default List<List<Object>> getPerformanceData(String packageName, String dataType, int dataReadTimeout)
+            throws Exception {
+        return CommandExecutionHelper.execute(this,
+                getPerformanceDataCommand(packageName, dataType, dataReadTimeout));
+    }
+}

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.html5.Location;
 
 import java.io.File;
 import java.util.Map;
+import java.util.List;
 
 public class AndroidDriverTest extends BaseAndroidTest {
 
@@ -140,4 +141,33 @@ public class AndroidDriverTest extends BaseAndroidTest {
         assertNotNull(driver.getDisplayDensity());
         assertNotEquals(0, driver.getSystemBars().size());
     }
+
+    @Test public void getSupportedPerformanceDataTypesTest() {
+        driver.startActivity("io.appium.android.apis", ".ApiDemos");
+
+        List<String> supportedPerformanceDataTypes = driver.getSupportedPerformanceDataTypes();
+        assert(supportedPerformanceDataTypes.size() == 4);
+
+    }
+
+    @Test public void getPerformanceDataTest() {
+        driver.startActivity("io.appium.android.apis", ".ApiDemos");
+
+        List<String> supportedPerformanceDataTypes = driver.getSupportedPerformanceDataTypes();
+
+        for(int i = 0 ; i < supportedPerformanceDataTypes.size() ;  ++ i){
+
+            String dataType = supportedPerformanceDataTypes.get(i);
+
+            List<List<Object>> valueTable = driver.getPerformanceData("com.example.android.apis", dataType, 60000);
+
+            int valueTableHeadLength = valueTable.get(0).size();
+
+            for(int j = 1 ; j < valueTable.size() ; ++ j){
+                assert(valueTableHeadLength == valueTable.get(j).size());
+            }
+        }
+
+    }
+
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -164,7 +164,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     }
 
-    @Test public void getPerformanceDataTest() {
+    @Test public void getPerformanceDataTest() throws Exception {
         driver.startActivity("io.appium.android.apis", ".ApiDemos");
 
         List<String> supportedPerformanceDataTypes = driver.getSupportedPerformanceDataTypes();

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -29,8 +29,10 @@ import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.html5.Location;
 
 import java.io.File;
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 
 public class AndroidDriverTest extends BaseAndroidTest {
 
@@ -145,8 +147,20 @@ public class AndroidDriverTest extends BaseAndroidTest {
     @Test public void getSupportedPerformanceDataTypesTest() {
         driver.startActivity("io.appium.android.apis", ".ApiDemos");
 
+        List<String> dataTypes = new ArrayList<String>();
+        dataTypes.add("cpuinfo");
+        dataTypes.add("memoryinfo");
+        dataTypes.add("batteryinfo");
+        dataTypes.add("networkinfo");
+
         List<String> supportedPerformanceDataTypes = driver.getSupportedPerformanceDataTypes();
-        assert(supportedPerformanceDataTypes.size() == 4);
+
+        assertEquals(4, supportedPerformanceDataTypes.size());
+
+        for ( int i = 0 ; i < supportedPerformanceDataTypes.size() ;  ++i) {
+            assertEquals(dataTypes.get(i), supportedPerformanceDataTypes.get(i));
+        }
+
 
     }
 
@@ -155,16 +169,14 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
         List<String> supportedPerformanceDataTypes = driver.getSupportedPerformanceDataTypes();
 
-        for(int i = 0 ; i < supportedPerformanceDataTypes.size() ;  ++ i){
+        for (int i = 0 ; i < supportedPerformanceDataTypes.size() ;  ++ i) {
 
             String dataType = supportedPerformanceDataTypes.get(i);
 
             List<List<Object>> valueTable = driver.getPerformanceData("com.example.android.apis", dataType, 60000);
 
-            int valueTableHeadLength = valueTable.get(0).size();
-
-            for(int j = 1 ; j < valueTable.size() ; ++ j){
-                assert(valueTableHeadLength == valueTable.get(j).size());
+            for ( int j = 1 ; j < valueTable.size() ; ++ j) {
+                assertEquals(valueTable.subList(0,0).size(), valueTable.subList(j, j).size());
             }
         }
 


### PR DESCRIPTION
## Change list

add apis to read the resource usage information of the application as like cpu, memory, network traffic, and battery
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The appium already has a way to gather the performance data by log.
but If the resulting data format is set to a log file, the user should conduct another parsing to show the data on the screen.
also I think user wants to decide the moment to read the data and associate the performance data and other information.
so I’d like to add apis to gather the performance data.

please refer below the commit code 
- https://github.com/appium/appium-base-driver/commit/0fd67e4efbed9c8a8352b18557b84b10649baabc
- https://github.com/appium/appium-android-driver/commit/1e6c644a9260ca22726405b44c5e4370b69f9059