### PR TITLE
Added System Port capability in AndroidMobileCapabilityType

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
@@ -239,4 +239,9 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
     String ANDROID_SCREENSHOT_PATH = "androidScreenshotPath";
 
     String SELENDROID_PORT = "selendroidPort";
+
+    /**
+     * The port number, which being used by UIAutomator2
+     */
+    String SYSTEM_PORT = "systemPort";
 }


### PR DESCRIPTION
## Change list

When automation to be run with UIAutomator2 capability for android, often instrumentation crash.
To mitigate we need to provide "systemPort" capability as a part of desired capability. 
This minor change and just tokenise "systenPort" into AndroidMobileCapability.

## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
As per @sravanmedarapu suggestion, In order to run Appium test with UIAutomator2 capability; it requires systemPort capability to be provided to keep parallel sessions alive. For further detail please find below link,
https://github.com/appium/appium/issues/7745#issuecomment-275417210

This changes is just tokenise "systemPort" capability into AndroidMobileCapability and its a very minor change to java-client.

