### PR TITLE
Add pushFile support to IOSDriver

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -357,4 +357,19 @@ public class MobileCommand {
         return new AbstractMap.SimpleEntry<>(SET_SETTINGS, prepareArguments("settings",
                 prepareArguments(setting.toString(), value)));
     }
+
+    /**
+     * This method forms a {@link java.util.Map} of parameters for the
+     * file pushing
+     *
+     * @param remotePath Path to file to write data to on remote device
+     * @param base64Data Base64 encoded byte array of data to write to remote device
+     * @return a key-value pair. The key is the command name. The value is a
+     * {@link java.util.Map} command arguments.
+     */
+    public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
+        String[] parameters = new String[] {"path", "data"};
+        Object[] values = new Object[] {remotePath, base64Data};
+        return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
+    }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -198,22 +198,6 @@ public class AndroidMobileCommandHelper extends MobileCommand {
 
     /**
      * This method forms a {@link java.util.Map} of parameters for the
-     * file pushing
-     *
-     * @param remotePath Path to file to write data to on remote device
-     * @param base64Data Base64 encoded byte array of data to write to remote device
-     * @return a key-value pair. The key is the command name. The value is a
-     * {@link java.util.Map} command arguments.
-     */
-    public static Map.Entry<String, Map<String, ?>>  pushFileCommandCommand(String remotePath,
-        byte[] base64Data) {
-        String[] parameters = new String[] {"path", "data"};
-        Object[] values = new Object[] {remotePath, base64Data};
-        return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
-    }
-
-    /**
-     * This method forms a {@link java.util.Map} of parameters for the
      * setting of device network connection.
      *
      * @param connection The bitmask of the desired connection

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -53,7 +53,7 @@ public class IOSDriver<T extends WebElement>
     extends AppiumDriver<T>
     implements HidesKeyboardWithKeyName, ShakesDevice, HasIOSSettings,
         FindsByIosUIAutomation<T>, LocksIOSDevice, PerformsTouchID, FindsByIosNSPredicate<T>,
-        FindsByIosClassChain<T> {
+        FindsByIosClassChain<T>, PushesFiles {
 
     private static final String IOS_PLATFORM = MobilePlatform.IOS;
 

--- a/src/main/java/io/appium/java_client/ios/PushesFiles.java
+++ b/src/main/java/io/appium/java_client/ios/PushesFiles.java
@@ -14,47 +14,51 @@
  * limitations under the License.
  */
 
-package io.appium.java_client.android;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static io.appium.java_client.MobileCommand.pushFileCommand;
+package io.appium.java_client.ios;
 
 import io.appium.java_client.CommandExecutionHelper;
 import io.appium.java_client.ExecutesMethod;
-import io.appium.java_client.InteractsWithFiles;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 
-public interface PushesFiles extends InteractsWithFiles, ExecutesMethod {
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.appium.java_client.MobileCommand.pushFileCommand;
+
+public interface PushesFiles extends ExecutesMethod {
 
     /**
-     * Saves base64 encoded data as a file on the remote mobile device.
+     * Saves base64 encoded data as a media file on the remote mobile device.
+     * This method is only supported on Simulator running Xcode SDK 8.1+.
      *
      * @param remotePath Path to file to write data to on remote device
-     * @param base64Data Base64 encoded byte array of data to write to remote device
+     *                   Only the filename part matters there, so the remote end
+     *                   can figure out which type of media data it is and save
+     *                   it into a proper folder on the target device. Check
+     *                   'xcrun simctl addmedia' output to get more details on
+     *                   supported media types
+     * @param base64Data Base64 encoded byte array of media file data to write to remote device
      */
     default void pushFile(String remotePath, byte[] base64Data) {
         CommandExecutionHelper.execute(this, pushFileCommand(remotePath, base64Data));
     }
 
     /**
-     * Saves given file as a file on the remote mobile device.
+     * Saves base64 encoded data as a media file on the remote mobile device.
+     * This method is only supported on Simulator running Xcode SDK 8.1+.
      *
-     * @param remotePath Path to file to write data to on remote device
-     * @param file is a file to write to remote device
+     * @param remotePath See the documentation on {@link #pushFile(String, byte[])}
+     * @param file Is an existing local file to be written to the remote device
      * @throws IOException when there are problems with a file or current file system
      */
     default void pushFile(String remotePath, File file) throws IOException {
         checkNotNull(file, "A reference to file should not be NULL");
         if (!file.exists()) {
-            throw new IOException("The given file "
-                + file.getAbsolutePath() + " doesn't exist");
+            throw new IOException(String.format("The given file %s doesn't exist", file.getAbsolutePath()));
         }
-        pushFile(remotePath,
-            Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
+        pushFile(remotePath, Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
     }
 
 }


### PR DESCRIPTION
## Change list

The PR adds support of pushFile endpoint to IOSDriver. For now it is only possible to upload media file to Simulator.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Addresses https://github.com/appium/java-client/issues/720