### PR TITLE
Update to Selenium 3.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ compileJava {
     ]
 }
 
-ext.seleniumVersion = '3.7.1'
+ext.seleniumVersion = '3.8.1'
 
 dependencies {
     compile ("org.seleniumhq.selenium:selenium-java:${seleniumVersion}") {

--- a/src/main/java/io/appium/java_client/events/DefaultListener.java
+++ b/src/main/java/io/appium/java_client/events/DefaultListener.java
@@ -34,7 +34,6 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.security.Credentials;
 import org.openqa.selenium.support.events.WebDriverEventListener;
 
 import java.lang.reflect.Proxy;
@@ -180,18 +179,6 @@ class DefaultListener
 
     @Override public void afterAlertSendKeys(WebDriver driver, Alert alert, String keys) {
         ((AlertEventListener) dispatcher).afterAlertSendKeys(driver, alert, keys);
-    }
-
-    @Override
-    @Deprecated
-    public void beforeAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        ((AlertEventListener) dispatcher).beforeAuthentication(driver, alert, credentials);
-    }
-
-    @Override
-    @Deprecated
-    public void afterAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        ((AlertEventListener) dispatcher).afterAuthentication(driver, alert, credentials);
     }
 
     @Override public void beforeWindowChangeSize(WebDriver driver, WebDriver.Window window,

--- a/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
+++ b/src/main/java/io/appium/java_client/events/api/general/AlertEventListener.java
@@ -19,7 +19,6 @@ package io.appium.java_client.events.api.general;
 import io.appium.java_client.events.api.Listener;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.security.Credentials;
 
 public interface AlertEventListener extends Listener {
 
@@ -74,36 +73,4 @@ public interface AlertEventListener extends Listener {
      * @param keys Keys which have been sent
      */
     void afterAlertSendKeys(WebDriver driver, Alert alert, String keys);
-
-    /**
-     * This action will be performed each time before
-     * {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
-     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}
-     * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
-     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
-     * at 3.8.0. This listener method is going to be removed as well.
-     *
-     * @param driver WebDriver
-     * @param alert {@link org.openqa.selenium.Alert} which is receiving user credentials
-     * @param credentials which are being sent
-     */
-    @Deprecated
-    void beforeAuthentication(WebDriver driver, Alert alert,
-        Credentials credentials);
-
-    /**
-     * This action will be performed each time after
-     * {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
-     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)}.
-     * It is deprecated because methods {@link org.openqa.selenium.Alert#setCredentials(Credentials)} and
-     * {@link org.openqa.selenium.Alert#authenticateUsing(Credentials)} were removed from selenium java client
-     * at 3.8.0. This listener method is going to be removed as well.
-     *
-     * @param driver WebDriver
-     * @param alert {@link org.openqa.selenium.Alert} which has received user credentials
-     * @param credentials which have been sent
-     */
-    @Deprecated
-    void afterAuthentication(WebDriver driver, Alert alert,
-        Credentials credentials);
 }

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -34,7 +34,6 @@ import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.security.Credentials;
 
 import java.net.URL;
 import java.time.Duration;
@@ -205,14 +204,6 @@ public class IOSDriver<T extends WebElement>
 
         @Override public void sendKeys(String keysToSend) {
             execute(DriverCommand.SET_ALERT_VALUE, prepareArguments("value", keysToSend));
-        }
-
-        @Override public void setCredentials(Credentials credentials) {
-            alert.setCredentials(credentials);
-        }
-
-        @Override public void authenticateUsing(Credentials credentials) {
-            alert.authenticateUsing(credentials);
         }
 
     }

--- a/src/test/java/io/appium/java_client/events/StubAlert.java
+++ b/src/test/java/io/appium/java_client/events/StubAlert.java
@@ -2,7 +2,6 @@ package io.appium.java_client.events;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Alert;
-import org.openqa.selenium.security.Credentials;
 
 public class StubAlert implements Alert {
     @Override public void dismiss() {
@@ -18,14 +17,6 @@ public class StubAlert implements Alert {
     }
 
     @Override public void sendKeys(String keysToSend) {
-        //STUB it does nothing
-    }
-
-    @Override public void setCredentials(Credentials credentials) {
-        //STUB it does nothing
-    }
-
-    @Override public void authenticateUsing(Credentials credentials) {
         //STUB it does nothing
     }
 }

--- a/src/test/java/io/appium/java_client/events/WebDriverEventListenerCompatibilityTest.java
+++ b/src/test/java/io/appium/java_client/events/WebDriverEventListenerCompatibilityTest.java
@@ -11,7 +11,6 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.openqa.selenium.Alert;
-import org.openqa.selenium.security.Credentials;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WebDriverEventListenerCompatibilityTest extends BaseListenerTest {
@@ -66,32 +65,6 @@ public class WebDriverEventListenerCompatibilityTest extends BaseListenerTest {
             alert.accept();
             alert.dismiss();
             alert.sendKeys("Keys");
-            Credentials credentials = new Credentials() {
-                @Override
-                public int hashCode() {
-                    return super.hashCode();
-                }
-
-                @Override
-                public String toString() {
-                    return "Test credentials 1";
-                }
-            };
-
-            Credentials credentials2 = new Credentials() {
-                @Override
-                public int hashCode() {
-                    return super.hashCode();
-                }
-
-                @Override
-                public String toString() {
-                    return "Test credentials 2";
-                }
-            };
-
-            alert.setCredentials(credentials);
-            alert.authenticateUsing(credentials2);
 
             assertThat(listener.messages,
                     hasItems(WEBDRIVER_EVENT_LISTENER + "Attempt to accept alert",

--- a/src/test/java/io/appium/java_client/events/listeners/AlertListener.java
+++ b/src/test/java/io/appium/java_client/events/listeners/AlertListener.java
@@ -3,7 +3,6 @@ package io.appium.java_client.events.listeners;
 import io.appium.java_client.events.api.general.AlertEventListener;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.security.Credentials;
 
 public class AlertListener extends TestListener implements AlertEventListener {
     @Override public void beforeAlertAccept(WebDriver driver, Alert alert) {
@@ -28,16 +27,6 @@ public class AlertListener extends TestListener implements AlertEventListener {
 
     @Override public void afterAlertSendKeys(WebDriver driver, Alert alert, String keys) {
         messages.add("Keys were sent to alert");
-    }
-
-    @Override
-    public void beforeAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        messages.add("Attempt to send credentials " + credentials.toString() + " to alert");
-    }
-
-    @Override
-    public void afterAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        messages.add("Credentials " + credentials.toString() + " were sent to alert");
     }
 
     @Override protected void add() {

--- a/src/test/java/io/appium/java_client/events/listeners/AlertListener2.java
+++ b/src/test/java/io/appium/java_client/events/listeners/AlertListener2.java
@@ -3,7 +3,6 @@ package io.appium.java_client.events.listeners;
 import io.appium.java_client.events.api.general.AlertEventListener;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.security.Credentials;
 
 public class AlertListener2 extends TestListener implements AlertEventListener {
     @Override public void beforeAlertAccept(WebDriver driver, Alert alert) {
@@ -28,18 +27,6 @@ public class AlertListener2 extends TestListener implements AlertEventListener {
 
     @Override public void afterAlertSendKeys(WebDriver driver, Alert alert, String keys) {
         messages.add("Externally defined listener: Keys were sent to alert");
-    }
-
-    @Override
-    public void beforeAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        messages.add("Externally defined listener: Attempt to send credentials "
-            + credentials.toString() + " to alert");
-    }
-
-    @Override
-    public void afterAuthentication(WebDriver driver, Alert alert, Credentials credentials) {
-        messages.add("Externally defined listener: Credentials " + credentials.toString()
-            + " were sent to alert");
     }
 
     @Override protected void add() {


### PR DESCRIPTION
## Change list

- Update to Selenium 3.8.1
- Removal of deprecated listener-methods from the AlertEventListener. These methods were
being invoked before/after authentication.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)