### PR TITLE
Addition to #846 and #855:

### DIFF
--- a/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
+++ b/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
@@ -61,7 +61,7 @@ public interface HasClipboard extends ExecutesMethod {
      */
     default void setClipboardText(String text) {
         setClipboard(ClipboardContentType.PLAINTEXT, Base64
-                .getEncoder()
+                .getMimeEncoder()
                 .encode(text.getBytes(StandardCharsets.UTF_8)));
     }
 

--- a/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
+++ b/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
@@ -72,7 +72,7 @@ public interface HasClipboard extends ExecutesMethod {
      */
     default String getClipboardText() {
         byte[] base64decodedBytes = Base64
-                .getDecoder()
+                .getMimeDecoder()
                 .decode(getClipboard(ClipboardContentType.PLAINTEXT));
         return new String(base64decodedBytes, StandardCharsets.UTF_8);
     }

--- a/src/main/java/io/appium/java_client/ios/HasIOSClipboard.java
+++ b/src/main/java/io/appium/java_client/ios/HasIOSClipboard.java
@@ -42,7 +42,7 @@ public interface HasIOSClipboard extends HasClipboard {
         try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             ImageIO.write(checkNotNull(img), "png", os);
             setClipboard(ClipboardContentType.IMAGE, Base64
-                    .getEncoder()
+                    .getMimeEncoder()
                     .encode(os.toByteArray()));
         }
     }
@@ -55,7 +55,7 @@ public interface HasIOSClipboard extends HasClipboard {
      */
     default BufferedImage getClipboardImage() throws IOException {
         final byte[] base64decodedBytes = Base64
-                .getDecoder()
+                .getMimeDecoder()
                 .decode(getClipboard(ClipboardContentType.IMAGE));
         return ImageIO.read(new ByteArrayInputStream(base64decodedBytes));
     }
@@ -67,7 +67,7 @@ public interface HasIOSClipboard extends HasClipboard {
      */
     default void setClipboardUrl(URL url) {
         setClipboard(ClipboardContentType.URL, Base64
-                .getEncoder()
+                .getMimeEncoder()
                 .encode(checkNotNull(url).toString().getBytes(StandardCharsets.UTF_8)));
     }
 
@@ -79,7 +79,7 @@ public interface HasIOSClipboard extends HasClipboard {
      */
     default URL getClipboardUrl() throws MalformedURLException {
         final byte[] base64decodedBytes = Base64
-                .getDecoder()
+                .getMimeDecoder()
                 .decode(getClipboard(ClipboardContentType.URL));
         return new URL(new String(base64decodedBytes, StandardCharsets.UTF_8));
     }

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -33,7 +33,7 @@ import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
-import org.openqa.selenium.remote.internal.ApacheHttpClient;
+import org.openqa.selenium.remote.internal.OkHttpClient;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.IOException;
@@ -70,12 +70,12 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
 
     public AppiumCommandExecutor(Map<String, CommandInfo> additionalCommands,
                                  URL addressOfRemoteServer) {
-        this(additionalCommands, addressOfRemoteServer, new ApacheHttpClient.Factory());
+        this(additionalCommands, addressOfRemoteServer, new OkHttpClient.Factory());
     }
 
     public AppiumCommandExecutor(Map<String, CommandInfo> additionalCommands,
                                  DriverService service) {
-        this(additionalCommands, service, new ApacheHttpClient.Factory());
+        this(additionalCommands, service, new OkHttpClient.Factory());
     }
 
     private <B> B getPrivateFieldValue(String fieldName, Class<B> fieldType) {


### PR DESCRIPTION
## Change list

- OkHttpClient instead of ApacheHttpClient
- fix of java.lang.IllegalArgumentException: Input byte array has incorrect ending byte at...
 
## Types of changes
- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
I could reproduce `java.lang.IllegalArgumentException: Input byte array has incorrect ending byte at...` on the getting of clipboard text