### PR TITLE
Clear existing actions/parameters after perform is invoked

### DIFF
--- a/src/main/java/io/appium/java_client/MultiTouchAction.java
+++ b/src/main/java/io/appium/java_client/MultiTouchAction.java
@@ -85,4 +85,14 @@ public class MultiTouchAction implements PerformsActions<MultiTouchAction> {
         });
         return ImmutableMap.of("actions", listOfActionChains.build());
     }
+
+    /**
+     * Clears all the existing touch actions and resets the instance to the initial state.
+     *
+     * @return this MultiTouchAction, for possible segmented-touches.
+     */
+    protected MultiTouchAction clearActions() {
+        actions = ImmutableList.builder();
+        return this;
+    }
 }

--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -29,6 +29,8 @@ public interface PerformsTouchActions extends ExecutesMethod {
      * https://dvcs.w3.org/hg/webdriver/raw-file/default/webdriver-spec.html
      * It's more convenient to call the perform() method of the TouchAction
      * object itself.
+     * All the existing touch action parameters will be wiped out after this method
+     * is called.
      *
      * @param touchAction A TouchAction object, which contains a list of individual
      *                    touch actions to perform
@@ -37,7 +39,7 @@ public interface PerformsTouchActions extends ExecutesMethod {
     default TouchAction performTouchAction(TouchAction touchAction) {
         ImmutableMap<String, ImmutableList<Object>> parameters = touchAction.getParameters();
         execute(PERFORM_TOUCH_ACTION, parameters);
-        return touchAction;
+        return touchAction.clearParameters();
     }
 
     /**
@@ -46,11 +48,14 @@ public interface PerformsTouchActions extends ExecutesMethod {
      * https://dvcs.w3.org/hg/webdriver/raw-file/default/webdriver-spec.html
      * It's more convenient to call the perform() method of the MultiTouchAction
      * object.
+     * All the existing multi touch actions will be wiped out after this method
+     * is called.
      *
      * @param multiAction the MultiTouchAction object to perform.
      */
     default void performMultiTouchAction(MultiTouchAction multiAction) {
         ImmutableMap<String, ImmutableList<Object>> parameters = multiAction.getParameters();
         execute(PERFORM_MULTI_TOUCH, parameters);
+        multiAction.clearActions();
     }
 }

--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -340,8 +340,14 @@ public class TouchAction implements PerformsActions<TouchAction> {
         return ImmutableMap.of("actions", parameters.build());
     }
 
-    protected void clearParameters() {
+    /**
+     * Clears all the existing action parameters and resets the instance to the initial state.
+     *
+     * @return this TouchAction, for possible segmented-touches.
+     */
+    protected TouchAction clearParameters() {
         parameterBuilder = ImmutableList.builder();
+        return this;
     }
 
     /**


### PR DESCRIPTION
## Change list

Clear existing actions/parameters after _perform_ method of the corresponding actions chain is invoked
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

I find the current behaviour confusing, since it may cause issues like this one: https://github.com/appium/appium/issues/8734

The second possible solution might be to make a chain immutable after _perform_ is called, so it will reject all the further parameter/action adding operations after _perform_ method has been invoked once on a chain instance.