### PR TITLE
Update to selenium 3.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ compileJava {
     ]
 }
 
-ext.seleniumVersion = '3.6.0'
+ext.seleniumVersion = '3.7.1'
 
 dependencies {
     compile ("org.seleniumhq.selenium:selenium-java:${seleniumVersion}") {
@@ -196,6 +196,11 @@ uploadArchives {
                         email 'srinivasan.sekar1990@gmail.com'
                         url 'https://github.com/SrinivasanTarget'
                         id 'SrinivasanTarget'
+                    };
+                    developer {
+                        name 'Mykola Mokhnach'
+                        url 'https://github.com/mykola-mokhnach'
+                        id 'mykola-mokhnach'
                     };
                 }
                 licenses {

--- a/src/main/java/io/appium/java_client/events/DefaultAspect.java
+++ b/src/main/java/io/appium/java_client/events/DefaultAspect.java
@@ -73,9 +73,6 @@ class DefaultAspect {
         + "dismiss(..))";
     private static final String EXECUTION_ALERT_SEND_KEYS = "execution(* org.openqa.selenium.Alert."
         + "sendKeys(..))";
-    private static final String EXECUTION_ALERT_AUTHENTICATION = "execution(* org.openqa.selenium."
-        + "Alert.setCredentials(..)) || "
-        + "execution(* org.openqa.selenium.Alert.authenticateUsing(..))";
     private static final String EXECUTION_WINDOW_SET_SIZE = "execution(* org.openqa.selenium."
         + "WebDriver.Window.setSize(..))";
     private static final String EXECUTION_WINDOW_SET_POSITION = "execution(* org.openqa.selenium.WebDriver."
@@ -403,26 +400,6 @@ class DefaultAspect {
         try {
             listener.afterAlertSendKeys(driver, castTarget(joinPoint),
                 String.valueOf(joinPoint.getArgs()[0]));
-        } catch (Throwable t) {
-            throw getRootCause(t);
-        }
-    }
-
-    @Before(EXECUTION_ALERT_AUTHENTICATION)
-    public void beforeAlertAuthentication(JoinPoint joinPoint) throws Throwable {
-        try {
-            listener.beforeAuthentication(driver,
-                castTarget(joinPoint), castArgument(joinPoint, 0));
-        } catch (Throwable t) {
-            throw getRootCause(t);
-        }
-    }
-
-    @After(EXECUTION_ALERT_AUTHENTICATION)
-    public void afterAlertAuthentication(JoinPoint joinPoint) throws Throwable {
-        try {
-            listener.afterAuthentication(driver, castTarget(joinPoint),
-                castArgument(joinPoint, 0));
         } catch (Throwable t) {
             throw getRootCause(t);
         }

--- a/src/main/java/io/appium/java_client/events/DefaultListener.java
+++ b/src/main/java/io/appium/java_client/events/DefaultListener.java
@@ -183,11 +183,13 @@ class DefaultListener
     }
 
     @Override
+    @Deprecated
     public void beforeAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
         ((AlertEventListener) dispatcher).beforeAuthentication(driver, alert, credentials);
     }
 
     @Override
+    @Deprecated
     public void afterAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
         ((AlertEventListener) dispatcher).afterAuthentication(driver, alert, credentials);
     }

--- a/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
+++ b/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
@@ -81,7 +81,7 @@ public interface AlertEventListener extends Listener {
      * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}
      * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
      * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
-     * at 3.8.0. These listener method is going to be removed too.
+     * at 3.8.0. This listener method is going to be removed as well.
      *
      * @param driver WebDriver
      * @param alert {@link org.openqa.selenium.Alert} which is receiving user credentials
@@ -97,7 +97,7 @@ public interface AlertEventListener extends Listener {
      * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}.
      * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
      * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
-     * at 3.8.0. These listener method is going to be removed too.
+     * at 3.8.0. This listener method is going to be removed as well.
      *
      * @param driver WebDriver
      * @param alert {@link org.openqa.selenium.Alert} which has received user credentials

--- a/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
+++ b/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
@@ -79,23 +79,31 @@ public interface AlertEventListener extends Listener {
      * This action will be performed each time before
      * {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
      * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}
+     * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
+     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
+     * at 3.8.0. These listener method is going to be removed too.
      *
      * @param driver WebDriver
      * @param alert {@link org.openqa.selenium.Alert} which is receiving user credentials
      * @param credentials which are being sent
      */
+    @Deprecated
     void beforeAuthentication(WebDriver driver, Alert alert,
         Credentials credentials);
 
     /**
      * This action will be performed each time after
      * {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
-     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}
+     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}.
+     * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
+     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
+     * at 3.8.0. These listener method is going to be removed too.
      *
      * @param driver WebDriver
      * @param alert {@link org.openqa.selenium.Alert} which has received user credentials
      * @param credentials which have been sent
      */
+    @Deprecated
     void afterAuthentication(WebDriver driver, Alert alert,
         Credentials credentials);
 }

--- a/src/test/java/io/appium/java_client/events/BaseListenerTest.java
+++ b/src/test/java/io/appium/java_client/events/BaseListenerTest.java
@@ -1,7 +1,6 @@
 package io.appium.java_client.events;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 import io.appium.java_client.MobileBy;
@@ -14,7 +13,6 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.security.Credentials;
 
 import java.net.URL;
 import java.util.List;
@@ -26,14 +24,14 @@ public class BaseListenerTest {
         try {
             driver.findElement(By.id("someId"));
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to find something using By.id: someId. The root element is null",
+                    contains(prefix + "Attempt to find something using By.id: someId. The root element is null",
                             prefix + "The searching for something using By.id: someId has beed finished. "
                                     + "The root element was null"));
 
             driver.findElements(By.id("someId2"));
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to find something using By.id: someId. The root element is null",
+                    contains(prefix + "Attempt to find something using By.id: someId. The root element is null",
                             prefix + "The searching for something using By.id: someId has beed finished. "
                                     + "The root element was null",
                             prefix + "Attempt to find something using By.id: someId2. The root element is null",
@@ -43,38 +41,43 @@ public class BaseListenerTest {
             driver.findElement(By.id("someId")).findElement(By.className("someClazz"));
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to find something using By.id: someId. The root element is null",
+                    contains(prefix + "Attempt to find something using By.id: someId. The root element is null",
                             prefix + "The searching for something using By.id: someId has beed finished. "
                                     + "The root element was null",
                             prefix + "Attempt to find something using By.id: someId2. The root element is null",
                             prefix + "The searching for something using By.id: someId2 has beed finished. "
                                     + "The root element was null",
-                            prefix + "Attempt to find something using By.className: someClazz. The root element is "
-                                    + "io.appium.java_client.events.StubWebElement",
+                            prefix + "Attempt to find something using By.id: someId. "
+                                    + "The root element is null",
+                            prefix + "The searching for something using By.id: someId has beed finished. "
+                                    + "The root element was null",
+                            prefix + "Attempt to find something using By.className: someClazz. "
+                                    + "The root element is io.appium.java_client.events.StubWebElement",
                             prefix + "The searching for something using By.className: someClazz has beed finished. "
-                                    + "The root element was "
-                                    + "io.appium.java_client.events.StubWebElement"));
+                                    + "The root element was io.appium.java_client.events.StubWebElement"));
 
             driver.findElements(By.id("someId2")).get(0).findElements(By.className("someClazz2"));
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to find something using By.id: someId. The root element is null",
+                    contains(prefix + "Attempt to find something using By.id: someId. The root element is null",
                             prefix + "The searching for something using By.id: someId has beed finished. "
                                     + "The root element was null",
                             prefix + "Attempt to find something using By.id: someId2. The root element is null",
                             prefix + "The searching for something using By.id: someId2 has beed finished. "
                                     + "The root element was null",
-                            prefix + "Attempt to find something using By.className: someClazz. The root element is "
-                                    + "io.appium.java_client.events.StubWebElement",
+                            prefix + "Attempt to find something using By.id: someId. The root element is null",
+                            prefix + "The searching for something using By.id: someId has beed finished. "
+                                    + "The root element was null",
+                            prefix + "Attempt to find something using By.className: someClazz. "
+                                    + "The root element is io.appium.java_client.events.StubWebElement",
                             prefix + "The searching for something using By.className: someClazz has beed finished. "
-                                    + "The root element was "
-                                    + "io.appium.java_client.events.StubWebElement",
-                            prefix + "Attempt to find something using By.className: someClazz2. The root element is "
-                                    + "io.appium.java_client.events.StubWebElement",
+                                    + "The root element was io.appium.java_client.events.StubWebElement",
+                            prefix + "Attempt to find something using By.id: someId2. The root element is null",
+                            prefix + "The searching for something using By.id: someId2 has beed finished. "
+                                    + "The root element was null",
+                            prefix + "Attempt to find something using By.className: someClazz2. "
+                                    + "The root element is io.appium.java_client.events.StubWebElement",
                             prefix + "The searching for something using By.className: someClazz2 has beed finished. "
-                                    + "The root element was "
-                                    + "io.appium.java_client.events.StubWebElement"));
-
-            assertThat(listener.messages.size(), is(12));
+                                    + "The root element was io.appium.java_client.events.StubWebElement"));
             return true;
         } finally {
             listener.messages.clear();
@@ -93,7 +96,7 @@ public class BaseListenerTest {
                     .findElement(MobileBy.IosUIAutomation("iOS UI Automation"));
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to find something using By.AndroidUIAutomator: Android UI Automator. "
+                    contains(prefix + "Attempt to find something using By.AndroidUIAutomator: Android UI Automator. "
                                     + "The root element is io.appium.java_client.events.StubWebElement",
                             prefix + "The searching for something using By.AndroidUIAutomator: "
                                     + "Android UI Automator has "
@@ -104,7 +107,6 @@ public class BaseListenerTest {
                             prefix + "The searching for something using By.IosUIAutomation: iOS UI Automation "
                                     + "has beed finished. "
                                     + "The root element was io.appium.java_client.events.StubWebElement"));
-            assertThat(listener.messages.size(), is(4));
             return true;
         } finally {
             listener.messages.clear();
@@ -122,7 +124,7 @@ public class BaseListenerTest {
             driver.navigate().refresh();
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to navigate to www.google.com",
+                    contains(prefix + "Attempt to navigate to www.google.com",
                             prefix + "Navigation to www.google.com was successful",
                             prefix + "Attempt to navigate to www.google2.com",
                             prefix + "Navigation to www.google2.com was successful",
@@ -134,7 +136,6 @@ public class BaseListenerTest {
                             prefix + "Navigation back was successful",
                             prefix + "Attempt to refresh",
                             prefix + "The refreshing was successful"));
-            assertThat(listener.messages.size(), is(12));
             return true;
         } finally {
             listener.messages.clear();
@@ -148,11 +149,10 @@ public class BaseListenerTest {
             e.sendKeys("Test keys");
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to click on the element",
+                    contains(prefix + "Attempt to click on the element",
                             prefix + "Thee element was clicked",
                             prefix + "Attempt to change value of the element",
                             prefix + "The value of the element was changed"));
-            assertThat(listener.messages.size(), is(4));
             return true;
         } finally {
             listener.messages.clear();
@@ -166,11 +166,10 @@ public class BaseListenerTest {
             driver.executeAsyncScript("Some test async script");
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to perform java script: Some test script",
+                    contains(prefix + "Attempt to perform java script: Some test script",
                             prefix + "Java script Some test script was performed",
                             prefix + "Attempt to perform java script: Some test async script",
                             prefix + "Java script Some test async script was performed"));
-            assertThat(listener.messages.size(), is(4));
             return true;
         } finally {
             listener.messages.clear();
@@ -192,11 +191,10 @@ public class BaseListenerTest {
             }
 
             assertThat(listener.messages,
-                    hasItems(prefix + "The exception was thrown: "
+                    contains(prefix + "The exception was thrown: "
                                     + WebDriverException.class,
                             prefix + "The exception was thrown: "
                                     + WebDriverException.class));
-            assertThat(listener.messages.size(), is(2));
             return true;
         } finally {
             listener.messages.clear();
@@ -209,45 +207,14 @@ public class BaseListenerTest {
             alert.accept();
             alert.dismiss();
             alert.sendKeys("Keys");
-            Credentials credentials = new Credentials() {
-                @Override
-                public int hashCode() {
-                    return super.hashCode();
-                }
-
-                @Override
-                public String toString() {
-                    return "Test credentials 1";
-                }
-            };
-
-            Credentials credentials2 = new Credentials() {
-                @Override
-                public int hashCode() {
-                    return super.hashCode();
-                }
-
-                @Override
-                public String toString() {
-                    return "Test credentials 2";
-                }
-            };
-
-            alert.setCredentials(credentials);
-            alert.authenticateUsing(credentials2);
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to accept alert",
+                    contains(prefix + "Attempt to accept alert",
                             prefix + "The alert was accepted",
                             prefix + "Attempt to dismiss alert",
                             prefix + "The alert was dismissed",
                             prefix + "Attempt to send keys to alert",
-                            prefix + "Keys were sent to alert",
-                            prefix + "Attempt to send credentials " + credentials.toString() + " to alert",
-                            prefix + "Credentials " + credentials.toString() + " were sent to alert",
-                            prefix + "Attempt to send credentials " + credentials2.toString() + " to alert",
-                            prefix + "Credentials " + credentials2.toString() + " were sent to alert"));
-            assertThat(listener.messages.size(), is(10));
+                            prefix + "Keys were sent to alert"));
             return true;
         } finally {
             listener.messages.clear();
@@ -260,11 +227,10 @@ public class BaseListenerTest {
             driver.context("WEB_VIEW");
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to change current context to NATIVE_APP",
+                    contains(prefix + "Attempt to change current context to NATIVE_APP",
                             prefix + "The previous context has been changed to NATIVE_APP",
                             prefix + "Attempt to change current context to WEB_VIEW",
                             prefix + "The previous context has been changed to WEB_VIEW"));
-            assertThat(listener.messages.size(), is(4));
             return true;
         } finally {
             listener.messages.clear();
@@ -279,7 +245,7 @@ public class BaseListenerTest {
             driver.rotate(ScreenOrientation.PORTRAIT);
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to change screen orientation. The new screen orientation is "
+                    contains(prefix + "Attempt to change screen orientation. The new screen orientation is "
                                     + ScreenOrientation.LANDSCAPE.toString(),
                             prefix + "The screen orientation has been changed to "
                                     + ScreenOrientation.LANDSCAPE.toString(),
@@ -287,7 +253,6 @@ public class BaseListenerTest {
                                     + ScreenOrientation.PORTRAIT.toString(),
                             prefix + "The screen orientation has been changed to "
                                     + ScreenOrientation.PORTRAIT.toString()));
-            assertThat(listener.messages.size(), is(4));
             return true;
         } finally {
             listener.messages.clear();
@@ -306,7 +271,7 @@ public class BaseListenerTest {
             window.maximize();
 
             assertThat(listener.messages,
-                    hasItems(prefix + "Attempt to change size of the window. The height is " + d.getHeight()
+                    contains(prefix + "Attempt to change size of the window. The height is " + d.getHeight()
                                     + " the width is " + d.getWidth(),
                             prefix + "Size of the window has been changed. The height is " + d.getHeight()
                                     + " the width is " + d.getWidth(),
@@ -316,7 +281,6 @@ public class BaseListenerTest {
                                     + " the Y is " + p.getY(),
                             prefix + "Attempt to maximize the window.",
                             prefix + "The window has been maximized"));
-            assertThat(listener.messages.size(), is(6));
             return true;
         } finally {
             listener.messages.clear();

--- a/src/test/java/io/appium/java_client/events/ListenableObjectTest.java
+++ b/src/test/java/io/appium/java_client/events/ListenableObjectTest.java
@@ -5,8 +5,7 @@ import static io.appium.java_client.events.EventFiringObjectFactory.getEventFiri
 import static io.appium.java_client.events.EventFiringWebDriverFactory.getEventFiringWebDriver;
 import static io.appium.java_client.events.listeners.SingleListeners.listeners;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -21,7 +20,6 @@ import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ContextAware;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.security.Credentials;
 
 import java.util.Set;
 import java.util.function.Predicate;
@@ -51,48 +49,22 @@ public class ListenableObjectTest {
         }
     };
 
-    private final Credentials credentials = new Credentials() {
-        @Override
-        public int hashCode() {
-            return super.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return "Test credentials 1";
-        }
-    };
-
-    private final Credentials credentials2 = new Credentials() {
-        @Override
-        public int hashCode() {
-            return super.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return "Test credentials 2";
-        }
-    };
-
     private final Predicate<ContextAware> contextAwarePredicate = (contextAware) -> {
         contextAware.context("WEB_VIEW");
 
         assertThat(contextListener.messages,
-                hasItems(PREFIX + "Attempt to change current context to NATIVE_APP",
+                contains(PREFIX + "Attempt to change current context to NATIVE_APP",
                         PREFIX + "The previous context has been changed to NATIVE_APP",
                         PREFIX + "Attempt to change current context to WEB_VIEW",
                         PREFIX + "The previous context has been changed to WEB_VIEW"));
-        assertThat(contextListener.messages.size(), is(4));
 
         ContextListener singleContextListener = (ContextListener)
                 listeners.get(ContextListener.class);
         assertThat(singleContextListener.messages,
-                hasItems("Attempt to change current context to NATIVE_APP",
+                contains("Attempt to change current context to NATIVE_APP",
                         "The previous context has been changed to NATIVE_APP",
                         "Attempt to change current context to WEB_VIEW",
                         "The previous context has been changed to WEB_VIEW"));
-        assertThat(singleContextListener.messages.size(), is(4));
         return true;
     };
 
@@ -101,56 +73,41 @@ public class ListenableObjectTest {
         alert.dismiss();
         alert.sendKeys("Keys");
 
-        alert.setCredentials(credentials);
-        alert.authenticateUsing(credentials2);
-
         assertThat(alertListener.messages,
-                hasItems(PREFIX + "Attempt to accept alert",
+                contains(PREFIX + "Attempt to accept alert",
                         PREFIX + "The alert was accepted",
                         PREFIX + "Attempt to dismiss alert",
                         PREFIX + "The alert was dismissed",
                         PREFIX + "Attempt to send keys to alert",
-                        PREFIX + "Keys were sent to alert",
-                        PREFIX + "Attempt to send credentials " + credentials.toString() + " to alert",
-                        PREFIX + "Credentials " + credentials.toString() + " were sent to alert",
-                        PREFIX + "Attempt to send credentials " + credentials2.toString() + " to alert",
-                        PREFIX + "Credentials " + credentials2.toString() + " were sent to alert"));
-        assertThat(alertListener.messages.size(), is(10));
+                        PREFIX + "Keys were sent to alert"));
 
         AlertListener singleAlertListener = (AlertListener)
                 listeners.get(AlertListener.class);
 
         assertThat(singleAlertListener.messages,
-                hasItems("Attempt to accept alert",
+                contains("Attempt to accept alert",
                         "The alert was accepted",
                         "Attempt to dismiss alert",
                         "The alert was dismissed",
                         "Attempt to send keys to alert",
-                        "Keys were sent to alert",
-                        "Attempt to send credentials " + credentials.toString() + " to alert",
-                        "Credentials " + credentials.toString() + " were sent to alert",
-                        "Attempt to send credentials " + credentials2.toString() + " to alert",
-                        "Credentials " + credentials2.toString() + " were sent to alert"));
-        assertThat(singleAlertListener.messages.size(), is(10));
+                        "Keys were sent to alert"));
         return true;
     };
 
     private final Predicate<WebDriver> webDriverPredicate = driver -> {
         driver.findElement(By.id("someId"));
         assertThat(searchingListener.messages,
-                hasItems(PREFIX + "Attempt to find something using By.id: someId. The root element is null",
+                contains(PREFIX + "Attempt to find something using By.id: someId. The root element is null",
                         PREFIX + "The searching for something using By.id: someId has beed finished. "
                                 + "The root element was null"));
-        assertThat(searchingListener.messages.size(), is(2));
 
         SearchingListener singleSearchingListener = (SearchingListener)
                 listeners.get(SearchingListener.class);
 
         assertThat(singleSearchingListener.messages,
-                hasItems("Attempt to find something using By.id: someId. The root element is null",
+                contains("Attempt to find something using By.id: someId. The root element is null",
                         "The searching for something using By.id: someId has beed finished. "
                                 + "The root element was null"));
-        assertThat(singleSearchingListener.messages.size(), is(2));
         return true;
     };
 


### PR DESCRIPTION
## Change list
- Update to selenium 3.7.1
- Methods `beforeAuthentication` and afterAuthentication` became deprecared.
- @mykola-mokhnach was added to the list of developers.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
I can't to update the project to selenium 3.8.x because of mentioned methods. It should be removed safely and users should be warned. 