### PR TITLE
Explicit

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocator.java
@@ -76,14 +76,9 @@ class AppiumElementLocator implements CacheableLocator {
         this.exceptionMessageIfElementNotFound =  "Can't locate an element by this strategy: " + by.toString();
     }
 
-    private void changeImplicitlyWaitTimeOut(long newTimeOut, TimeUnit newTimeUnit) {
-        originalWebDriver.manage().timeouts().implicitlyWait(newTimeOut, newTimeUnit);
-    }
-
     private <T extends Object> T waitFor(Supplier<T> supplier) {
         WaitingFunction<T> function = new WaitingFunction<>();
         try {
-            changeImplicitlyWaitTimeOut(0, TimeUnit.SECONDS);
             FluentWait<Supplier<T>> wait = new FluentWait<>(supplier)
                     .ignoring(NoSuchElementException.class);
             wait.withTimeout(timeOutDuration.getTime(), timeOutDuration.getTimeUnit());
@@ -94,8 +89,6 @@ class AppiumElementLocator implements CacheableLocator {
                         .class.cast(function.foundStaleElementReferenceException);
             }
             throw e;
-        } finally {
-            changeImplicitlyWaitTimeOut(originalTimeOutDuration.getTime(), originalTimeOutDuration.getTimeUnit());
         }
     }
 

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -62,7 +62,7 @@ public class AppiumFieldDecorator implements FieldDecorator {
     private static final List<Class<? extends WebElement>> availableElementClasses = ImmutableList.of(WebElement.class,
             RemoteWebElement.class, MobileElement.class, AndroidElement.class,
             IOSElement.class, WindowsElement.class);
-    public static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
+    public static long DEFAULT_TIMEOUT = 1;
     public static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
     private final WebDriver originalDriver;
     private final DefaultFieldDecorator defaultElementFieldDecoracor;
@@ -73,9 +73,9 @@ public class AppiumFieldDecorator implements FieldDecorator {
     private final HasSessionDetails hasSessionDetails;
 
 
-    public AppiumFieldDecorator(SearchContext context, long implicitlyWaitTimeOut,
+    public AppiumFieldDecorator(SearchContext context, long timeOut,
         TimeUnit timeUnit) {
-        this(context, new TimeOutDuration(implicitlyWaitTimeOut, timeUnit));
+        this(context, new TimeOutDuration(timeOut, timeUnit));
     }
 
     /**
@@ -144,7 +144,7 @@ public class AppiumFieldDecorator implements FieldDecorator {
     }
 
     public AppiumFieldDecorator(SearchContext context) {
-        this(context, DEFAULT_IMPLICITLY_WAIT_TIMEOUT, DEFAULT_TIMEUNIT);
+        this(context, DEFAULT_TIMEOUT, DEFAULT_TIMEUNIT);
     }
 
     /**

--- a/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
@@ -82,7 +82,7 @@ public class TimeOutResetTest {
                 "src/test/java/io/appium/java_client/pagefactory_tests/chromedriver");
         }
         driver = new ChromeDriver();
-        timeOutDuration = new TimeOutDuration(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT,
+        timeOutDuration = new TimeOutDuration(AppiumFieldDecorator.DEFAULT_TIMEOUT,
             AppiumFieldDecorator.DEFAULT_TIMEUNIT);
         PageFactory.initElements(new AppiumFieldDecorator(driver, timeOutDuration), this);
     }
@@ -102,10 +102,10 @@ public class TimeOutResetTest {
     }
 
     @Test public void test() {
-        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT,
+        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_TIMEOUT,
             AppiumFieldDecorator.DEFAULT_TIMEUNIT, getBenchMark(stubElements)));
         System.out.println(
-            String.valueOf(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT) + " "
+            String.valueOf(AppiumFieldDecorator.DEFAULT_TIMEOUT) + " "
                 + AppiumFieldDecorator.DEFAULT_TIMEUNIT.toString() + ": Fine");
 
         timeOutDuration.setTime(15500000, TimeUnit.MICROSECONDS);
@@ -122,10 +122,10 @@ public class TimeOutResetTest {
     }
 
     @Test public void test2() {
-        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT,
+        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_TIMEOUT,
             AppiumFieldDecorator.DEFAULT_TIMEUNIT, getBenchMark(stubElements)));
         System.out.println(
-            String.valueOf(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT) + " "
+            String.valueOf(AppiumFieldDecorator.DEFAULT_TIMEOUT) + " "
                 + AppiumFieldDecorator.DEFAULT_TIMEUNIT.toString() + ": Fine");
 
         assertTrue(checkTimeDifference(5, TimeUnit.SECONDS, getBenchMark(stubElements2)));
@@ -148,7 +148,7 @@ public class TimeOutResetTest {
         long startMark = Calendar.getInstance().getTimeInMillis();
         driver.findElements(By.id("FakeId"));
         long endMark = Calendar.getInstance().getTimeInMillis();
-        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT,
+        assertTrue(checkTimeDifference(AppiumFieldDecorator.DEFAULT_TIMEOUT,
                 AppiumFieldDecorator.DEFAULT_TIMEUNIT, endMark - startMark));
     }
 


### PR DESCRIPTION
## Change list
* Changes name of constant since it actually isn't being used implicitly
* Removes the resetting of implicit waits
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Implicit waits are currently entirely overridden. Setting implicit wait to 0.5 or 300 won't make any difference when locating elements.

I don't think we should remove the user's ability to set an implicit wait, even if it can have negative consequences for them.

This is a "breaking" change because implicit waits will now be respected, which can allow users to combine implicit and explicit in ways that are not ideal, or cause longer test runs if users are testing for the absence of an element. But I think them not being respected before was technically the unexpected behavior, and this is essentially a bug fix for that.

I think this should be released with the recognition that people might have timing issues and that they should be told not to set implicit waits if they want to keep previous behavior.

I'm trying to think about how overriding the implicit wait setting in the appium driver, storing the value and doing fancy things with it during location method could work... but all I come up with would remove options from the user that I think they should have.

Anyway, let's discuss. Feel free to use/modify this code as necessary in anything you end up doing..