### PR TITLE
Less strict verification

### DIFF
--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -125,6 +125,11 @@ public class TouchAction<T extends TouchAction<T>> implements PerformsActions<T>
      * Moves current touch to a new position.
      *
      * @param  moveToOptions see {@link PointOption} and {@link ElementOption}
+     *                       Important: some older Appium drivers releases have a bug when moveTo
+     *                       coordinates are calculated as relative to the recent pointer position
+     *                       in the chain instead of being absolute.
+     *                       @see <a href="https://github.com/appium/appium/issues/7486">Appium Issue #7486</a>
+     *                       for more details.
      * @return this TouchAction, for chaining.
      */
     public T moveTo(PointOption moveToOptions) {

--- a/src/main/java/io/appium/java_client/touch/offset/PointOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/PointOption.java
@@ -1,7 +1,5 @@
 package io.appium.java_client.touch.offset;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 import static java.util.Optional.ofNullable;
 
 import io.appium.java_client.touch.ActionOptions;
@@ -12,8 +10,6 @@ import java.util.Map;
 public class PointOption<T extends PointOption<T>> extends ActionOptions<T> {
 
     protected Point coordinates;
-
-    private static final String ERROR_MESSAGE_TEMPLATE = "%s coordinate value should be equal or greater than zero";
 
     /**
      * It creates a built instance of {@link PointOption} which takes x and y coordinates.
@@ -36,14 +32,14 @@ public class PointOption<T extends PointOption<T>> extends ActionOptions<T> {
      * @return self-reference
      */
     public T withCoordinates(int xOffset, int yOffset) {
-        checkArgument(xOffset >= 0, format(ERROR_MESSAGE_TEMPLATE, "X"));
-        checkArgument(yOffset >= 0, format(ERROR_MESSAGE_TEMPLATE, "Y"));
         coordinates = new Point(xOffset, yOffset);
+        //noinspection unchecked
         return (T) this;
     }
 
     @Override
     protected void verify() {
+        //noinspection ResultOfMethodCallIgnored
         ofNullable(coordinates).orElseThrow(() -> new IllegalArgumentException(
                 "Coordinate values must be defined"));
     }

--- a/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
+++ b/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
@@ -44,8 +44,6 @@ public class TouchOptionsTests {
         final List<Runnable> invalidOptions = new ArrayList<>();
         invalidOptions.add(() -> waitOptions(ofMillis(-1)));
         invalidOptions.add(() -> new ElementOption().withCoordinates(0, 0).withElement(null));
-        invalidOptions.add(() -> new PointOption().withCoordinates(0, -1));
-        invalidOptions.add(() -> new PointOption().withCoordinates(-1, 0));
         invalidOptions.add(() -> new WaitOptions().withDuration(null));
         invalidOptions.add(() -> tapOptions().withTapsCount(-1));
         invalidOptions.add(() -> longPressOptions().withDuration(null));


### PR DESCRIPTION
## Change list

`moveTo` fix is not deployed to Appium yet, so it's OK to allow clients to still use relative coordinates. I've also added a note about the problem into the docstring.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

