### PR TITLE
Removed 'set' prefix from waitForIdleTimeout setting

### DIFF
--- a/src/main/java/io/appium/java_client/Setting.java
+++ b/src/main/java/io/appium/java_client/Setting.java
@@ -22,7 +22,7 @@ package io.appium.java_client;
 public enum Setting {
 
     IGNORE_UNIMPORTANT_VIEWS("ignoreUnimportantViews"),
-    WAIT_FOR_IDLE_TIMEOUT("setWaitForIdleTimeout"),
+    WAIT_FOR_IDLE_TIMEOUT("waitForIdleTimeout"),
     WAIT_FOR_SELECTOR_TIMEOUT("setWaitForSelectorTimeout"),
     WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT("setScrollAcknowledgmentTimeout"),
     WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT("setActionAcknowledgmentTimeout"),


### PR DESCRIPTION
## Change list

This sets waitForIdleTimeout via settings. 

## Types of changes
removed prefix "set" from enum constant setWaitForIdleTimeout.
 
What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
appium-uiautomator2-server and appium-android-bootstrap expects "waitForIdleTimeout" 
 
PR implementing waitForIdleTimeout in appium-uiautomator2-server
https://github.com/appium/appium-uiautomator2-server/pull/80