### PR TITLE
Use standard Java plugin source sets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,22 +87,6 @@ ext {
     Docs = file("$buildDir/doc")
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir('src/main/java')
-        }
-        resources {
-            srcDir('src/main/resources')
-        }
-    }
-    test {
-        java {
-            srcDir('src/test/java')
-        }
-    }
-}
-
 dependencyCheck {
     failBuildOnCVSS=22
 }


### PR DESCRIPTION
## Change list

The Java plugin defines two standard source sets, called `main` and `test`. There is no reason to duplicate their declaration. (https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_source_sets)
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [X] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)