### PR TITLE
Use default Selenium HTTP client factory

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -33,7 +33,6 @@ import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.remote.http.HttpRequest;
 import org.openqa.selenium.remote.http.W3CHttpCommandCodec;
-import org.openqa.selenium.remote.internal.OkHttpClient;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.IOException;
@@ -70,12 +69,12 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
 
     public AppiumCommandExecutor(Map<String, CommandInfo> additionalCommands,
                                  URL addressOfRemoteServer) {
-        this(additionalCommands, addressOfRemoteServer, new OkHttpClient.Factory());
+        this(additionalCommands, addressOfRemoteServer, HttpClient.Factory.createDefault());
     }
 
     public AppiumCommandExecutor(Map<String, CommandInfo> additionalCommands,
                                  DriverService service) {
-        this(additionalCommands, service, new OkHttpClient.Factory());
+        this(additionalCommands, service, HttpClient.Factory.createDefault());
     }
 
     private <B> B getPrivateFieldValue(String fieldName, Class<B> fieldType) {


### PR DESCRIPTION
## Change list

Use default Selenium HTTP client factory instead of its particular implementation.
 
## Types of changes

- [ ] No changes in production code.
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Usage of default Selenium HTTP client factory brings required level of abstraction, clients rely on the same mechanism as for Selenium WD while choosing HTTP client. The implementation used can be changed by setting the `webdriver.http.factory` system property.
