### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/archive/docs/How-to-propose-a-PR.md
+++ b/archive/docs/How-to-propose-a-PR.md
@@ -1,4 +1,4 @@
-#A good pull-request should contain
+# A good pull-request should contain
 
 ### Change list
 
@@ -19,6 +19,6 @@ There should be provided more details about changes if it is necessary. If there
 can provide code samples which show the way they work and possible use cases. Also you can create [gists](https://gist.github.com) 
 with pasted java code samples or put them at a PR description using markdown. About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
 
-#Pull-request template
+# Pull-request template
 
 There is [PULL_REQUEST_TEMPLATE.md)](https://github.com/appium/java-client/blob/master/PULL_REQUEST_TEMPLATE.md) which should help you to make a good pull request.

--- a/archive/docs/How-to-report-an-issue.md
+++ b/archive/docs/How-to-report-an-issue.md
@@ -1,10 +1,10 @@
-#Be sure that it is not a server-side problem if you are facing something that looks like a bug
+# Be sure that it is not a server-side problem if you are facing something that looks like a bug
 
 The Appium Java client is the thin client which just sends requests and receives responces generally. 
 Be sure that this bug is not reported [here](https://github.com/appium/appium/issues) and/or there is
 no progress on this issue.
 
-#The good issue report should contain
+# The good issue report should contain
 
 ### Description
 
@@ -42,9 +42,9 @@ There should be created a [gist](https://gist.github.com) which is a paste of yo
 If you are reporting a bug, _always_ include Appium logs as linked gists! It helps to define the problem correctly and clearly. 
 
 
-#Issue template
+# Issue template
 There is [ISSUE_TEMPLATE.md](https://github.com/appium/java-client/blob/master/ISSUE_TEMPLATE.md) which should help you to make a good issue report.
 
-#... And don't say that you weren't warned. 
+# ... And don't say that you weren't warned. 
 
 If a report is not readable and/or there is no response from a reporter and some important details are needed then the issue will be closed after some time.

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -1,6 +1,6 @@
 Appium java client has some features based on [Java 8 Functional interfaces](https://www.oreilly.com/learning/java-8-functional-interfaces).
 
-#Conditions
+# Conditions
 
 ```java
 io.appium.java_client.functions.AppiumFunction
@@ -58,7 +58,7 @@ private final AppiumFunction<Pattern, WebDriver> contextFunction = input -> {
 };
 ```
 
-##using one function as pre-condition
+## using one function as pre-condition
 
 ```java
 @Test public void tezt() {
@@ -70,7 +70,7 @@ private final AppiumFunction<Pattern, WebDriver> contextFunction = input -> {
 }
 ```
 
-##using one function as post-condition
+## using one function as post-condition
 
 ```java
 import org.openqa.selenium.support.ui.FluentWait;
@@ -85,7 +85,7 @@ import org.openqa.selenium.support.ui.Wait;
 }
 ```
 
-#Touch action supplier
+# Touch action supplier
 
 [About touch actions](https://github.com/appium/java-client/blob/master/docs/Touch-actions.md)
 
@@ -96,7 +96,7 @@ create gesture libraries/utils using suppliers. Appium java client provides this
 io.appium.java_client.functions.ActionSupplier
 ``` 
 
-##Samples
+## Samples
 
 ```java
 private final ActionSupplier<TouchAction> horizontalSwipe = () -> {

--- a/docs/How-to-propose-a-PR.md
+++ b/docs/How-to-propose-a-PR.md
@@ -1,4 +1,4 @@
-#A good pull-request should contain
+# A good pull-request should contain
 
 ### Change list
 
@@ -19,6 +19,6 @@ There should be provided more details about changes if it is necessary. If there
 can provide code samples which show the way they work and possible use cases. Also you can create [gists](https://gist.github.com) 
 with pasted java code samples or put them at a PR description using markdown. About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
 
-#Pull-request template
+# Pull-request template
 
 There is [PULL_REQUEST_TEMPLATE.md)](https://github.com/appium/java-client/blob/master/PULL_REQUEST_TEMPLATE.md) which should help you to make a good pull request.

--- a/docs/How-to-report-an-issue.md
+++ b/docs/How-to-report-an-issue.md
@@ -1,10 +1,10 @@
-#Be sure that it is not a server-side problem if you are facing something that looks like a bug
+# Be sure that it is not a server-side problem if you are facing something that looks like a bug
 
 The Appium Java client is the thin client which just sends requests and receives responces generally. 
 Be sure that this bug is not reported [here](https://github.com/appium/appium/issues) and/or there is
 no progress on this issue.
 
-#The good issue report should contain
+# The good issue report should contain
 
 ### Description
 
@@ -42,9 +42,9 @@ There should be created a [gist](https://gist.github.com) which is a paste of yo
 If you are reporting a bug, _always_ include Appium logs as linked gists! It helps to define the problem correctly and clearly. 
 
 
-#Issue template
+# Issue template
 There is [ISSUE_TEMPLATE.md](https://github.com/appium/java-client/blob/master/ISSUE_TEMPLATE.md) which should help you to make a good issue report.
 
-#... And don't say that you weren't warned. 
+# ... And don't say that you weren't warned. 
 
 If a report is not readable and/or there is no response from a reporter and some important details are needed then the issue will be closed after some time.

--- a/docs/Installing-the-project.md
+++ b/docs/Installing-the-project.md
@@ -1,10 +1,10 @@
-#Requirements
+# Requirements
 
 Firstly you should install appium server. [Appium getting started](http://appium.io/getting-started.html). The version 1.6.3 or greater is recommended.
 
 Since version 5.x there many features based on Java 8. So we recommend to install JDK SE 8 and provide that source compatibility.
 
-#Maven
+# Maven
 
 Add the following to pom.xml:
 
@@ -40,7 +40,7 @@ If it is necessary to change the version of Selenium then you can configure pom.
 </dependency>
 ```
 
-#Gradle
+# Gradle
 
 Add the following to build.gradle:
 

--- a/docs/Tech-stack.md
+++ b/docs/Tech-stack.md
@@ -12,7 +12,7 @@ Also tech stack includes [Spring framework](https://projects.spring.io/spring-fr
 It is the client framework. It is the thin client which just sends requests to Appium server and receives responses. Also it has some
 high-level features which were designed to simplify user's work.
 
-#It supports: 
+# It supports: 
 
 ![](https://cloud.githubusercontent.com/assets/4927589/21467612/4b6b3f70-ca05-11e6-9a31-d3820e98dac6.png)  
 ![](https://cloud.githubusercontent.com/assets/4927589/21467614/73883828-ca05-11e6-846d-3ed8847a7e08.jpg)

--- a/docs/The-starting-of-an-Android-app.md
+++ b/docs/The-starting-of-an-Android-app.md
@@ -65,7 +65,7 @@ capabilities);
 ```
 
 
-##If it needs to start browser then
+## If it needs to start browser then
 
 This capability should be used
 
@@ -75,7 +75,7 @@ capabilities.setCapability(MobileCapabilityType.BROWSER_NAME, MobileBrowserType.
 //is your choice
 ```
 
-##There are three automation types
+## There are three automation types
 
 ```java
 capabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.SELENDROID);

--- a/docs/The-starting-of-an-iOS-app.md
+++ b/docs/The-starting-of-an-iOS-app.md
@@ -68,13 +68,13 @@ new URL("http://target_ip:used_port/wd/hub"), //if it needs to use locally start
 capabilities);
 ```
 
-##If it needs to start browser then 
+## If it needs to start browser then 
 
 ```java
 capabilities.setCapability(MobileCapabilityType.BROWSER_NAME, MobileBrowserType.SAFARI);
 ```
 
-##There are two automation types
+## There are two automation types
 
 Default iOS Automation (v < iOS 10.x) does not require any specific capability. However you can 
 ```java

--- a/docs/Touch-actions.md
+++ b/docs/Touch-actions.md
@@ -1,6 +1,6 @@
 Appium server side provides abilities to emulate touch actions. It is possible construct single, complex and multiple touch actions.
  
-#How to use a single touch action
+# How to use a single touch action
 
 ```java
 import io.appium.java_client.TouchAction;
@@ -12,7 +12,7 @@ new TouchAction(driver)
                 .findElementById("io.appium.android.apis:id/start")).perform();
 ```
 
-#How to construct complex actions
+# How to construct complex actions
 
 ```java
 import io.appium.java_client.TouchAction;
@@ -24,7 +24,7 @@ TouchAction swipe = new TouchAction(driver).press(images.get(2), -10, center.y -
 swipe.perform();
 ```
 
-#How to construct multiple touch action. 
+# How to construct multiple touch action. 
 
 ```java
 import io.appium.java_client.TouchAction;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
