### PR TITLE
Update runAppInBackground method implementation for XCUITest

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -37,7 +37,7 @@ public class MobileCommand {
     protected static final String SET_VALUE;
     protected static final String PULL_FILE;
     protected static final String PULL_FOLDER;
-    protected static final String RUN_APP_IN_BACKGROUND;
+    public static final String RUN_APP_IN_BACKGROUND;
     protected static final String PERFORM_TOUCH_ACTION;
     protected static final String PERFORM_MULTI_TOUCH;
     protected static final String IS_APP_INSTALLED;

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client.ios;
 
+import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
 import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import io.appium.java_client.AppiumDriver;
@@ -162,6 +163,24 @@ public class IOSDriver<T extends WebElement>
         int xOffset = endx - startx;
         int yOffset = endy - starty;
         new TouchAction(this).press(startx, starty).waitAction(duration).moveTo(xOffset, yOffset).release().perform();
+    }
+
+    /**
+     * Runs the current app as a background app for the number of seconds
+     * or minimizes the app
+     *
+     * @param seconds if seconds &gt;= 0: Number of seconds to run App in background.
+     *                This method call will block main thread and restore the application under
+     *                test after the timeout expires.
+     *                if seconds &lt; 0: any negative number of seconds will put the application
+     *                under test into background and return immediately, so iOS dashboard
+     *                will remain on-screen (this, actually, simulates click on Home button)
+     */
+    @Override public void runAppInBackground(int seconds) {
+        // timeout parameter is expected to be in milliseconds
+        // float values are allowed
+        execute(RUN_APP_IN_BACKGROUND,
+                prepareArguments("seconds", prepareArguments("timeout", seconds * 1000)));
     }
 
     @Override public TargetLocator switchTo() {

--- a/src/test/java/io/appium/java_client/ios/XCUIAutomationTest.java
+++ b/src/test/java/io/appium/java_client/ios/XCUIAutomationTest.java
@@ -16,12 +16,17 @@
 
 package io.appium.java_client.ios;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.After;
 import org.junit.Test;
 import org.openqa.selenium.DeviceRotation;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 public class XCUIAutomationTest extends AppXCUITTest {
 
@@ -49,6 +54,18 @@ public class XCUIAutomationTest extends AppXCUITTest {
         } catch (Exception e) {
             throw e;
         }
+    }
+
+    @Test public void testPutIntoBackgroundAndRestore() {
+        final long msStarted = System.currentTimeMillis();
+        driver.runAppInBackground(4);
+        assertThat(System.currentTimeMillis() - msStarted, greaterThan(3000L));
+    }
+
+    @Test public void testPutIntoBackgroundWithoutRestore() {
+        assertThat(driver.findElementsById("IntegerA"), is(not(empty())));
+        driver.runAppInBackground(-1);
+        assertThat(driver.findElementsById("IntegerA"), is(empty()));
     }
 
     @Test public void doubleTapTest() {


### PR DESCRIPTION
## Change list

See details.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

This change is based on https://github.com/appium/appium-xcuitest-driver/pull/381, which makes possible to minimize the application under test and then return to iOS springboard (emulates clicking Home button). The change is breaking since the format of input parameters has been changed for **background** API call (the old format is still supported, but shows deprecation warning).