### PR TITLE
#574 FIX

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -151,6 +151,10 @@ class AppiumElementLocator implements CacheableLocator {
         return shouldCache;
     }
 
+    @Override public String toString() {
+        return String.format("Located by %s", by);
+    }
+
 
     // This function waits for not empty element list using all defined by
     private static class WaitingFunction<T> implements Function<Supplier<T>, T> {

--- a/src/main/java/io/appium/java_client/pagefactory/ElementInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ElementInterceptor.java
@@ -16,6 +16,8 @@
 
 package io.appium.java_client.pagefactory;
 
+import static io.appium.java_client.pagefactory.ThrowableUtil.extractReadableException;
+
 import io.appium.java_client.pagefactory.interceptors.InterceptorOfASingleElement;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -37,7 +39,7 @@ class ElementInterceptor extends InterceptorOfASingleElement {
         try {
             return method.invoke(element, args);
         } catch (Throwable t) {
-            throw ThrowableUtil.extractReadableException(t);
+            throw extractReadableException(t);
         }
     }
 }

--- a/src/main/java/io/appium/java_client/pagefactory/ElementListInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ElementListInterceptor.java
@@ -16,6 +16,8 @@
 
 package io.appium.java_client.pagefactory;
 
+import static io.appium.java_client.pagefactory.ThrowableUtil.extractReadableException;
+
 import io.appium.java_client.pagefactory.interceptors.InterceptorOfAListOfElements;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
@@ -37,7 +39,7 @@ class ElementListInterceptor extends InterceptorOfAListOfElements {
         try {
             return method.invoke(elements, args);
         } catch (Throwable t) {
-            throw ThrowableUtil.extractReadableException(t);
+            throw extractReadableException(t);
         }
     }
 

--- a/src/main/java/io/appium/java_client/pagefactory/WidgetInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WidgetInterceptor.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client.pagefactory;
 
+import static io.appium.java_client.pagefactory.ThrowableUtil.extractReadableException;
 import static io.appium.java_client.pagefactory.utils.WebDriverUnpackUtility.getCurrentContentType;
 
 import io.appium.java_client.pagefactory.bys.ContentType;
@@ -76,7 +77,7 @@ class WidgetInterceptor extends InterceptorOfASingleElement {
             method.setAccessible(true);
             return method.invoke(cachedInstances.get(type), args);
         } catch (Throwable t) {
-            throw ThrowableUtil.extractReadableException(t);
+            throw extractReadableException(t);
         }
     }
 

--- a/src/main/java/io/appium/java_client/pagefactory/WidgetListInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WidgetListInterceptor.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client.pagefactory;
 
+import static io.appium.java_client.pagefactory.ThrowableUtil.extractReadableException;
 import static io.appium.java_client.pagefactory.utils.WebDriverUnpackUtility.getCurrentContentType;
 
 import io.appium.java_client.pagefactory.bys.ContentType;
@@ -70,7 +71,7 @@ class WidgetListInterceptor extends InterceptorOfAListOfElements {
         try {
             return method.invoke(cachedWidgets, args);
         } catch (Throwable t) {
-            throw ThrowableUtil.extractReadableException(t);
+            throw extractReadableException(t);
         }
     }
 }

--- a/src/main/java/io/appium/java_client/pagefactory/interceptors/InterceptorOfASingleElement.java
+++ b/src/main/java/io/appium/java_client/pagefactory/interceptors/InterceptorOfASingleElement.java
@@ -23,7 +23,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.WrapsDriver;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 
@@ -37,7 +36,7 @@ public abstract class InterceptorOfASingleElement implements MethodInterceptor {
     }
 
     protected abstract Object getObject(WebElement element, Method method, Object[] args)
-        throws InvocationTargetException, IllegalAccessException, InstantiationException, Throwable;
+        throws Throwable;
 
     /**
      * Look at
@@ -45,6 +44,11 @@ public abstract class InterceptorOfASingleElement implements MethodInterceptor {
      */
     public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy)
         throws Throwable {
+
+        if (method.getName().equals("toString") && args.length == 0) {
+            return locator.toString();
+        }
+
         if (Object.class.equals(method.getDeclaringClass())) {
             return proxy.invokeSuper(obj, args);
         }


### PR DESCRIPTION
## Change list

- #574 BUG FIX;
- Some codestyle improvements;
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

@vikramvi I could find the rootcause of the bug. 
Here:  https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/support/ui/ExpectedConditions.java#L293

the `toString()` method is invoked. And this method is overriden by [RemoteWebElement](https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/remote/RemoteWebElement.java#L395). So the searching was being invoked... twice :)))

Now this sample test passes:
```java
package io.appium.java_client.pagefactory_tests;

import io.appium.java_client.android.BaseAndroidTest;
import io.appium.java_client.pagefactory.AndroidFindBy;
import io.appium.java_client.pagefactory.AppiumFieldDecorator;
import io.appium.java_client.pagefactory.WithTimeout;
import org.junit.Assert;
import org.junit.Before;
import org.junit.Test;
import org.openqa.selenium.WebElement;
import org.openqa.selenium.support.PageFactory;
import org.openqa.selenium.support.ui.ExpectedConditions;
import org.openqa.selenium.support.ui.WebDriverWait;

import java.util.Calendar;
import java.util.concurrent.TimeUnit;

import static org.junit.Assert.assertTrue;

public class BugReproducing extends BaseAndroidTest {

    private static final long ACCEPTABLE_DELTA_MILLS = 1500;

    @WithTimeout(time = 4, unit = TimeUnit.SECONDS)
    @AndroidFindBy(className = "ABC")  //this is invalid locator; purposely put up
    private WebElement textView;

    /**
     * The setting up.
     */
    @Before
    public void setUp() throws Exception {
        PageFactory.initElements(new AppiumFieldDecorator(driver, 15, TimeUnit.SECONDS), this);
    }

    public boolean isElementPresent(WebElement elementName, int timeout){
        try{
            WebDriverWait wait = new WebDriverWait(driver, timeout);
            wait.until(ExpectedConditions.visibilityOf(elementName));
            return true;
        }catch(Exception e){
            return false;
        }
    }

    private static boolean checkTimeDifference(long expectedTime, TimeUnit expectedTimeUnit,
                                               long currentMillis) {
        long expectedMillis = TimeUnit.MILLISECONDS.convert(expectedTime, expectedTimeUnit);
        try {
            Assert.assertEquals(true,
                    ((currentMillis - expectedMillis) < ACCEPTABLE_DELTA_MILLS) && (
                            (currentMillis - expectedMillis) >= 0));
        } catch (Error e) {
            String message = String.valueOf(expectedTime) + " "
                    + expectedTimeUnit.toString()
                    + " current duration in millis "
                    + String.valueOf(currentMillis) + " Failed";
            throw new AssertionError(message, e);
        }
        return true;
    }

    @Test
    public void findByElementTest() {
        long startMark = Calendar.getInstance().getTimeInMillis();
        isElementPresent(textView,2);
        /*try {
            textView.isDisplayed();
        }
        catch (Exception e) {
            e.printStackTrace();
        }*/
        long endMark = Calendar.getInstance().getTimeInMillis();
        assertTrue(checkTimeDifference(4,
                TimeUnit.SECONDS, endMark - startMark));
    }
}
```

![image](https://cloud.githubusercontent.com/assets/4927589/23323305/16732ea2-faf9-11e6-9b11-de6761d33d57.png)
