### PR TITLE
Add TouchAction constructor argument verification

### DIFF
--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -49,7 +49,7 @@ public class TouchAction<T extends TouchAction<T>> implements PerformsActions<T>
     private PerformsTouchActions performsTouchActions;
 
     public TouchAction(PerformsTouchActions performsTouchActions) {
-        this.performsTouchActions = performsTouchActions;
+        this.performsTouchActions = checkNotNull(performsTouchActions);
         parameterBuilder = builder();
     }
 


### PR DESCRIPTION
## Change list

I saw some issue reports where people complain about NPE while the driver instance, which is passed as the constructor argument, equals to `null`. This fix allows to detect the problem on the early stage.
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)