### PR TITLE
Add name() method to WindowsBy and WindowsFindBy interfaces

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/WindowsBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsBy.java
@@ -52,6 +52,11 @@ public @interface WindowsBy {
     String xpath() default "";
 
     /**
+     * It is a name of the target element.
+     */
+    String name() default "";
+
+    /**
      * @return priority of the searching. Higher number means lower priority.
      */
     int priority() default 0;

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindBy.java
@@ -66,6 +66,11 @@ public @interface WindowsFindBy {
     String xpath() default "";
 
     /**
+     * It is a name of the target element.
+     */
+    String name() default "";
+
+    /**
      * @return priority of the searching. Higher number means lower priority.
      */
     int priority() default 0;


### PR DESCRIPTION
## Change list

Add WindowsBy and WindowsFindBy support for 'name'.

## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The `@WindowsFindBy(...)` PageFactory annotation does not currently support finding elements by name although it is possible to search using by `windowsDriver.findElementByName(..)`.

Currently supported arguments to `@WindowsFindBy` are:

- windowsAutomation
- accessibility
- id
- className
- tagName
- xpath

This PR adds:

- name

This address  issue #641 