### PR TITLE
Add an optional format argument to getDeviceTime and update the documentation

### DIFF
--- a/src/main/java/io/appium/java_client/HasDeviceTime.java
+++ b/src/main/java/io/appium/java_client/HasDeviceTime.java
@@ -27,23 +27,10 @@ public interface HasDeviceTime extends ExecutesMethod {
     /**
      * Gets device date and time for both iOS(host time is returned for simulators) and Android devices.
      *
-     * @param format datetime format specifier:
-     *                          %% literal %             %n newline              %t tab
-     *                          %S seconds (00-60)       %M minute (00-59)       %m month (01-12)
-     *                          %H hour (0-23)           %I hour (01-12)         %p AM/PM
-     *                          %y short year (00-99)    %Y year                 %C century
-     *                          %a short weekday name    %A weekday name         %u day of week (1-7, 1=mon)
-     *                          %b short month name      %B month name           %Z timezone name
-     *                          %j day of year (001-366) %d day of month (01-31) %e day of month ( 1-31)
-     *                          %s seconds past the Epoch
-     *
-     *                          %U Week of year (0-53 start sunday)   %W Week of year (0-53 start monday)
-     *                          %V Week of year (1-53 start monday, week < 4 days not part of this year)
-     *
-     *                          %D = "%m/%d/%y"    %r = "%I : %M : %S %p"   %T = "%H:%M:%S"   %h = "%b"
-     *                          %x locale date     %X locale time           %c locale date/time
-     *               The specifier is only supported since Appium 1.8.2.
-     *               The default format specifier is "+%Y-%m-%dT%T%z".
+     * @param format The set of format specifiers. Read
+     *               https://momentjs.com/docs/ to get the full list of supported
+     *               datetime format specifiers. The default format is
+     *               `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601
      * @return Device time string
      */
     default String getDeviceTime(String format) {
@@ -53,7 +40,7 @@ public interface HasDeviceTime extends ExecutesMethod {
 
     /**
      * Gets device date and time for both iOS(host time is returned for simulators) and Android devices.
-     * The default time format for is ISO-8601 since Appium 1.8.2,
+     * The default format since Appium 1.8.2 is `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601.
      *
      * @return Device time string
      */

--- a/src/main/java/io/appium/java_client/HasDeviceTime.java
+++ b/src/main/java/io/appium/java_client/HasDeviceTime.java
@@ -18,11 +18,44 @@ package io.appium.java_client;
 
 import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.openqa.selenium.remote.Response;
 
 public interface HasDeviceTime extends ExecutesMethod {
-    /*
-        Gets device date and time for both iOS(Supports only real device) and Android devices
+
+    /**
+     * Gets device date and time for both iOS(host time is returned for simulators) and Android devices.
+     *
+     * @param format datetime format specifier:
+     *                          %% literal %             %n newline              %t tab
+     *                          %S seconds (00-60)       %M minute (00-59)       %m month (01-12)
+     *                          %H hour (0-23)           %I hour (01-12)         %p AM/PM
+     *                          %y short year (00-99)    %Y year                 %C century
+     *                          %a short weekday name    %A weekday name         %u day of week (1-7, 1=mon)
+     *                          %b short month name      %B month name           %Z timezone name
+     *                          %j day of year (001-366) %d day of month (01-31) %e day of month ( 1-31)
+     *                          %s seconds past the Epoch
+     *
+     *                          %U Week of year (0-53 start sunday)   %W Week of year (0-53 start monday)
+     *                          %V Week of year (1-53 start monday, week < 4 days not part of this year)
+     *
+     *                          %D = "%m/%d/%y"    %r = "%I : %M : %S %p"   %T = "%H:%M:%S"   %h = "%b"
+     *                          %x locale date     %X locale time           %c locale date/time
+     *               The specifier is only supported since Appium 1.8.2.
+     *               The default format specifier is "+%Y-%m-%dT%T%z".
+     * @return Device time string
+     */
+    default String getDeviceTime(String format) {
+        Response response = execute(GET_DEVICE_TIME, ImmutableMap.of("format", format));
+        return response.getValue().toString();
+    }
+
+    /**
+     * Gets device date and time for both iOS(host time is returned for simulators) and Android devices.
+     * The default time format for is ISO-8601 since Appium 1.8.2,
+     *
+     * @return Device time string
      */
     default String getDeviceTime() {
         Response response = execute(GET_DEVICE_TIME);

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -118,7 +118,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     @Test public void getDeviceTimeTest() {
         String time = driver.getDeviceTime();
-        assertTrue(!time.isEmpty());
+        assertFalse(time.isEmpty());
     }
 
     @Test public void isAppInstalledTest() {

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -118,7 +118,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     @Test public void getDeviceTimeTest() {
         String time = driver.getDeviceTime();
-        assertTrue(time.length() == 28);
+        assertTrue(!time.isEmpty());
     }
 
     @Test public void isAppInstalledTest() {

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -33,7 +33,7 @@ public class IOSDriverTest extends AppIOSTest {
     @Test
     public void getDeviceTimeTest() {
         String time = driver.getDeviceTime();
-        assertTrue(!time.isEmpty());
+        assertFalse(time.isEmpty());
     }
 
     @Test public void resetTest() {

--- a/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSDriverTest.java
@@ -30,11 +30,10 @@ import org.openqa.selenium.html5.Location;
 
 public class IOSDriverTest extends AppIOSTest {
 
-    //TODO There is no ability to check this function usibg simulators.
-    // When CI will have been set up then this test will be returned
+    @Test
     public void getDeviceTimeTest() {
         String time = driver.getDeviceTime();
-        assertTrue(time.length() == 28);
+        assertTrue(!time.isEmpty());
     }
 
     @Test public void resetTest() {


### PR DESCRIPTION
## Change list

Now it is possible to explicitly set the format specifiers for the returned datetime. Also, the default response format is changed to ISO-8601
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

