### PR TITLE
Init web socket clients lazily

### DIFF
--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -35,6 +35,7 @@ import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.screenrecording.CanRecordScreen;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
+import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
@@ -65,6 +66,8 @@ public class AndroidDriver<T extends WebElement>
         HasBattery<AndroidBatteryInfo> {
 
     private static final String ANDROID_PLATFORM = MobilePlatform.ANDROID;
+
+    private StringWebSocketClient logcatClient;
 
     /**
      * Creates a new instance based on command {@code executor} and {@code capabilities}.
@@ -192,5 +195,13 @@ public class AndroidDriver<T extends WebElement>
     public AndroidBatteryInfo getBatteryInfo() {
         return new AndroidBatteryInfo((Map<String, Object>) execute(EXECUTE_SCRIPT, ImmutableMap.of(
                 "script", "mobile: batteryInfo", "args", Collections.emptyList())));
+    }
+
+    @Override
+    public synchronized StringWebSocketClient getLogcatClient() {
+        if (logcatClient == null) {
+            logcatClient = new StringWebSocketClient();
+        }
+        return logcatClient;
     }
 }

--- a/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
+++ b/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.function.Consumer;
 
 public interface ListensToLogcatMessages extends ExecutesMethod {
-    StringWebSocketClient logcatClient = new StringWebSocketClient();
+    StringWebSocketClient getLogcatClient();
 
     /**
      * Start logcat messages broadcast via web socket.
@@ -68,7 +68,7 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-        logcatClient.connect(endpointUri);
+        getLogcatClient().connect(endpointUri);
     }
 
     /**
@@ -80,7 +80,7 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
      * @param handler a function, which accepts a single argument, which is the actual log message
      */
     default void addLogcatMessagesListener(Consumer<String> handler) {
-        logcatClient.addMessageHandler(handler);
+        getLogcatClient().addMessageHandler(handler);
     }
 
     /**
@@ -92,7 +92,7 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
      * @param handler a function, which accepts a single argument, which is the actual exception instance
      */
     default void addLogcatErrorsListener(Consumer<Throwable> handler) {
-        logcatClient.addErrorHandler(handler);
+        getLogcatClient().addErrorHandler(handler);
     }
 
     /**
@@ -105,7 +105,7 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
      *                connected to the web socket
      */
     default void addLogcatConnectionListener(Runnable handler) {
-        logcatClient.addConnectionHandler(handler);
+        getLogcatClient().addConnectionHandler(handler);
     }
 
     /**
@@ -118,14 +118,14 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
      *                disconnected from the web socket
      */
     default void addLogcatDisconnectionListener(Runnable handler) {
-        logcatClient.addDisconnectionHandler(handler);
+        getLogcatClient().addDisconnectionHandler(handler);
     }
 
     /**
      * Removes all existing logcat handlers.
      */
     default void removeAllLogcatListeners() {
-        logcatClient.removeAllHandlers();
+        getLogcatClient().removeAllHandlers();
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -34,6 +34,7 @@ import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.screenrecording.CanRecordScreen;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
+import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
@@ -67,6 +68,8 @@ public class IOSDriver<T extends WebElement>
         HasBattery<IOSBatteryInfo> {
 
     private static final String IOS_PLATFORM = MobilePlatform.IOS;
+
+    private StringWebSocketClient syslogClient;
 
     /**
      * Creates a new instance based on command {@code executor} and {@code capabilities}.
@@ -224,5 +227,13 @@ public class IOSDriver<T extends WebElement>
             execute(DriverCommand.SET_ALERT_VALUE, prepareArguments("value", keysToSend));
         }
 
+    }
+
+    @Override
+    public synchronized StringWebSocketClient getSyslogClient() {
+        if (syslogClient == null) {
+            syslogClient = new StringWebSocketClient();
+        }
+        return syslogClient;
     }
 }

--- a/src/main/java/io/appium/java_client/ios/ListensToSyslogMessages.java
+++ b/src/main/java/io/appium/java_client/ios/ListensToSyslogMessages.java
@@ -31,7 +31,8 @@ import java.util.Collections;
 import java.util.function.Consumer;
 
 public interface ListensToSyslogMessages extends ExecutesMethod {
-    StringWebSocketClient syslogClient = new StringWebSocketClient();
+
+    StringWebSocketClient getSyslogClient();
 
     /**
      * Start syslog messages broadcast via web socket.
@@ -68,7 +69,7 @@ public interface ListensToSyslogMessages extends ExecutesMethod {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-        syslogClient.connect(endpointUri);
+        getSyslogClient().connect(endpointUri);
     }
 
     /**
@@ -80,7 +81,7 @@ public interface ListensToSyslogMessages extends ExecutesMethod {
      * @param handler a function, which accepts a single argument, which is the actual log message
      */
     default void addSyslogMessagesListener(Consumer<String> handler) {
-        syslogClient.addMessageHandler(handler);
+        getSyslogClient().addMessageHandler(handler);
     }
 
     /**
@@ -92,7 +93,7 @@ public interface ListensToSyslogMessages extends ExecutesMethod {
      * @param handler a function, which accepts a single argument, which is the actual exception instance
      */
     default void addSyslogErrorsListener(Consumer<Throwable> handler) {
-        syslogClient.addErrorHandler(handler);
+        getSyslogClient().addErrorHandler(handler);
     }
 
     /**
@@ -105,7 +106,7 @@ public interface ListensToSyslogMessages extends ExecutesMethod {
      *                connected to the web socket
      */
     default void addSyslogConnectionListener(Runnable handler) {
-        syslogClient.addConnectionHandler(handler);
+        getSyslogClient().addConnectionHandler(handler);
     }
 
     /**
@@ -118,14 +119,14 @@ public interface ListensToSyslogMessages extends ExecutesMethod {
      *                disconnected from the web socket
      */
     default void addSyslogDisconnectionListener(Runnable handler) {
-        syslogClient.addDisconnectionHandler(handler);
+        getSyslogClient().addDisconnectionHandler(handler);
     }
 
     /**
      * Removes all existing syslog handlers.
      */
     default void removeAllSyslogListeners() {
-        syslogClient.removeAllHandlers();
+        getSyslogClient().removeAllHandlers();
     }
 
     /**


### PR DESCRIPTION
## Change list

It looks like web socket lib throws an exception on init for some reason. So it would be safer to init the stuff lazily in order to avoid the java class loader from throwing this exception each time when the driver is instantiated.

See https://stackoverflow.com/questions/50293463/appium-test-case-throws-exception for the reference.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

