### PR TITLE
added get_current_package session

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -76,6 +76,7 @@ public class MobileCommand {
     protected static final String REPLACE_VALUE;
     protected static final String GET_SETTINGS;
     protected static final String SET_SETTINGS;
+    protected static final String GET_CURRENT_PACKAGE;
 
     public static final  Map<String, AppiumCommandInfo> commandRepository;
 
@@ -122,6 +123,7 @@ public class MobileCommand {
         REPLACE_VALUE = "replaceValue";
         GET_SETTINGS = "getSettings";
         SET_SETTINGS = "setSettings";
+        GET_CURRENT_PACKAGE = "getCurrentPackage";
 
         commandRepository = new HashMap<>();
         commandRepository.put(RESET, postC("/session/:sessionId/appium/app/reset"));
@@ -176,6 +178,7 @@ public class MobileCommand {
                         postC("/session/:sessionId/appium/device/toggle_location_services"));
         commandRepository.put(UNLOCK, postC("/session/:sessionId/appium/device/unlock"));
         commandRepository. put(REPLACE_VALUE, postC("/session/:sessionId/appium/element/:id/replace_value"));
+        commandRepository.put(GET_CURRENT_PACKAGE,getC("/session/:sessionId/appium/device/current_package"));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -16,7 +16,6 @@
 
 package io.appium.java_client.android;
 
-import static io.appium.java_client.android.AndroidMobileCommandHelper.currentPackageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
@@ -182,7 +181,4 @@ public class AndroidDriver<T extends WebElement>
         CommandExecutionHelper.execute(this, toggleLocationServicesCommand());
     }
 
-    public String getCurrentPackage() {
-        return CommandExecutionHelper.execute(this, currentPackageCommand());
-    }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client.android;
 
+import static io.appium.java_client.android.AndroidMobileCommandHelper.currentPackageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
@@ -179,5 +180,9 @@ public class AndroidDriver<T extends WebElement>
 
     public void toggleLocationServices() {
         CommandExecutionHelper.execute(this, toggleLocationServicesCommand());
+    }
+
+    public String getCurrentPackage() {
+        return CommandExecutionHelper.execute(this, currentPackageCommand());
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -48,6 +48,18 @@ public class AndroidMobileCommandHelper extends MobileCommand {
 
     /**
      * This method forms a {@link java.util.Map} of parameters for the
+     * getting of the current package.
+     *
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
+    public static Map.Entry<String, Map<String, ?>> currentPackageCommand() {
+        return new AbstractMap.SimpleEntry<>(
+                GET_CURRENT_PACKAGE, ImmutableMap.<String, Object>of());
+    }
+
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
      * ending of the test coverage.
      *
      * @param intent intent to broadcast.

--- a/src/main/java/io/appium/java_client/android/StartsActivity.java
+++ b/src/main/java/io/appium/java_client/android/StartsActivity.java
@@ -17,6 +17,7 @@
 package io.appium.java_client.android;
 
 import static io.appium.java_client.android.AndroidMobileCommandHelper.currentActivityCommand;
+import static io.appium.java_client.android.AndroidMobileCommandHelper.currentPackageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.startActivityCommand;
 
 import io.appium.java_client.CommandExecutionHelper;
@@ -157,5 +158,14 @@ public interface StartsActivity extends ExecutesMethod {
      */
     default String currentActivity() {
         return CommandExecutionHelper.execute(this, currentActivityCommand());
+    }
+
+    /**
+     * Get the current package being run on the mobile device.
+     *
+     * @return a current package being run on the mobile device.
+     */
+    default String getCurrentPackage() {
+        return CommandExecutionHelper.execute(this, currentPackageCommand());
     }
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -183,4 +183,8 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     }
 
+    @Test public void getCurrentPackage() {
+        assertEquals("io.appium.android.apis",driver.getCurrentPackage());
+    }
+
 }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -183,7 +183,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     }
 
-    @Test public void getCurrentPackage() {
+    @Test public void getCurrentPackageTest() {
         assertEquals("io.appium.android.apis",driver.getCurrentPackage());
     }
 


### PR DESCRIPTION
## Change list

Appium 1.6.6 beta has a new endpoint for getting the currently running package during an Android test.
See appium/appium-base-driver@190a896

Re: appium/appium#8674
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
