### PR TITLE
Fix checkstyle violations

### DIFF
--- a/google-style.xml
+++ b/google-style.xml
@@ -163,7 +163,6 @@
             <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">

--- a/google-style.xml
+++ b/google-style.xml
@@ -177,9 +177,7 @@
             <property name="allowSamelineMultipleAnnotations" value="true"/>
         </module>
         <module name="NonEmptyAtclauseDescription"/>
-        <module name="JavadocTagContinuationIndentation">
-            <property name="severity" value="warning"/>
-        </module>
+        <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>

--- a/google-style.xml
+++ b/google-style.xml
@@ -182,7 +182,6 @@
         </module>
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
-            <property name="severity" value="warning"/>
         </module>
         <module name="JavadocParagraph">
             <property name="severity" value="warning"/>

--- a/src/main/java/io/appium/java_client/InteractsWithApps.java
+++ b/src/main/java/io/appium/java_client/InteractsWithApps.java
@@ -29,15 +29,16 @@ import static io.appium.java_client.MobileCommand.TERMINATE_APP;
 import static io.appium.java_client.MobileCommand.prepareArguments;
 
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.appmanagement.ApplicationState;
 import io.appium.java_client.appmanagement.BaseActivateApplicationOptions;
 import io.appium.java_client.appmanagement.BaseInstallApplicationOptions;
 import io.appium.java_client.appmanagement.BaseRemoveApplicationOptions;
 import io.appium.java_client.appmanagement.BaseTerminateApplicationOptions;
 
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.AbstractMap;
+import javax.annotation.Nullable;
 
 public interface InteractsWithApps extends ExecutesMethod {
 

--- a/src/main/java/io/appium/java_client/LocksDevice.java
+++ b/src/main/java/io/appium/java_client/LocksDevice.java
@@ -16,11 +16,11 @@
 
 package io.appium.java_client;
 
-import java.time.Duration;
-
 import static io.appium.java_client.MobileCommand.getIsDeviceLockedCommand;
 import static io.appium.java_client.MobileCommand.lockDeviceCommand;
 import static io.appium.java_client.MobileCommand.unlockDeviceCommand;
+
+import java.time.Duration;
 
 public interface LocksDevice extends ExecutesMethod {
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidStartScreenRecordingOptions.java
+++ b/src/main/java/io/appium/java_client/android/AndroidStartScreenRecordingOptions.java
@@ -16,13 +16,14 @@
 
 package io.appium.java_client.android;
 
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.screenrecording.BaseStartScreenRecordingOptions;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static java.util.Optional.ofNullable;
 
 public class AndroidStartScreenRecordingOptions
         extends BaseStartScreenRecordingOptions<AndroidStartScreenRecordingOptions> {

--- a/src/main/java/io/appium/java_client/android/SupportsNetworkStateManagement.java
+++ b/src/main/java/io/appium/java_client/android/SupportsNetworkStateManagement.java
@@ -1,11 +1,11 @@
 package io.appium.java_client.android;
 
-import io.appium.java_client.CommandExecutionHelper;
-import io.appium.java_client.ExecutesMethod;
-
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleAirplaneCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleDataCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleWifiCommand;
+
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
 
 public interface SupportsNetworkStateManagement extends ExecutesMethod {
 

--- a/src/main/java/io/appium/java_client/android/SupportsNetworkStateManagement.java
+++ b/src/main/java/io/appium/java_client/android/SupportsNetworkStateManagement.java
@@ -10,15 +10,14 @@ import io.appium.java_client.ExecutesMethod;
 public interface SupportsNetworkStateManagement extends ExecutesMethod {
 
     /**
-     * Toggles Wifi on and off
+     * Toggles Wifi on and off.
      */
     default void toggleWifi() {
         CommandExecutionHelper.execute(this, toggleWifiCommand());
     }
 
     /**
-     * Toggle Airplane mode and this works
-     * on OS 6.0 and lesser
+     * Toggle Airplane mode and this works on OS 6.0 and lesser
      * and does not work on OS 7.0 and greater
      */
     default void toggleAirplaneMode() {
@@ -26,8 +25,7 @@ public interface SupportsNetworkStateManagement extends ExecutesMethod {
     }
 
     /**
-     * Toggle Mobile Data and this works on Emulator
-     * and rooted device
+     * Toggle Mobile Data and this works on Emulator and rooted device.
      */
     default void toggleData() {
         CommandExecutionHelper.execute(this, toggleDataCommand());

--- a/src/main/java/io/appium/java_client/android/appmanagement/AndroidInstallApplicationOptions.java
+++ b/src/main/java/io/appium/java_client/android/appmanagement/AndroidInstallApplicationOptions.java
@@ -16,15 +16,16 @@
 
 package io.appium.java_client.android.appmanagement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.appmanagement.BaseInstallApplicationOptions;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public class AndroidInstallApplicationOptions extends
         BaseInstallApplicationOptions<AndroidInstallApplicationOptions> {

--- a/src/main/java/io/appium/java_client/android/appmanagement/AndroidRemoveApplicationOptions.java
+++ b/src/main/java/io/appium/java_client/android/appmanagement/AndroidRemoveApplicationOptions.java
@@ -16,15 +16,16 @@
 
 package io.appium.java_client.android.appmanagement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.appmanagement.BaseRemoveApplicationOptions;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public class AndroidRemoveApplicationOptions extends
         BaseRemoveApplicationOptions<AndroidRemoveApplicationOptions> {

--- a/src/main/java/io/appium/java_client/android/appmanagement/AndroidTerminateApplicationOptions.java
+++ b/src/main/java/io/appium/java_client/android/appmanagement/AndroidTerminateApplicationOptions.java
@@ -16,15 +16,16 @@
 
 package io.appium.java_client.android.appmanagement;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.appmanagement.BaseTerminateApplicationOptions;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public class AndroidTerminateApplicationOptions extends
         BaseTerminateApplicationOptions<AndroidTerminateApplicationOptions> {

--- a/src/main/java/io/appium/java_client/ios/IOSStartScreenRecordingOptions.java
+++ b/src/main/java/io/appium/java_client/ios/IOSStartScreenRecordingOptions.java
@@ -16,14 +16,15 @@
 
 package io.appium.java_client.ios;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
+
 import io.appium.java_client.screenrecording.BaseStartScreenRecordingOptions;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public class IOSStartScreenRecordingOptions
         extends BaseStartScreenRecordingOptions<IOSStartScreenRecordingOptions> {

--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -16,10 +16,6 @@
 
 package io.appium.java_client.remote;
 
-import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
-
-import java.util.Map;
-
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_ATTRIBUTE;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION;
 import static org.openqa.selenium.remote.DriverCommand.GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW;
@@ -32,6 +28,9 @@ import static org.openqa.selenium.remote.DriverCommand.SET_ALERT_VALUE;
 import static org.openqa.selenium.remote.DriverCommand.SET_TIMEOUT;
 import static org.openqa.selenium.remote.DriverCommand.SUBMIT_ELEMENT;
 
+import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
+
+import java.util.Map;
 
 public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
 

--- a/src/main/java/io/appium/java_client/screenrecording/BaseScreenRecordingOptions.java
+++ b/src/main/java/io/appium/java_client/screenrecording/BaseScreenRecordingOptions.java
@@ -16,12 +16,12 @@
 
 package io.appium.java_client.screenrecording;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public abstract class BaseScreenRecordingOptions<T extends BaseScreenRecordingOptions<T>> {
     private ScreenRecordingUploadOptions uploadOptions;

--- a/src/main/java/io/appium/java_client/screenrecording/BaseStartScreenRecordingOptions.java
+++ b/src/main/java/io/appium/java_client/screenrecording/BaseStartScreenRecordingOptions.java
@@ -16,13 +16,13 @@
 
 package io.appium.java_client.screenrecording;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
 
 import java.time.Duration;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public abstract class BaseStartScreenRecordingOptions<T extends BaseStartScreenRecordingOptions<T>>
         extends BaseScreenRecordingOptions<BaseStartScreenRecordingOptions<T>> {

--- a/src/main/java/io/appium/java_client/screenrecording/CanRecordScreen.java
+++ b/src/main/java/io/appium/java_client/screenrecording/CanRecordScreen.java
@@ -32,7 +32,7 @@ public interface CanRecordScreen extends ExecutesMethod {
      * @param options see the documentation on the {@link BaseStartScreenRecordingOptions}
      *                descendant for the particular platform.
      * @return Base-64 encoded content of the recorded media file or an empty string
-     * if the file has been successfully uploaded to a remote location (depends on the actual options).
+     *     if the file has been successfully uploaded to a remote location (depends on the actual options).
      */
     default <T extends BaseStartScreenRecordingOptions> String startRecordingScreen(T options) {
         return CommandExecutionHelper.execute(this, startRecordingScreenCommand(options));
@@ -53,7 +53,7 @@ public interface CanRecordScreen extends ExecutesMethod {
      * @param options see the documentation on the {@link BaseStopScreenRecordingOptions}
      *                descendant for the particular platform.
      * @return Base-64 encoded content of the recorded media file or an empty string
-     * if the file has been successfully uploaded to a remote location (depends on the actual options).
+     *     if the file has been successfully uploaded to a remote location (depends on the actual options).
      */
     default <T extends BaseStopScreenRecordingOptions> String stopRecordingScreen(T options) {
         return CommandExecutionHelper.execute(this, stopRecordingScreenCommand(options));

--- a/src/main/java/io/appium/java_client/screenrecording/CanRecordScreen.java
+++ b/src/main/java/io/appium/java_client/screenrecording/CanRecordScreen.java
@@ -16,14 +16,13 @@
 
 package io.appium.java_client.screenrecording;
 
-import io.appium.java_client.CommandExecutionHelper;
-import io.appium.java_client.ExecutesMethod;
-
 import static io.appium.java_client.MobileCommand.START_RECORDING_SCREEN;
-import static io.appium.java_client.MobileCommand.startRecordingScreenCommand;
 import static io.appium.java_client.MobileCommand.STOP_RECORDING_SCREEN;
+import static io.appium.java_client.MobileCommand.startRecordingScreenCommand;
 import static io.appium.java_client.MobileCommand.stopRecordingScreenCommand;
 
+import io.appium.java_client.CommandExecutionHelper;
+import io.appium.java_client.ExecutesMethod;
 
 public interface CanRecordScreen extends ExecutesMethod {
 

--- a/src/main/java/io/appium/java_client/screenrecording/ScreenRecordingUploadOptions.java
+++ b/src/main/java/io/appium/java_client/screenrecording/ScreenRecordingUploadOptions.java
@@ -16,12 +16,12 @@
 
 package io.appium.java_client.screenrecording;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.Optional.ofNullable;
 
 public class ScreenRecordingUploadOptions {
     private String remotePath;

--- a/src/test/java/io/appium/java_client/android/AndroidScreenRecordTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidScreenRecordTest.java
@@ -1,14 +1,14 @@
 package io.appium.java_client.android;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.WebDriverException;
 
 import java.time.Duration;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
 
 public class AndroidScreenRecordTest extends BaseAndroidTest {
 

--- a/src/test/java/io/appium/java_client/ios/IOSScreenRecordTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSScreenRecordTest.java
@@ -1,12 +1,12 @@
 package io.appium.java_client.ios;
 
-import org.junit.Test;
-
-import java.time.Duration;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
+
+import org.junit.Test;
+
+import java.time.Duration;
 
 public class IOSScreenRecordTest extends AppIOSTest {
 


### PR DESCRIPTION
## Change list

- Fix `CustomImportOrder` checkstyle violations
- Change severity of `CustomImportOrder` checkstyle rule from `warning` to default (`error`)
- Fix `SummaryJavadoc` checkstyle violations
- Change severity of `SummaryJavadoc` checkstyle rule from `warning` to default (`error`)
- Fix `JavadocTagContinuationIndentation` checkstyle violations
- Change severity of `JavadocTagContinuationIndentation` checkstyle rule from `warning` to default (`error`)

 
## Types of changes

- [X] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
