### PR TITLE
Use java.time.Duration to represent time deltas instead of elementary types

### DIFF
--- a/src/main/java/io/appium/java_client/InteractsWithApps.java
+++ b/src/main/java/io/appium/java_client/InteractsWithApps.java
@@ -27,6 +27,7 @@ import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 
 public interface InteractsWithApps extends ExecutesMethod {
@@ -68,11 +69,24 @@ public interface InteractsWithApps extends ExecutesMethod {
      * Runs the current app as a background app for the number of seconds
      * requested. This is a synchronous method, it returns after the back has
      * been returned to the foreground.
+     * This method is deprecated. Please use {@link #runAppInBackground(Duration)} instead.
      *
      * @param seconds Number of seconds to run App in background.
      */
+    @Deprecated
     default void runAppInBackground(int seconds) {
-        execute(RUN_APP_IN_BACKGROUND, ImmutableMap.of("seconds", seconds));
+        runAppInBackground(Duration.ofSeconds(seconds));
+    }
+
+    /**
+     * Runs the current app as a background app for the time
+     * requested. This is a synchronous method, it returns after the back has
+     * been returned to the foreground.
+     *
+     * @param duration The time to run App in background. Minimum time resolution is one second
+     */
+    default void runAppInBackground(Duration duration) {
+        execute(RUN_APP_IN_BACKGROUND, ImmutableMap.of("seconds", duration.getSeconds()));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 
+import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -331,13 +332,27 @@ public class MobileCommand {
     /**
      * This method forms a {@link java.util.Map} of parameters for the
      * device locking.
+     * The method is deprecated. Please use {@link #lockDeviceCommand(Duration)} instead.
      *
      * @param seconds seconds number of seconds to lock the screen for
      * @return  a key-value pair. The key is the command name. The value is a
      * {@link java.util.Map} command arguments.
      */
-    public static Map.Entry<String, Map<String, ?>>  lockDeviceCommand(int seconds) {
+    @Deprecated
+    public static Map.Entry<String, Map<String, ?>> lockDeviceCommand(int seconds) {
+        return lockDeviceCommand(Duration.ofSeconds(seconds));
+    }
+
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * device locking.
+     *
+     * @param duration for how long to lock the screen for. Minimum time resolution is one second
+     * @return  a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
+    public static Map.Entry<String, Map<String, ?>> lockDeviceCommand(Duration duration) {
         return new AbstractMap.SimpleEntry<>(
-                LOCK, prepareArguments("seconds", seconds));
+                LOCK, prepareArguments("seconds", duration.getSeconds()));
     }
 }

--- a/src/main/java/io/appium/java_client/SwipeElementDirection.java
+++ b/src/main/java/io/appium/java_client/SwipeElementDirection.java
@@ -191,6 +191,7 @@ public enum SwipeElementDirection {
 
     /**
      * Creates the swiping action. It is supposed to be performed inside the given element.
+     * The method is deprecated and has no effect.
      *
      * @param driver an instance that extends {@link AppiumDriver}
      * @param element the element that is going to be swiped
@@ -199,6 +200,7 @@ public enum SwipeElementDirection {
      * @param duration in milliseconds
      * @throws IllegalCoordinatesException when starting/ending coordinates are outside of the given element
      */
+    @Deprecated
     public void swipe(AppiumDriver<?> driver, MobileElement element, int offset1, int offset2,
         int duration) throws IllegalCoordinatesException {
         Point p = element.getCenter();

--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.HasIdentity;
 
+import java.time.Duration;
+
 /**
  * Used for Webdriver 3 touch actions
  * See the Webriver 3 spec
@@ -197,13 +199,25 @@ public class TouchAction implements PerformsActions<TouchAction> {
 
     /**
      * Waits for specified amount of time to pass before continue to next touch action.
+     * The method is deprecated. Please use {@link #waitAction(Duration)} instead.
      *
      * @param ms time in milliseconds to wait.
      * @return this TouchAction, for chaining.
      */
+    @Deprecated
     public TouchAction waitAction(int ms) {
+        return waitAction(Duration.ofMillis(ms));
+    }
+
+    /**
+     * Waits for specified amount of time to pass before continue to next touch action.
+     *
+     * @param duration of the wait action. Minimum time reolution unit is one millisecond.
+     * @return this TouchAction, for chaining.
+     */
+    public TouchAction waitAction(Duration duration) {
         ActionParameter action = new ActionParameter("wait");
-        action.addParameter("ms", ms);
+        action.addParameter("ms", duration.toMillis());
         parameterBuilder.add(action);
         return this;
     }
@@ -222,14 +236,27 @@ public class TouchAction implements PerformsActions<TouchAction> {
 
     /**
      * Press and hold the at the center of an element until the contextmenu event has fired.
+     * This method is deprecated. Please use {@link #longPress(WebElement, Duration)} instead.
      *
      * @param el       element to long-press.
      * @param duration of the long-press, in milliseconds.
      * @return this TouchAction, for chaining.
      */
+    @Deprecated
     public TouchAction longPress(WebElement el, int duration) {
+        return longPress(el, Duration.ofMillis(duration));
+    }
+
+    /**
+     * Press and hold the at the center of an element until the contextmenu event has fired.
+     *
+     * @param el       element to long-press.
+     * @param duration of the long-press. Minimum time resolution unit is one millisecond.
+     * @return this TouchAction, for chaining.
+     */
+    public TouchAction longPress(WebElement el, Duration duration) {
         ActionParameter action = new ActionParameter("longPress", (HasIdentity) el);
-        action.addParameter("duration", duration);
+        action.addParameter("duration", duration.toMillis());
         parameterBuilder.add(action);
         return this;
     }
@@ -253,20 +280,36 @@ public class TouchAction implements PerformsActions<TouchAction> {
     /**
      * Press and hold the at an absolute position on the screen until the
      * contextmenu event has fired.
+     * The method is deprecated. Please use {@link #longPress(int, int, Duration)} instead.
      *
      * @param x        x coordinate.
      * @param y        y coordinate.
      * @param duration of the long-press, in milliseconds.
      * @return this TouchAction, for chaining.
      */
+    @Deprecated
     public TouchAction longPress(int x, int y, int duration) {
+        return longPress(x, y, Duration.ofMillis(duration));
+    }
+
+    /**
+     * Press and hold the at an absolute position on the screen until the
+     * contextmenu event has fired.
+     *
+     * @param x        x coordinate.
+     * @param y        y coordinate.
+     * @param duration of the long-press. Minimum time resolution unit is one millisecond.
+     * @return this TouchAction, for chaining.
+     */
+    public TouchAction longPress(int x, int y, Duration duration) {
         ActionParameter action = new ActionParameter("longPress");
         action.addParameter("x", x);
         action.addParameter("y", y);
-        action.addParameter("duration", duration);
+        action.addParameter("duration", duration.toMillis());
         parameterBuilder.add(action);
         return this;
     }
+
 
     /**
      * Press and hold the at an elements upper-left corner, offset by the given amount,
@@ -288,6 +331,7 @@ public class TouchAction implements PerformsActions<TouchAction> {
     /**
      * Press and hold the at an elements upper-left corner, offset by the
      * given amount, until the contextmenu event has fired.
+     * The method is deprecated. Please use {@link #longPress(WebElement, int, int, Duration)} instead.
      *
      * @param el       element to long-press.
      * @param x        x offset.
@@ -295,11 +339,26 @@ public class TouchAction implements PerformsActions<TouchAction> {
      * @param duration of the long-press, in milliseconds.
      * @return this TouchAction, for chaining.
      */
+    @Deprecated
     public TouchAction longPress(WebElement el, int x, int y, int duration) {
+        return longPress(el, x, y, Duration.ofMillis(duration));
+    }
+
+    /**
+     * Press and hold the at an elements upper-left corner, offset by the
+     * given amount, until the contextmenu event has fired.
+     *
+     * @param el       element to long-press.
+     * @param x        x offset.
+     * @param y        y offset.
+     * @param duration of the long-press. Minimum time resolution unit is one millisecond.
+     * @return this TouchAction, for chaining.
+     */
+    public TouchAction longPress(WebElement el, int x, int y, Duration duration) {
         ActionParameter action = new ActionParameter("longPress", (HasIdentity) el);
         action.addParameter("x", x);
         action.addParameter("y", y);
-        action.addParameter("duration", duration);
+        action.addParameter("duration", duration.toMillis());
         parameterBuilder.add(action);
         return this;
     }

--- a/src/main/java/io/appium/java_client/android/HasSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasSettings.java
@@ -26,6 +26,7 @@ import io.appium.java_client.ExecutesMethod;
 
 import org.openqa.selenium.remote.Response;
 
+import java.time.Duration;
 import java.util.Map;
 
 interface HasSettings extends ExecutesMethod {
@@ -53,7 +54,7 @@ interface HasSettings extends ExecutesMethod {
         Map.Entry<String, Map<String, ?>> keyValuePair = getSettingsCommand();
         Response response = execute(keyValuePair.getKey(), keyValuePair.getValue());
 
-        return  ImmutableMap.<String, Object>builder()
+        return ImmutableMap.<String, Object>builder()
                 .putAll(Map.class.cast(response.getValue())).build();
     }
 
@@ -72,46 +73,106 @@ interface HasSettings extends ExecutesMethod {
 
     /**
      * invoke {@code setWaitForIdleTimeout} in {@code com.android.uiautomator.core.Configurator}
+     * This method is deprecated. Please use {@link #configuratorSetWaitForIdleTimeout(Duration)} instead.
      *
      * @param timeout in milliseconds. A negative value would reset to its default value
      */
+    @Deprecated
     default void configuratorSetWaitForIdleTimeout(int timeout) {
-        setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, timeout);
+        configuratorSetWaitForIdleTimeout(Duration.ofMillis(timeout));
+    }
+
+    /**
+     * invoke {@code setWaitForIdleTimeout} in {@code com.android.uiautomator.core.Configurator}
+     *
+     * @param timeout A negative value would reset to its default value. Minimum time unit
+     *                resolution is one millisecond
+     */
+    default void configuratorSetWaitForIdleTimeout(Duration timeout) {
+        setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, timeout.toMillis());
+    }
+
+    /**
+     * invoke {@code setWaitForSelectorTimeout} in {@code com.android.uiautomator.core.Configurator}
+     * This method is deprecated. Please use {@link #configuratorSetWaitForSelectorTimeout(Duration)} instead.
+     *
+     * @param timeout in milliseconds. A negative value would reset to its default value
+     */
+    @Deprecated
+    default void configuratorSetWaitForSelectorTimeout(int timeout) {
+        configuratorSetWaitForSelectorTimeout(Duration.ofMillis(timeout));
     }
 
     /**
      * invoke {@code setWaitForSelectorTimeout} in {@code com.android.uiautomator.core.Configurator}
      *
+     * @param timeout A negative value would reset to its default value. Minimum time unit
+     *                resolution is one millisecond
+     */
+    default void configuratorSetWaitForSelectorTimeout(Duration timeout) {
+        setSetting(Setting.WAIT_FOR_SELECTOR_TIMEOUT, timeout.toMillis());
+    }
+
+    /**
+     * invoke {@code setScrollAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
+     * This method is deprecated. Please use {@link #configuratorSetScrollAcknowledgmentTimeout(Duration)} instead.
+     *
      * @param timeout in milliseconds. A negative value would reset to its default value
      */
-    default void configuratorSetWaitForSelectorTimeout(int timeout) {
-        setSetting(Setting.WAIT_FOR_SELECTOR_TIMEOUT, timeout);
+    @Deprecated
+    default void configuratorSetScrollAcknowledgmentTimeout(int timeout) {
+        configuratorSetScrollAcknowledgmentTimeout(Duration.ofMillis(timeout));
     }
 
     /**
      * invoke {@code setScrollAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
      *
-     * @param timeout in milliseconds. A negative value would reset to its default value
+     * @param timeout A negative value would reset to its default value. Minimum time unit
+     *                resolution is one millisecond
      */
-    default void configuratorSetScrollAcknowledgmentTimeout(int timeout) {
-        setSetting(Setting.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT, timeout);
+    default void configuratorSetScrollAcknowledgmentTimeout(Duration timeout) {
+        setSetting(Setting.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
+    }
+
+    /**
+     * invoke {@code configuratorSetKeyInjectionDelay} in {@code com.android.uiautomator.core.Configurator}
+     * This method is deprecated. Please use {@link #configuratorSetKeyInjectionDelay(Duration)} instead.
+     *
+     * @param delay in milliseconds. A negative value would reset to its default value
+     */
+    @Deprecated
+    default void configuratorSetKeyInjectionDelay(int delay) {
+        configuratorSetKeyInjectionDelay(Duration.ofMillis(delay));
     }
 
     /**
      * invoke {@code configuratorSetKeyInjectionDelay} in {@code com.android.uiautomator.core.Configurator}
      *
-     * @param delay in milliseconds. A negative value would reset to its default value
+     * @param delay A negative value would reset to its default value. Minimum time unit
+     *              resolution is one millisecond
      */
-    default void configuratorSetKeyInjectionDelay(int delay) {
-        setSetting(Setting.KEY_INJECTION_DELAY, delay);
+    default void configuratorSetKeyInjectionDelay(Duration delay) {
+        setSetting(Setting.KEY_INJECTION_DELAY, delay.toMillis());
+    }
+
+    /**
+     * invoke {@code setActionAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
+     * This method is deprecated. Please use {@link #configuratorSetActionAcknowledgmentTimeout(Duration)} instead.
+     *
+     * @param timeout in milliseconds. A negative value would reset to its default value
+     */
+    @Deprecated
+    default void configuratorSetActionAcknowledgmentTimeout(int timeout) {
+        configuratorSetActionAcknowledgmentTimeout(Duration.ofMillis(timeout));
     }
 
     /**
      * invoke {@code setActionAcknowledgmentTimeout} in {@code com.android.uiautomator.core.Configurator}
      *
-     * @param timeout in milliseconds. A negative value would reset to its default value
+     * @param timeout A negative value would reset to its default value. Minimum time unit
+     *                resolution is one millisecond
      */
-    default void configuratorSetActionAcknowledgmentTimeout(int timeout) {
-        setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout);
+    default void configuratorSetActionAcknowledgmentTimeout(Duration timeout) {
+        setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
     }
 }

--- a/src/main/java/io/appium/java_client/ios/LocksIOSDevice.java
+++ b/src/main/java/io/appium/java_client/ios/LocksIOSDevice.java
@@ -21,14 +21,28 @@ import static io.appium.java_client.MobileCommand.lockDeviceCommand;
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.ExecutesMethod;
 
+import java.time.Duration;
+
 public interface LocksIOSDevice extends ExecutesMethod {
     /**
      * Lock the device (bring it to the lock screen) for a given number of
      * seconds.
+     * Thsi method is deprecated. Please use {@link #lockDevice(Duration)} instead.
      *
      * @param seconds number of seconds to lock the screen for
      */
+    @Deprecated
     default void lockDevice(int seconds) {
-        CommandExecutionHelper.execute(this, lockDeviceCommand(seconds));
+        lockDevice(Duration.ofSeconds(seconds));
+    }
+
+    /**
+     * Lock the device (bring it to the lock screen) for a given number of
+     * seconds.
+     *
+     * @param duration for how long to lock the screen. Minimum time resolution is one second
+     */
+    default void lockDevice(Duration duration) {
+        CommandExecutionHelper.execute(this, lockDeviceCommand(duration));
     }
 }

--- a/src/test/java/io/appium/java_client/android/AndroidAbilityToUseSupplierTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidAbilityToUseSupplierTest.java
@@ -8,6 +8,7 @@ import io.appium.java_client.functions.ActionSupplier;
 import org.junit.Test;
 import org.openqa.selenium.Point;
 
+import java.time.Duration;
 import java.util.List;
 
 public class AndroidAbilityToUseSupplierTest extends BaseAndroidTest {
@@ -22,12 +23,13 @@ public class AndroidAbilityToUseSupplierTest extends BaseAndroidTest {
         Point center = gallery.getCenter();
 
         return new TouchAction(driver).press(images.get(2), -10, center.y - location.y)
-                .waitAction(2000).moveTo(gallery, 10, center.y - location.y).release();
+                .waitAction(Duration.ofSeconds(2)).moveTo(gallery, 10, center.y - location.y).release();
     };
 
     private final ActionSupplier<TouchAction> verticalSwiping = () ->
         new TouchAction(driver).press(driver.findElementByAccessibilityId("Gallery"))
-                .waitAction(2000).moveTo(driver.findElementByAccessibilityId("Auto Complete")).release();
+                .waitAction(Duration.ofSeconds(2)).moveTo(driver.findElementByAccessibilityId("Auto Complete"))
+                .release();
 
     @Test public void horizontalSwipingWithSupplier() throws Exception {
         Activity activity = new Activity("io.appium.android.apis", ".view.Gallery1");

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.html5.Location;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -109,7 +110,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     @Test public void runAppInBackgroundTest() {
         long time = System.currentTimeMillis();
-        driver.runAppInBackground(4);
+        driver.runAppInBackground(Duration.ofSeconds(4));
         long timeAfter = System.currentTimeMillis();
         assert (timeAfter - time > 3000);
     }

--- a/src/test/java/io/appium/java_client/android/AndroidTouchTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidTouchTest.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.List;
 
 public class AndroidTouchTest extends BaseAndroidTest {
@@ -46,7 +47,7 @@ public class AndroidTouchTest extends BaseAndroidTest {
         assertEquals("Drag text not empty", "", dragText.getText());
 
         TouchAction dragNDrop =
-                new TouchAction(driver).longPress(dragDot1, 2000).moveTo(dragDot3).release();
+                new TouchAction(driver).longPress(dragDot1, Duration.ofSeconds(2)).moveTo(dragDot3).release();
         dragNDrop.perform();
         assertNotEquals("Drag text empty", "", dragText.getText());
     }
@@ -82,7 +83,8 @@ public class AndroidTouchTest extends BaseAndroidTest {
         Point center2 = dragDot3.getCenter();
 
         TouchAction dragNDrop =
-                new TouchAction(driver).longPress(center1.x, center1.y, 2000).moveTo(center2.x, center2.y).release();
+                new TouchAction(driver).longPress(center1.x, center1.y, Duration.ofSeconds(2))
+                        .moveTo(center2.x, center2.y).release();
         dragNDrop.perform();
         assertNotEquals("Drag text empty", "", dragText.getText());
     }
@@ -92,7 +94,8 @@ public class AndroidTouchTest extends BaseAndroidTest {
         driver.startActivity(activity);
         Point point =
                 driver.findElementById("io.appium.android.apis:id/button_toggle").getLocation();
-        new TouchAction(driver).press(point.x + 20, point.y + 30).waitAction(1000).release().perform();
+        new TouchAction(driver).press(point.x + 20, point.y + 30).waitAction(Duration.ofSeconds(1))
+                .release().perform();
         assertEquals("ON" ,driver
                 .findElementById("io.appium.android.apis:id/button_toggle").getText());
     }
@@ -101,7 +104,7 @@ public class AndroidTouchTest extends BaseAndroidTest {
         Activity activity = new Activity("io.appium.android.apis", ".view.Buttons1");
         driver.startActivity(activity);
         new TouchAction(driver).press(driver.findElementById("io.appium.android.apis:id/button_toggle"))
-                .waitAction(1000).release().perform();
+                .waitAction(Duration.ofSeconds(1)).release().perform();
         assertEquals("ON" ,driver
                 .findElementById("io.appium.android.apis:id/button_toggle").getText());
     }
@@ -113,7 +116,7 @@ public class AndroidTouchTest extends BaseAndroidTest {
                 driver.findElementById("io.appium.android.apis:id/chronometer");
 
         TouchAction startStop = new TouchAction(driver)
-                .tap(driver.findElementById("io.appium.android.apis:id/start")).waitAction(2000)
+                .tap(driver.findElementById("io.appium.android.apis:id/start")).waitAction(Duration.ofSeconds(2))
                 .tap(driver.findElementById("io.appium.android.apis:id/stop"));
 
         startStop.perform();
@@ -155,7 +158,7 @@ public class AndroidTouchTest extends BaseAndroidTest {
         Point center = gallery.getCenter();
 
         TouchAction swipe = new TouchAction(driver).press(images.get(2), -10, center.y - location.y)
-                .waitAction(2000).moveTo(gallery, 10, center.y - location.y).release();
+                .waitAction(Duration.ofSeconds(2)).moveTo(gallery, 10, center.y - location.y).release();
         swipe.perform();
         assertNotEquals(originalImageCount, gallery
                 .findElementsByClassName("android.widget.ImageView").size());
@@ -165,7 +168,8 @@ public class AndroidTouchTest extends BaseAndroidTest {
         Activity activity = new Activity("io.appium.android.apis", ".view.Buttons1");
         driver.startActivity(activity);
         TouchAction press = new TouchAction(driver);
-        press.press(driver.findElementById("io.appium.android.apis:id/button_toggle")).waitAction(1000).release();
+        press.press(driver.findElementById("io.appium.android.apis:id/button_toggle")).waitAction(Duration.ofSeconds(1))
+                .release();
         new MultiTouchAction(driver).add(press)
                 .perform();
         assertEquals("ON" ,driver

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.time.Duration;
+
 public class SettingTest extends BaseAndroidTest {
 
     @Test public void ignoreUnimportantViewsTest() {
@@ -17,19 +19,19 @@ public class SettingTest extends BaseAndroidTest {
     }
 
     @Test public void configuratorTest() {
-        driver.configuratorSetActionAcknowledgmentTimeout(500);
+        driver.configuratorSetActionAcknowledgmentTimeout(Duration.ofMillis(500));
         assertJSONElementContains(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, 500);
 
-        driver.configuratorSetKeyInjectionDelay(400);
+        driver.configuratorSetKeyInjectionDelay(Duration.ofMillis(400));
         assertJSONElementContains(Setting.KEY_INJECTION_DELAY, 400);
 
-        driver.configuratorSetScrollAcknowledgmentTimeout(300);
+        driver.configuratorSetScrollAcknowledgmentTimeout(Duration.ofMillis(300));
         assertJSONElementContains(Setting.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT, 300);
 
-        driver.configuratorSetWaitForIdleTimeout(600);
+        driver.configuratorSetWaitForIdleTimeout(Duration.ofMillis(600));
         assertJSONElementContains(Setting.WAIT_FOR_IDLE_TIMEOUT, 600);
 
-        driver.configuratorSetWaitForSelectorTimeout(1000);
+        driver.configuratorSetWaitForSelectorTimeout(Duration.ofSeconds(1));
         assertJSONElementContains(Setting.WAIT_FOR_SELECTOR_TIMEOUT, 1000);
     }
 

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.html5.Location;
 
+import java.time.Duration;
 import java.util.function.Supplier;
 
 public class IOSDriverTest extends AppIOSTest {
@@ -62,7 +63,7 @@ public class IOSDriverTest extends AppIOSTest {
 
     @Test public void lockTest() {
         Supplier<Boolean> lock = () -> {
-            driver.lockDevice(20);
+            driver.lockDevice(Duration.ofSeconds(20));
             return true;
         };
         assertTrue(lock.get());

--- a/src/test/java/io/appium/java_client/ios/IOSTouchTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSTouchTest.java
@@ -14,6 +14,8 @@ import org.junit.runners.MethodSorters;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class IOSTouchTest extends AppIOSTest {
 
@@ -36,7 +38,7 @@ public class IOSTouchTest extends AppIOSTest {
         Dimension size = slider.getSize();
 
         TouchAction swipe = new TouchAction(driver).press(slider, size.width / 2 + 2, size.height / 2)
-                .waitAction(2000).moveTo(slider, 1, size.height / 2).release();
+                .waitAction(Duration.ofSeconds(2)).moveTo(slider, 1, size.height / 2).release();
         swipe.perform();
         assertEquals("0%", slider.getAttribute("value"));
     }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/android/simple/AndroidMovie.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/android/simple/AndroidMovie.java
@@ -7,6 +7,8 @@ import io.appium.java_client.pagefactory.AndroidFindBy;
 import io.appium.java_client.pagefactory_tests.widgets.Movie;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
+
 public class AndroidMovie extends Movie {
 
     @AndroidFindBy(id = "com.codepath.example.rottentomatoes:id/tvTitle") private AndroidElement
@@ -36,6 +38,6 @@ public class AndroidMovie extends Movie {
 
     @Override public void goToReview() {
         TouchAction tap = new TouchAction(PerformsTouchActions.class.cast(getWrappedDriver()));
-        tap.press(getWrappedElement()).waitAction(1500).release().perform();
+        tap.press(getWrappedElement()).waitAction(Duration.ofMillis(1500)).release().perform();
     }
 }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widgets/ios/simple/IOSMovie.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widgets/ios/simple/IOSMovie.java
@@ -7,6 +7,7 @@ import io.appium.java_client.pagefactory.iOSFindBy;
 import io.appium.java_client.pagefactory_tests.widgets.Movie;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.List;
 
 public class IOSMovie extends Movie {
@@ -31,6 +32,6 @@ public class IOSMovie extends Movie {
 
     @Override public void goToReview() {
         TouchAction tap = new TouchAction(PerformsTouchActions.class.cast(getWrappedDriver()));
-        tap.press(getWrappedElement()).waitAction(1500).release().perform();
+        tap.press(getWrappedElement()).waitAction(Duration.ofMillis(1500)).release().perform();
     }
 }


### PR DESCRIPTION
## Change list

Replace timeout/duration arguments where possible with _java.time.Duration_ type, which has been introduced in Java 8.. This gives us better control over time conversion and helps to avoid time unit conversion issues in general.

All the existing methods, that have replacements, were marked as deprecated.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



