### PR TITLE
Send keys helper

### DIFF
--- a/src/main/java/io/appium/java_client/android/nativekey/ASCIICharacter.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/ASCIICharacter.java
@@ -1,0 +1,549 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android.nativekey;
+
+import java.util.stream.Stream;
+
+public enum ASCIICharacter {
+    /**
+     * Null.
+     */
+    NUL,
+    /**
+     * Start of Heading (Communication Control).
+     */
+    SOH,
+    /**
+     * Start of Text (Communication Control).
+     */
+    STX,
+    /**
+     * End of Text (Communication Control).
+     */
+    ETX,
+    /**
+     * End of Transmission (Communication Control).
+     */
+    EOT,
+    /**
+     * Enquiry (Communication Control).
+     */
+    ENW,
+    /**
+     * Acknowledge (Communication Control).
+     */
+    ACK,
+    /**
+     * Bell (audible or attention signal).
+     */
+    BEL,
+    /**
+     * Backspace (Format Effector).
+     */
+    BS,
+    /**
+     * Horizontal Tabulation (punched card skip) (Format Effector).
+     */
+    HT,
+    /**
+     * Line Feed (Format Effector).
+     */
+    LF,
+    /**
+     * Vertical Tabulation (Format Effector).
+     */
+    VT,
+    /**
+     * Form Feed (Format Effector).
+     */
+    FF,
+    /**
+     * Carriage Return (Format Effector).
+     */
+    CR,
+    /**
+     * Shift Out.
+     */
+    SO,
+    /**
+     * Shift In.
+     */
+    SI,
+    /**
+     * Data Link Escape (Communication Control).
+     */
+    DLE,
+    /**
+     * Device Control 1.
+     */
+    DC1,
+    /**
+     * Device Control 2.
+     */
+    DC2,
+    /**
+     * Device Control 3.
+     */
+    DC3,
+    /**
+     * Device Control 4 (Stop).
+     */
+    DC4,
+    /**
+     * Negative Acknowledge (Communication Control).
+     */
+    NAK,
+    /**
+     * Synchronous Idle (Communication Control).
+     */
+    SYN,
+    /**
+     * End of Transmission Block (Communication Control).
+     */
+    ETB,
+    /**
+     * Cancel.
+     */
+    CAN,
+    /**
+     * End of Medium.
+     */
+    EM,
+    /**
+     * Substitute.
+     */
+    SUB,
+    /**
+     * Escape.
+     */
+    ESC,
+    /**
+     * File Separator (Information Separator).
+     */
+    FS,
+    /**
+     * Group Separator (Information Separator).
+     */
+    GS,
+    /**
+     * Record Separator (Information Separator).
+     */
+    RS,
+    /**
+     * Unit Separator (Information Separator).
+     */
+    US,
+    /**
+     * Space (Normally Non-Printing).
+     */
+    SPACE,
+    /**
+     * Exclamation Point.
+     */
+    EXCLAMATION_POINT,
+    /**
+     * Quotation Marks.
+     */
+    QUOTATION_MARKS,
+    /**
+     * Number Sign.
+     */
+    NUMBER_SIGN,
+    /**
+     * Dollar Sign.
+     */
+    DOLLAR_SIGN,
+    /**
+     * Percent.
+     */
+    PERCENT,
+    /**
+     * Ampersand.
+     */
+    AMPERSAND,
+    /**
+     * Apostrophe.
+     */
+    APOSTROPHE,
+    /**
+     * Opening Parenthesis.
+     */
+    OPENING_PARENTHESIS,
+    /**
+     * Closing Parenthesis.
+     */
+    CLOSING_PARENTHESIS,
+    /**
+     * Asterisk.
+     */
+    ASTERISK,
+    /**
+     * Plus.
+     */
+    PLUS,
+    /**
+     * Comma.
+     */
+    COMMA,
+    /**
+     * Hyphen (Minus).
+     */
+    HYPHEN,
+    /**
+     * Period (Decimal Point).
+     */
+    PERIOD,
+    /**
+     * Slant.
+     */
+    SLANT,
+    /**
+     * '0'.
+     */
+    DIGIT_0,
+    /**
+     * '1'.
+     */
+    DIGIT_1,
+    /**
+     * '2'.
+     */
+    DIGIT_2,
+    /**
+     * '3'.
+     */
+    DIGIT_3,
+    /**
+     * '4'.
+     */
+    DIGIT_4,
+    /**
+     * '5'.
+     */
+    DIGIT_5,
+    /**
+     * '6'.
+     */
+    DIGIT_6,
+    /**
+     * '7'.
+     */
+    DIGIT_7,
+    /**
+     * '8'.
+     */
+    DIGIT_8,
+    /**
+     * '9'.
+     */
+    DIGIT_9,
+    /**
+     * Colon.
+     */
+    COLON,
+    /**
+     * Semicolon.
+     */
+    SEMICOLON,
+    /**
+     * Less Than.
+     */
+    LESS_THAN,
+    /**
+     * Equals.
+     */
+    EQUALS,
+    /**
+     * Greater Than.
+     */
+    GREATER_THAN,
+    /**
+     * Question Mark.
+     */
+    QUESTION_MARK,
+    /**
+     * Commercial At.
+     */
+    COMMERCIAL_AT,
+    /**
+     * 'A'.
+     */
+    UPPERCASE_A,
+    /**
+     * 'B'.
+     */
+    UPPERCASE_B,
+    /**
+     * 'C'.
+     */
+    UPPERCASE_C,
+    /**
+     * 'D'.
+     */
+    UPPERCASE_D,
+    /**
+     * 'E'.
+     */
+    UPPERCASE_E,
+    /**
+     * 'F'.
+     */
+    UPPERCASE_F,
+    /**
+     * 'G'.
+     */
+    UPPERCASE_G,
+    /**
+     * 'H'.
+     */
+    UPPERCASE_H,
+    /**
+     * 'I'.
+     */
+    UPPERCASE_I,
+    /**
+     * 'J'.
+     */
+    UPPERCASE_J,
+    /**
+     * 'K'.
+     */
+    UPPERCASE_K,
+    /**
+     * 'L'.
+     */
+    UPPERCASE_L,
+    /**
+     * 'M'.
+     */
+    UPPERCASE_M,
+    /**
+     * 'N'.
+     */
+    UPPERCASE_N,
+    /**
+     * 'O'.
+     */
+    UPPERCASE_O,
+    /**
+     * 'P'.
+     */
+    UPPERCASE_P,
+    /**
+     * 'Q'.
+     */
+    UPPERCASE_Q,
+    /**
+     * 'R'.
+     */
+    UPPERCASE_R,
+    /**
+     * 'S'.
+     */
+    UPPERCASE_S,
+    /**
+     * 'T'.
+     */
+    UPPERCASE_T,
+    /**
+     * 'U'.
+     */
+    UPPERCASE_U,
+    /**
+     * 'V'.
+     */
+    UPPERCASE_V,
+    /**
+     * 'W'.
+     */
+    UPPERCASE_W,
+    /**
+     * 'X'.
+     */
+    UPPERCASE_X,
+    /**
+     * 'Y'.
+     */
+    UPPERCASE_Y,
+    /**
+     * 'Z'.
+     */
+    UPPERCASE_Z,
+    /**
+     * Opening Bracket.
+     */
+    OPENING_BRACKET,
+    /**
+     * Reverse Slant.
+     */
+    REVERSE_SLANT,
+    /**
+     * Closing Bracket.
+     */
+    CLOSING_BRACKET,
+    /**
+     * Circumflex.
+     */
+    CIRCUMFLEX,
+    /**
+     * Underline.
+     */
+    UNDERLINE,
+    /**
+     * Grave Accent (Opening Single Quotation Mark).
+     */
+    GRAVE_ACCENT,
+    /**
+     * 'a'.
+     */
+    LOWERCASE_A,
+    /**
+     * 'b'.
+     */
+    LOWERCASE_B,
+    /**
+     * 'c'.
+     */
+    LOWERCASE_C,
+    /**
+     * 'd'.
+     */
+    LOWERCASE_D,
+    /**
+     * 'e'.
+     */
+    LOWERCASE_E,
+    /**
+     * 'f'.
+     */
+    LOWERCASE_F,
+    /**
+     * 'g'.
+     */
+    LOWERCASE_G,
+    /**
+     * 'h'.
+     */
+    LOWERCASE_H,
+    /**
+     * 'i'.
+     */
+    LOWERCASE_I,
+    /**
+     * 'j'.
+     */
+    LOWERCASE_J,
+    /**
+     * 'k'.
+     */
+    LOWERCASE_K,
+    /**
+     * 'l'.
+     */
+    LOWERCASE_L,
+    /**
+     * 'm'.
+     */
+    LOWERCASE_M,
+    /**
+     * 'n'.
+     */
+    LOWERCASE_N,
+    /**
+     * 'o'.
+     */
+    LOWERCASE_O,
+    /**
+     * 'p'.
+     */
+    LOWERCASE_P,
+    /**
+     * 'q'.
+     */
+    LOWERCASE_Q,
+    /**
+     * 'r'.
+     */
+    LOWERCASE_R,
+    /**
+     * 's'.
+     */
+    LOWERCASE_S,
+    /**
+     * 't'.
+     */
+    LOWERCASE_T,
+    /**
+     * 'u'.
+     */
+    LOWERCASE_U,
+    /**
+     * 'v'.
+     */
+    LOWERCASE_V,
+    /**
+     * 'w'.
+     */
+    LOWERCASE_W,
+    /**
+     * 'x'.
+     */
+    LOWERCASE_X,
+    /**
+     * 'y'.
+     */
+    LOWERCASE_Y,
+    /**
+     * 'z'.
+     */
+    LOWERCASE_Z,
+    /**
+     * Opening Brace.
+     */
+    OPENING_BRACE,
+    /**
+     * Vertical Line.
+     */
+    VERTICAL_LINE,
+    /**
+     * Closing Brace.
+     */
+    CLOSING_BRACE,
+    /**
+     * Tilde.
+     */
+    TILDE,
+    /**
+     * Delete.
+     */
+    DEL;
+
+    /**
+     * Creates ASCII character instance based on its code.
+     *
+     * @param codePoint The code of the character.
+     * @return Character instance.
+     * @throws IllegalArgumentException if the ASCII char with the given code point is unknown.
+     */
+    public static ASCIICharacter fromCode(int codePoint) {
+        return Stream.of(ASCIICharacter.values())
+                .filter(x -> x.ordinal() == codePoint)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("ASCII character with code %d does not exist", codePoint)));
+    }
+}

--- a/src/main/java/io/appium/java_client/android/nativekey/AndroidKey.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/AndroidKey.java
@@ -1,5 +1,7 @@
 package io.appium.java_client.android.nativekey;
 
+import java.util.stream.Stream;
+
 public enum AndroidKey {
     /**
      * Key code constant: Unknown key code.
@@ -1287,6 +1289,22 @@ public enum AndroidKey {
 
     public int getCode() {
         return code;
+    }
+
+    /**
+     * creates the corresponding AndroidKey instance for
+     * the given key code.
+     *
+     * @param code the actual key code
+     * @return AndroidKey instance
+     * @throws IllegalArgumentException if the ASCII char with the given code point is unknown.
+     */
+    public static AndroidKey fromCode(int code) {
+        return Stream.of(AndroidKey.values())
+                .filter(x -> x.getCode() == code)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("Android key with code %d is unknown", code)));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
@@ -64,7 +64,7 @@ public class KeyActionsHelpers {
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.LESS_THAN, new KeyEvent(AndroidKey.COMMA)
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
-        ASCII_CHARS_MAPPING.put(ASCIICharacter.GREATER_THAN, new KeyEvent(AndroidKey.NUMPAD_DOT)
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.GREATER_THAN, new KeyEvent(AndroidKey.PERIOD)
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.DOLLAR_SIGN, new KeyEvent(AndroidKey.DIGIT_4)
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
@@ -59,7 +59,7 @@ public class KeyActionsHelpers {
         ASCII_CHARS_MAPPING.put(ASCIICharacter.SLANT, new KeyEvent(AndroidKey.SLASH));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.SPACE, new KeyEvent(AndroidKey.SPACE));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.EXCLAMATION_POINT, new KeyEvent(AndroidKey.DIGIT_1)
-            .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.COLON, new KeyEvent(AndroidKey.SEMICOLON)
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.LESS_THAN, new KeyEvent(AndroidKey.COMMA)
@@ -112,6 +112,7 @@ public class KeyActionsHelpers {
      * @return The altered actions.
      */
     public static Actions sendNativeKeys(Actions actions, String str) {
+        Actions result = actions;
         final int length = str.length();
         for (int offset = 0; offset < length; ) {
             final int codePoint = str.codePointAt(offset);
@@ -123,21 +124,20 @@ public class KeyActionsHelpers {
             //noinspection ConstantConditions
             final String keyCode = new String(Character.toChars(keyEvent.getKeyCode()));
             if (keyEvent.getMetaState() == null) {
-                actions = actions.keyDown(keyCode);
-                actions = actions.keyUp(keyCode);
+                result = result
+                        .keyDown(keyCode)
+                        .keyUp(keyCode);
             } else {
                 final String metaCode = new String(Character
                         .toChars(META_CODES_SHIFT + keyEvent.getMetaState()));
-                actions = actions.keyDown(metaCode);
-
-                actions = actions.keyDown(keyCode);
-                actions = actions.keyUp(keyCode);
-
-                actions = actions.keyUp(metaCode);
+                result = result.keyDown(metaCode)
+                        .keyDown(keyCode)
+                        .keyUp(keyCode)
+                        .keyUp(metaCode);
             }
             offset += Character.charCount(codePoint);
         }
-        return actions;
+        return result;
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
@@ -82,6 +82,10 @@ public class KeyActionsHelpers {
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
         ASCII_CHARS_MAPPING.put(ASCIICharacter.CIRCUMFLEX, new KeyEvent(AndroidKey.DIGIT_6)
                 .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.VERTICAL_LINE, new KeyEvent(AndroidKey.BACKSLASH)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.QUOTATION_MARKS, new KeyEvent(AndroidKey.APOSTROPHE)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
 
         IntStream.rangeClosed(ASCIICharacter.DIGIT_0.ordinal(), ASCIICharacter.DIGIT_9.ordinal())
                 .forEach(x -> ASCII_CHARS_MAPPING.put(ASCIICharacter.fromCode(x),

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
@@ -116,6 +116,7 @@ public class KeyActionsHelpers {
         final int length = str.length();
         for (int offset = 0; offset < length; ) {
             final int codePoint = str.codePointAt(offset);
+            offset += Character.charCount(codePoint);
             final KeyEvent keyEvent = toKeyEvent(codePoint);
             if (keyEvent == null) {
                 continue;
@@ -135,7 +136,6 @@ public class KeyActionsHelpers {
                         .keyUp(keyCode)
                         .keyUp(metaCode);
             }
-            offset += Character.charCount(codePoint);
         }
         return result;
     }

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyActionsHelpers.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.android.nativekey;
+
+import org.openqa.selenium.interactions.Actions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+
+public class KeyActionsHelpers {
+    private static final Map<ASCIICharacter, KeyEvent> ASCII_CHARS_MAPPING = new HashMap<>();
+    /**
+     * It is necessary to shift the meta codes to avoid
+     * unexpected matches with key codes.
+     * Unfortunately there is no other way to distinguish
+     * key codes from meta codes, since W3C standard only provides a single field
+     * to keep the code value.
+     */
+    public static final int META_CODES_SHIFT = 0x1000;
+
+    static {
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.BS, new KeyEvent(AndroidKey.DEL));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.HT, new KeyEvent(AndroidKey.TAB));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.LF, new KeyEvent(AndroidKey.ENTER));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.ESC, new KeyEvent(AndroidKey.ESCAPE));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.DEL, new KeyEvent(AndroidKey.FORWARD_DEL));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.APOSTROPHE, new KeyEvent(AndroidKey.APOSTROPHE));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.ASTERISK, new KeyEvent(AndroidKey.STAR));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.CLOSING_BRACKET, new KeyEvent(AndroidKey.RIGHT_BRACKET));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.CLOSING_PARENTHESIS, new KeyEvent(AndroidKey.NUMPAD_RIGHT_PAREN));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.COMMA, new KeyEvent(AndroidKey.COMMA));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.COMMERCIAL_AT, new KeyEvent(AndroidKey.AT));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.EQUALS, new KeyEvent(AndroidKey.EQUALS));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.GRAVE_ACCENT, new KeyEvent(AndroidKey.GRAVE));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.HYPHEN, new KeyEvent(AndroidKey.MINUS));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.NUMBER_SIGN, new KeyEvent(AndroidKey.POUND));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.OPENING_BRACKET, new KeyEvent(AndroidKey.LEFT_BRACKET));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.OPENING_PARENTHESIS, new KeyEvent(AndroidKey.NUMPAD_LEFT_PAREN));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.PERIOD, new KeyEvent(AndroidKey.PERIOD));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.PLUS, new KeyEvent(AndroidKey.PLUS));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.REVERSE_SLANT, new KeyEvent(AndroidKey.BACKSLASH));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.SEMICOLON, new KeyEvent(AndroidKey.SEMICOLON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.SLANT, new KeyEvent(AndroidKey.SLASH));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.SPACE, new KeyEvent(AndroidKey.SPACE));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.EXCLAMATION_POINT, new KeyEvent(AndroidKey.DIGIT_1)
+            .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.COLON, new KeyEvent(AndroidKey.SEMICOLON)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.LESS_THAN, new KeyEvent(AndroidKey.COMMA)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.GREATER_THAN, new KeyEvent(AndroidKey.NUMPAD_DOT)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.DOLLAR_SIGN, new KeyEvent(AndroidKey.DIGIT_4)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.PERCENT, new KeyEvent(AndroidKey.DIGIT_5)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.AMPERSAND, new KeyEvent(AndroidKey.DIGIT_7)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.QUESTION_MARK, new KeyEvent(AndroidKey.SLASH)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.OPENING_BRACE, new KeyEvent(AndroidKey.LEFT_BRACKET)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.CLOSING_BRACE, new KeyEvent(AndroidKey.RIGHT_BRACKET)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.UNDERLINE, new KeyEvent(AndroidKey.MINUS)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+        ASCII_CHARS_MAPPING.put(ASCIICharacter.CIRCUMFLEX, new KeyEvent(AndroidKey.DIGIT_6)
+                .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+
+        IntStream.rangeClosed(ASCIICharacter.DIGIT_0.ordinal(), ASCIICharacter.DIGIT_9.ordinal())
+                .forEach(x -> ASCII_CHARS_MAPPING.put(ASCIICharacter.fromCode(x),
+                        new KeyEvent(AndroidKey
+                                .fromCode(AndroidKey.DIGIT_0.getCode() + x - ASCIICharacter.DIGIT_0.ordinal()))));
+        IntStream.rangeClosed(ASCIICharacter.LOWERCASE_A.ordinal(), ASCIICharacter.LOWERCASE_Z.ordinal())
+                .forEach(x -> ASCII_CHARS_MAPPING.put(ASCIICharacter.fromCode(x),
+                        new KeyEvent(AndroidKey
+                                .fromCode(AndroidKey.A.getCode() + x - ASCIICharacter.LOWERCASE_A.ordinal()))));
+        //noinspection ConstantConditions
+        IntStream.rangeClosed(ASCIICharacter.UPPERCASE_A.ordinal(), ASCIICharacter.UPPERCASE_Z.ordinal())
+                .forEach(x -> ASCII_CHARS_MAPPING.put(ASCIICharacter.fromCode(x),
+                        new KeyEvent(AndroidKey
+                                .fromCode(AndroidKey.A.getCode() + x - ASCIICharacter.UPPERCASE_A.ordinal())))
+                        .withMetaModifier(KeyEventMetaModifier.SHIFT_ON));
+    }
+
+    /**
+     * Creates an action chain for sending key codes to Android
+     * via W3C actions. The normal sendKeys routine won't work there,
+     * since Android key codes are different from ASCII key codes used
+     * by browsers.
+     *
+     * @param actions W3C actions instance
+     * @param str     The actual string to type. Not all characters are
+     *                going to be transformed, but only these, that are present
+     *                in ASCII_CHARS_MAPPING.
+     * @return The altered actions.
+     */
+    public static Actions sendNativeKeys(Actions actions, String str) {
+        final int length = str.length();
+        for (int offset = 0; offset < length; ) {
+            final int codePoint = str.codePointAt(offset);
+            final KeyEvent keyEvent = toKeyEvent(codePoint);
+            if (keyEvent == null) {
+                continue;
+            }
+
+            //noinspection ConstantConditions
+            final String keyCode = new String(Character.toChars(keyEvent.getKeyCode()));
+            if (keyEvent.getMetaState() == null) {
+                actions = actions.keyDown(keyCode);
+                actions = actions.keyUp(keyCode);
+            } else {
+                final String metaCode = new String(Character
+                        .toChars(META_CODES_SHIFT + keyEvent.getMetaState()));
+                actions = actions.keyDown(metaCode);
+
+                actions = actions.keyDown(keyCode);
+                actions = actions.keyUp(keyCode);
+
+                actions = actions.keyUp(metaCode);
+            }
+            offset += Character.charCount(codePoint);
+        }
+        return actions;
+    }
+
+    /**
+     * Transforms the given code point to the native key event.
+     *
+     * @param codePoint The actual code point.
+     * @return KeyEvent instance or null if no match can be found for the given code point.
+     */
+    @Nullable
+    public static KeyEvent toKeyEvent(int codePoint) {
+        return ASCII_CHARS_MAPPING.keySet().stream()
+                .filter(x -> x.ordinal() == codePoint)
+                .findFirst()
+                .map(ASCII_CHARS_MAPPING::get)
+                .orElse(null);
+    }
+}

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
@@ -21,6 +21,7 @@ import static java.util.Optional.ofNullable;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 public class KeyEvent {
     private Integer keyCode;
@@ -73,6 +74,21 @@ public class KeyEvent {
         }
         this.flags |= keyEventFlag.getValue();
         return this;
+    }
+
+    @Nullable
+    public Integer getKeyCode() {
+        return keyCode;
+    }
+
+    @Nullable
+    public Integer getFlags() {
+        return flags;
+    }
+
+    @Nullable
+    public Integer getMetaState() {
+        return metaState;
     }
 
     /**

--- a/src/test/java/io/appium/java_client/android/KeyCodeTest.java
+++ b/src/test/java/io/appium/java_client/android/KeyCodeTest.java
@@ -21,12 +21,14 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import io.appium.java_client.android.nativekey.AndroidKey;
+import io.appium.java_client.android.nativekey.KeyActionsHelpers;
 import io.appium.java_client.android.nativekey.KeyEvent;
 import io.appium.java_client.android.nativekey.KeyEventFlag;
 import io.appium.java_client.android.nativekey.KeyEventMetaModifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.interactions.Actions;
 
 public class KeyCodeTest extends BaseAndroidTest {
     private static final By PRESS_RESULT_VIEW = By.id("io.appium.android.apis:id/text");
@@ -83,5 +85,16 @@ public class KeyCodeTest extends BaseAndroidTest {
         assertThat(state, containsString(String.format("META_%s", KeyEventMetaModifier.SHIFT_ON.name())));
         assertThat(state, containsString(String.format("flags=0x%s",
                 Integer.toHexString(KeyEventFlag.LONG_PRESS.getValue()))));
+    }
+
+    @Test
+    public void w3cActionsTest() {
+        KeyActionsHelpers
+                .sendNativeKeys(new Actions(driver), "Hi")
+                .perform();
+        final String state = driver.findElement(PRESS_RESULT_VIEW).getText();
+        assertThat(state, containsString(String.format("KEYCODE_%s", AndroidKey.H.name())));
+        assertThat(state, containsString(String.format("KEYCODE_%s", AndroidKey.I.name())));
+        assertThat(state, containsString(String.format("META_%s", KeyEventMetaModifier.SHIFT_ON.name())));
     }
 }


### PR DESCRIPTION
## Change list

This is for now poor-man's implementation of Android send keys support using W3C actions. Perhaps, the keys transformation algorithm might be improved by importing some routines from roboelectric lib, but I don't really want to include it into the dependencies list.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)