### PR TITLE
Add a handler for isDispalyed endpoint in W3C mode

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -44,6 +44,7 @@ public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
      */
     public AppiumW3CHttpCommandCodec() {
         defineCommand(GET_ELEMENT_ATTRIBUTE, get("/session/:sessionId/element/:id/attribute/:name"));
+        defineCommand(IS_ELEMENT_DISPLAYED, get("/session/:sessionId/element/:id/displayed"));
         defineCommand(GET_PAGE_SOURCE, get("/session/:sessionId/source"));
     }
 


### PR DESCRIPTION
## Change list

Add missing handler for `isDisplayed` endpoint , which is missing in W3C mode. In the original codec it's replaced with executeScript alias.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
