### PR TITLE
Fix the second argument type for pushFile

### DIFF
--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -377,11 +377,13 @@ public class MobileCommand {
      */
     public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
+        String data;
         try {
-            Object[] values = new Object[]{remotePath, new String(base64Data, "UTF-8")};
-            return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
+            data = new String(base64Data, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            throw new IllegalArgumentException(e);
         }
+        Object[] values = new Object[]{remotePath, data};
+        return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
     }
 }

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -24,7 +24,6 @@ import org.openqa.selenium.remote.http.HttpMethod;
 
 import java.time.Duration;
 import java.util.AbstractMap;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -377,7 +376,7 @@ public class MobileCommand {
      */
     public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
-        Object[] values = new Object[] {remotePath, Arrays.toString(base64Data)};
+        Object[] values = new Object[] {remotePath, new String(base64Data)};
         return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
     }
 }

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -23,6 +23,7 @@ import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.HashMap;
@@ -377,13 +378,7 @@ public class MobileCommand {
      */
     public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
-        String data;
-        try {
-            data = new String(base64Data, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(e);
-        }
-        Object[] values = new Object[]{remotePath, data};
+        Object[] values = new Object[]{remotePath, new String(base64Data, StandardCharsets.UTF_8)};
         return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
     }
 }

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.AbstractMap;

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -24,6 +24,7 @@ import org.openqa.selenium.remote.http.HttpMethod;
 
 import java.time.Duration;
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -376,7 +377,7 @@ public class MobileCommand {
      */
     public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
-        Object[] values = new Object[] {remotePath, base64Data};
+        Object[] values = new Object[] {remotePath, Arrays.toString(base64Data)};
         return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
     }
 }

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.http.HttpMethod;
 
+import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.HashMap;
@@ -376,7 +377,11 @@ public class MobileCommand {
      */
     public static Map.Entry<String, Map<String, ?>> pushFileCommand(String remotePath, byte[] base64Data) {
         String[] parameters = new String[] {"path", "data"};
-        Object[] values = new Object[] {remotePath, new String(base64Data)};
-        return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
+        try {
+            Object[] values = new Object[]{remotePath, new String(base64Data, "UTF-8")};
+            return new AbstractMap.SimpleEntry<>(PUSH_FILE, prepareArguments(parameters, values));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## Change list

Fixes the second argument type for `pushFile` endpoint. Appium expects it to be base64-encoded string, but we send array of bytes instead.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

See https://github.com/appium/appium-xcuitest-driver/pull/605