### PR TITLE
Implement custom command codec

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/AppiumW3CHttpCommandCodec.java
@@ -31,9 +31,6 @@ import static org.openqa.selenium.remote.DriverCommand.GET_ALERT_TEXT;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_HANDLE;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_POSITION;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_SIZE;
-import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION;
-import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_RECT;
-import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_SIZE;
 import static org.openqa.selenium.remote.DriverCommand.GET_WINDOW_HANDLES;
 import static org.openqa.selenium.remote.DriverCommand.MAXIMIZE_CURRENT_WINDOW;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
@@ -46,10 +43,12 @@ import static org.openqa.selenium.remote.DriverCommand.SET_TIMEOUT;
 
 public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
 
+    /**
+     * This class overrides the built-in Selenium W3C commands codec,
+     * since the latter hardcodes many commands in Javascript,
+     * which does not work with Appium.
+     */
     public AppiumW3CHttpCommandCodec() {
-        alias(GET_ELEMENT_LOCATION, GET_ELEMENT_RECT);
-        alias(GET_ELEMENT_SIZE, GET_ELEMENT_RECT);
-
         defineCommand(EXECUTE_SCRIPT, post("/session/:sessionId/execute/sync"));
         defineCommand(EXECUTE_ASYNC_SCRIPT, post("/session/:sessionId/execute/async"));
 

--- a/src/main/java/io/appium/java_client/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/AppiumW3CHttpCommandCodec.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client;
+
+import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
+
+import java.util.Map;
+
+import static org.openqa.selenium.remote.DriverCommand.ACCEPT_ALERT;
+import static org.openqa.selenium.remote.DriverCommand.ACTIONS;
+import static org.openqa.selenium.remote.DriverCommand.CLEAR_ACTIONS_STATE;
+import static org.openqa.selenium.remote.DriverCommand.DISMISS_ALERT;
+import static org.openqa.selenium.remote.DriverCommand.EXECUTE_ASYNC_SCRIPT;
+import static org.openqa.selenium.remote.DriverCommand.EXECUTE_SCRIPT;
+import static org.openqa.selenium.remote.DriverCommand.GET_ACTIVE_ELEMENT;
+import static org.openqa.selenium.remote.DriverCommand.GET_ALERT_TEXT;
+import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_HANDLE;
+import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_POSITION;
+import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_SIZE;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_RECT;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_SIZE;
+import static org.openqa.selenium.remote.DriverCommand.GET_WINDOW_HANDLES;
+import static org.openqa.selenium.remote.DriverCommand.MAXIMIZE_CURRENT_WINDOW;
+import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
+import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ELEMENT;
+import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_VALUE;
+import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_POSITION;
+import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_SIZE;
+import static org.openqa.selenium.remote.DriverCommand.SET_TIMEOUT;
+
+
+public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
+
+    public AppiumW3CHttpCommandCodec() {
+        alias(GET_ELEMENT_LOCATION, GET_ELEMENT_RECT);
+        alias(GET_ELEMENT_SIZE, GET_ELEMENT_RECT);
+
+        defineCommand(EXECUTE_SCRIPT, post("/session/:sessionId/execute/sync"));
+        defineCommand(EXECUTE_ASYNC_SCRIPT, post("/session/:sessionId/execute/async"));
+
+        defineCommand(MAXIMIZE_CURRENT_WINDOW, post("/session/:sessionId/window/maximize"));
+        defineCommand(GET_CURRENT_WINDOW_SIZE, get("/session/:sessionId/window/rect"));
+        defineCommand(SET_CURRENT_WINDOW_SIZE, post("/session/:sessionId/window/rect"));
+        alias(GET_CURRENT_WINDOW_POSITION, GET_CURRENT_WINDOW_SIZE);
+        alias(SET_CURRENT_WINDOW_POSITION, SET_CURRENT_WINDOW_SIZE);
+        defineCommand(GET_CURRENT_WINDOW_HANDLE, get("/session/:sessionId/window"));
+        defineCommand(GET_WINDOW_HANDLES, get("/session/:sessionId/window/handles"));
+
+        defineCommand(ACCEPT_ALERT, post("/session/:sessionId/alert/accept"));
+        defineCommand(DISMISS_ALERT, post("/session/:sessionId/alert/dismiss"));
+        defineCommand(GET_ALERT_TEXT, get("/session/:sessionId/alert/text"));
+        defineCommand(SET_ALERT_VALUE, post("/session/:sessionId/alert/text"));
+
+        defineCommand(GET_ACTIVE_ELEMENT, get("/session/:sessionId/element/active"));
+
+        defineCommand(ACTIONS, post("/session/:sessionId/actions"));
+        defineCommand(CLEAR_ACTIONS_STATE, delete("/session/:sessionId/actions"));
+    }
+
+    @Override
+    protected Map<String, ?> amendParameters(String name, Map<String, ?> parameters) {
+        switch (name) {
+            case SEND_KEYS_TO_ACTIVE_ELEMENT:
+            case SEND_KEYS_TO_ELEMENT:
+            case SET_ALERT_VALUE:
+            case SET_TIMEOUT:
+                return super.amendParameters(name, parameters);
+            default:
+                return parameters;
+        }
+    }
+}

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -151,9 +151,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         if (DriverCommand.NEW_SESSION.equals(command.getName())
                 && getCommandCodec() instanceof W3CHttpCommandCodec) {
             setCommandCodec(new AppiumW3CHttpCommandCodec());
-            for (Map.Entry<String, CommandInfo> entry : getAdditionalCommands().entrySet()) {
-                defineCommand(entry.getKey(), entry.getValue());
-            }
+            getAdditionalCommands().forEach(this::defineCommand);
         }
 
         return response;

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -149,8 +149,8 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
             }
         }
 
-        if (DriverCommand.NEW_SESSION.equals(command.getName()) &&
-                getCommandCodec() instanceof W3CHttpCommandCodec) {
+        if (DriverCommand.NEW_SESSION.equals(command.getName())
+                && getCommandCodec() instanceof W3CHttpCommandCodec) {
             setCommandCodec(new AppiumW3CHttpCommandCodec());
             for (Map.Entry<String, CommandInfo> entry : getAdditionalCommands().entrySet()) {
                 defineCommand(entry.getKey(), entry.getValue());

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -23,7 +23,6 @@ import static java.util.Optional.ofNullable;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 
-import io.appium.java_client.AppiumW3CHttpCommandCodec;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.CommandCodec;

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -23,17 +23,22 @@ import static java.util.Optional.ofNullable;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 
+import io.appium.java_client.AppiumW3CHttpCommandCodec;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.Command;
+import org.openqa.selenium.remote.CommandCodec;
 import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
+import org.openqa.selenium.remote.http.HttpRequest;
+import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
 import org.openqa.selenium.remote.internal.ApacheHttpClient;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.ConnectException;
 import java.net.URL;
 import java.util.Map;
@@ -74,7 +79,42 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         this(additionalCommands, service, new ApacheHttpClient.Factory());
     }
 
-    @Override public Response execute(Command command) throws WebDriverException {
+    private <B> B getPrivateFieldValue(String fieldName, Class<B> fieldType) {
+        try {
+            final Field f = getClass().getSuperclass().getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return fieldType.cast(f.get(this));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private void setPrivateFieldValue(String fieldName, Object newValue) {
+        try {
+            final Field f = getClass().getSuperclass().getDeclaredField(fieldName);
+            f.setAccessible(true);
+            f.set(this, newValue);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private Map<String, CommandInfo> getAdditionalCommands() {
+        //noinspection unchecked
+        return getPrivateFieldValue("additionalCommands", Map.class);
+    }
+
+    private CommandCodec<HttpRequest> getCommandCodec() {
+        //noinspection unchecked
+        return getPrivateFieldValue("commandCodec", CommandCodec.class);
+    }
+
+    private void setCommandCodec(CommandCodec<HttpRequest> newCodec) {
+        setPrivateFieldValue("commandCodec", newCodec);
+    }
+
+    @Override
+    public Response execute(Command command) throws WebDriverException {
         if (DriverCommand.NEW_SESSION.equals(command.getName())) {
             serviceOptional.ifPresent(driverService -> {
                 try {
@@ -85,8 +125,9 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
             });
         }
 
+        Response response;
         try {
-            return super.execute(command);
+            response = super.execute(command);
         } catch (Throwable t) {
             Throwable rootCause = Throwables.getRootCause(t);
             if (rootCause instanceof ConnectException
@@ -107,5 +148,15 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
                 serviceOptional.ifPresent(DriverService::stop);
             }
         }
+
+        if (DriverCommand.NEW_SESSION.equals(command.getName()) &&
+                getCommandCodec() instanceof W3CHttpCommandCodec) {
+            setCommandCodec(new AppiumW3CHttpCommandCodec());
+            for (Map.Entry<String, CommandInfo> entry : getAdditionalCommands().entrySet()) {
+                defineCommand(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return response;
     }
 }

--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -58,9 +58,10 @@ public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
             case IS_ELEMENT_DISPLAYED:
             case SUBMIT_ELEMENT:
             case GET_PAGE_SOURCE:
-                break;
+                return;
             default:
                 super.alias(commandName, isAnAliasFor);
+                break;
         }
     }
 

--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -31,6 +31,8 @@ import static org.openqa.selenium.remote.DriverCommand.GET_ALERT_TEXT;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_HANDLE;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_POSITION;
 import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_SIZE;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_ATTRIBUTE;
+import static org.openqa.selenium.remote.DriverCommand.GET_PAGE_SOURCE;
 import static org.openqa.selenium.remote.DriverCommand.GET_WINDOW_HANDLES;
 import static org.openqa.selenium.remote.DriverCommand.MAXIMIZE_CURRENT_WINDOW;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
@@ -47,8 +49,13 @@ public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
      * This class overrides the built-in Selenium W3C commands codec,
      * since the latter hardcodes many commands in Javascript,
      * which does not work with Appium.
+     * Check https://www.w3.org/TR/webdriver/ to see all available W3C
+     * endpoints.
      */
     public AppiumW3CHttpCommandCodec() {
+        defineCommand(GET_ELEMENT_ATTRIBUTE, get("/session/:sessionId/element/:id/attribute/:name"));
+        defineCommand(GET_PAGE_SOURCE, get("/session/:sessionId/source"));
+
         defineCommand(EXECUTE_SCRIPT, post("/session/:sessionId/execute/sync"));
         defineCommand(EXECUTE_ASYNC_SCRIPT, post("/session/:sessionId/execute/async"));
 

--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -20,27 +20,17 @@ import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
 
 import java.util.Map;
 
-import static org.openqa.selenium.remote.DriverCommand.ACCEPT_ALERT;
-import static org.openqa.selenium.remote.DriverCommand.ACTIONS;
-import static org.openqa.selenium.remote.DriverCommand.CLEAR_ACTIONS_STATE;
-import static org.openqa.selenium.remote.DriverCommand.DISMISS_ALERT;
-import static org.openqa.selenium.remote.DriverCommand.EXECUTE_ASYNC_SCRIPT;
-import static org.openqa.selenium.remote.DriverCommand.EXECUTE_SCRIPT;
-import static org.openqa.selenium.remote.DriverCommand.GET_ACTIVE_ELEMENT;
-import static org.openqa.selenium.remote.DriverCommand.GET_ALERT_TEXT;
-import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_HANDLE;
-import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_POSITION;
-import static org.openqa.selenium.remote.DriverCommand.GET_CURRENT_WINDOW_SIZE;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_ATTRIBUTE;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW;
+import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_SIZE;
 import static org.openqa.selenium.remote.DriverCommand.GET_PAGE_SOURCE;
-import static org.openqa.selenium.remote.DriverCommand.GET_WINDOW_HANDLES;
-import static org.openqa.selenium.remote.DriverCommand.MAXIMIZE_CURRENT_WINDOW;
+import static org.openqa.selenium.remote.DriverCommand.IS_ELEMENT_DISPLAYED;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ACTIVE_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.SEND_KEYS_TO_ELEMENT;
 import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_VALUE;
-import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_POSITION;
-import static org.openqa.selenium.remote.DriverCommand.SET_CURRENT_WINDOW_SIZE;
 import static org.openqa.selenium.remote.DriverCommand.SET_TIMEOUT;
+import static org.openqa.selenium.remote.DriverCommand.SUBMIT_ELEMENT;
 
 
 public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
@@ -55,31 +45,28 @@ public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
     public AppiumW3CHttpCommandCodec() {
         defineCommand(GET_ELEMENT_ATTRIBUTE, get("/session/:sessionId/element/:id/attribute/:name"));
         defineCommand(GET_PAGE_SOURCE, get("/session/:sessionId/source"));
+    }
 
-        defineCommand(EXECUTE_SCRIPT, post("/session/:sessionId/execute/sync"));
-        defineCommand(EXECUTE_ASYNC_SCRIPT, post("/session/:sessionId/execute/async"));
-
-        defineCommand(MAXIMIZE_CURRENT_WINDOW, post("/session/:sessionId/window/maximize"));
-        defineCommand(GET_CURRENT_WINDOW_SIZE, get("/session/:sessionId/window/rect"));
-        defineCommand(SET_CURRENT_WINDOW_SIZE, post("/session/:sessionId/window/rect"));
-        alias(GET_CURRENT_WINDOW_POSITION, GET_CURRENT_WINDOW_SIZE);
-        alias(SET_CURRENT_WINDOW_POSITION, SET_CURRENT_WINDOW_SIZE);
-        defineCommand(GET_CURRENT_WINDOW_HANDLE, get("/session/:sessionId/window"));
-        defineCommand(GET_WINDOW_HANDLES, get("/session/:sessionId/window/handles"));
-
-        defineCommand(ACCEPT_ALERT, post("/session/:sessionId/alert/accept"));
-        defineCommand(DISMISS_ALERT, post("/session/:sessionId/alert/dismiss"));
-        defineCommand(GET_ALERT_TEXT, get("/session/:sessionId/alert/text"));
-        defineCommand(SET_ALERT_VALUE, post("/session/:sessionId/alert/text"));
-
-        defineCommand(GET_ACTIVE_ELEMENT, get("/session/:sessionId/element/active"));
-
-        defineCommand(ACTIONS, post("/session/:sessionId/actions"));
-        defineCommand(CLEAR_ACTIONS_STATE, delete("/session/:sessionId/actions"));
+    @Override
+    public void alias(String commandName, String isAnAliasFor) {
+        // This blocks parent constructor from undesirable aliases assigning
+        switch (commandName) {
+            case GET_ELEMENT_ATTRIBUTE:
+            case GET_ELEMENT_LOCATION:
+            case GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW:
+            case GET_ELEMENT_SIZE:
+            case IS_ELEMENT_DISPLAYED:
+            case SUBMIT_ELEMENT:
+            case GET_PAGE_SOURCE:
+                break;
+            default:
+                super.alias(commandName, isAnAliasFor);
+        }
     }
 
     @Override
     protected Map<String, ?> amendParameters(String name, Map<String, ?> parameters) {
+        // This blocks parent constructor from undesirable parameters amending
         switch (name) {
             case SEND_KEYS_TO_ACTIVE_ELEMENT:
             case SEND_KEYS_TO_ELEMENT:

--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.appium.java_client;
+package io.appium.java_client.remote;
 
 import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
 


### PR DESCRIPTION
## Change list

This is kind of dirty hack to make W3C protocol working properly with Appium. Currently Selenium has a bunch of hardcoded javascript snippets there, which are not going to work in mobile env. I'm also not sure how this is going to work in web context.

Perhaps, @TikhomirovSergey, you'll have better ideas on how to improve it. Check the recent conversation in java_client Slack group for more details.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)