### PR TITLE
Inherit the default process environment by default

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -93,6 +93,7 @@ public final class AppiumServiceBuilder
 
     public AppiumServiceBuilder() {
         usingPort(DEFAULT_APPIUM_PORT);
+        withEnvironment(new ProcessBuilder().environment());
     }
 
     private static void validateNodeStructure(File node) {

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -93,7 +93,7 @@ public final class AppiumServiceBuilder
 
     public AppiumServiceBuilder() {
         usingPort(DEFAULT_APPIUM_PORT);
-        withEnvironment(new ProcessBuilder().environment());
+        withEnvironment(System.getenv());
     }
 
     private static void validateNodeStructure(File node) {


### PR DESCRIPTION
## Change list

I see many people are struggling because of the fact that we set an empty environment by default while building Appium executor. This causes Appium drivers to fail unexpectedly since they cannot find executables that are supposed to available in PATH. This PR adds all the inherited process env variable to the builder by default.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
