### PR TITLE
Avoid amending parameters for SET_ALERT_VALUE endpoint

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumW3CHttpCommandCodec.java
@@ -71,7 +71,6 @@ public class AppiumW3CHttpCommandCodec extends W3CHttpCommandCodec {
         switch (name) {
             case SEND_KEYS_TO_ACTIVE_ELEMENT:
             case SEND_KEYS_TO_ELEMENT:
-            case SET_ALERT_VALUE:
             case SET_TIMEOUT:
                 return super.amendParameters(name, parameters);
             default:


### PR DESCRIPTION
## Change list

The previous implementation was crashing in W3C mode, since we always only set `value` argument and selenium hook expects `text` to be set as well while performing parameters amend. W3C spec itself only has `value` description.

## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

