### PR TITLE
Use hamcrest-library instead of hamcrest-all dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     compile 'org.glassfish.tyrus:tyrus-container-grizzly:1.1'
     
     testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 ext {


### PR DESCRIPTION
## Change list

Use hamcrest-library instead of hamcrest-all dependency. 
 
## Types of changes

- [X] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

`hamcrest-library` is enough to cover functionality required by unit tests, while `hamcrest-all` dependency is excessive. See overview of hamcrest distributables for more details: https://code.google.com/archive/p/hamcrest/wikis/HamcrestDistributables.wiki .