### PR TITLE
Expand touch options API to accept coordinates as Point

### DIFF
--- a/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
@@ -19,6 +19,18 @@ public class ElementOption extends PointOption<ElementOption> {
      * This method creates a build instance of the {@link ElementOption}.
      *
      * @param element is the element to calculate offset from.
+     * @param offset is the offset from the upper left corner of the given element.
+     * @return the built option
+     */
+    public static ElementOption element(WebElement element, Point offset) {
+        return new ElementOption().withElement(element).withCoordinates(offset);
+    }
+
+
+    /**
+     * This method creates a build instance of the {@link ElementOption}.
+     *
+     * @param element is the element to calculate offset from.
      * @param x is the x-offset from the upper left corner of the given element.
      * @param y is the y-offset from the upper left corner of the given element.
      * @return the built option
@@ -40,13 +52,25 @@ public class ElementOption extends PointOption<ElementOption> {
     /**
      * It defines x and y offset from the upper left corner of an element.
      *
-     * @param xOffset is x value.
-     * @param yOffset is y value.
+     * @param offset is the offset from the upper left corner of the given element.
+     * @return self-reference
+     */
+    @Override
+    public ElementOption withCoordinates(Point offset) {
+        super.withCoordinates(offset);
+        return this;
+    }
+
+    /**
+     * It defines x and y offset from the upper left corner of an element.
+     *
+     * @param xOffset is the x-offset from the upper left corner of the given element.
+     * @param yOffset is the y-offset from the upper left corner of the given element.
      * @return self-reference
      */
     @Override
     public ElementOption withCoordinates(int xOffset, int yOffset) {
-        coordinates = new Point(xOffset, yOffset);
+        super.withCoordinates(xOffset, yOffset);
         return this;
     }
 

--- a/src/main/java/io/appium/java_client/touch/offset/PointOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/PointOption.java
@@ -15,12 +15,34 @@ public class PointOption<T extends PointOption<T>> extends ActionOptions<T> {
      * It creates a built instance of {@link PointOption} which takes x and y coordinates.
      * This is offset from the upper left corner of the screen.
      *
+     * @param offset is an offset value.
+     * @return a built option
+     */
+    public static PointOption point(Point offset) {
+        return new PointOption().withCoordinates(offset);
+    }
+
+    /**
+     * It creates a built instance of {@link PointOption} which takes x and y coordinates.
+     * This is offset from the upper left corner of the screen.
+     *
      * @param xOffset is x value.
      * @param yOffset is y value.
      * @return a built option
      */
     public static PointOption point(int xOffset, int yOffset) {
         return new PointOption().withCoordinates(xOffset, yOffset);
+    }
+
+    /**
+     * It defines x and y coordinates.
+     * This is offset from the upper left corner of the screen.
+     *
+     * @param offset is an offset value.
+     * @return self-reference
+     */
+    public T withCoordinates(Point offset) {
+        return withCoordinates(offset.x, offset.y);
     }
 
     /**

--- a/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
+++ b/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.isIn;
 import io.appium.java_client.touch.offset.ElementOption;
 import io.appium.java_client.touch.offset.PointOption;
 import org.junit.Test;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 
@@ -43,7 +44,7 @@ public class TouchOptionsTests {
     public void invalidOptionsArgumentsShouldFailOnAltering() {
         final List<Runnable> invalidOptions = new ArrayList<>();
         invalidOptions.add(() -> waitOptions(ofMillis(-1)));
-        invalidOptions.add(() -> new ElementOption().withCoordinates(0, 0).withElement(null));
+        invalidOptions.add(() -> new ElementOption().withCoordinates(new Point(0, 0)).withElement(null));
         invalidOptions.add(() -> new WaitOptions().withDuration(null));
         invalidOptions.add(() -> tapOptions().withTapsCount(-1));
         invalidOptions.add(() -> longPressOptions().withDuration(null));
@@ -71,7 +72,7 @@ public class TouchOptionsTests {
     @Test
     public void tapOptionsShouldBuildProperly() {
         final Map<String, Object> actualOpts = tapOptions()
-                .withPosition(point(0, 0))
+                .withPosition(point(new Point(0, 0)))
                 .withTapsCount(2)
                 .build();
         final Map<String, Object> expectedOpts = new HashMap<>();


### PR DESCRIPTION
## Change list

Expand touch options API to accept coordinates as `org.openqa.selenium.Point`
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)