### PR TITLE
JDK9 compatibility: replace DatatypeConverter with Base64

### DIFF
--- a/src/main/java/io/appium/java_client/InteractsWithFiles.java
+++ b/src/main/java/io/appium/java_client/InteractsWithFiles.java
@@ -23,7 +23,8 @@ import com.google.common.collect.ImmutableMap;
 
 import org.openqa.selenium.remote.Response;
 
-import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 public interface InteractsWithFiles extends ExecutesMethod {
 
@@ -50,7 +51,7 @@ public interface InteractsWithFiles extends ExecutesMethod {
         Response response = execute(PULL_FILE, ImmutableMap.of("path", remotePath));
         String base64String = response.getValue().toString();
 
-        return DatatypeConverter.parseBase64Binary(base64String);
+        return Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
@@ -76,7 +77,7 @@ public interface InteractsWithFiles extends ExecutesMethod {
         Response response = execute(PULL_FOLDER, ImmutableMap.of("path", remotePath));
         String base64String = response.getValue().toString();
 
-        return DatatypeConverter.parseBase64Binary(base64String);
+        return Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
     }
 
 }


### PR DESCRIPTION
## Change list

JDK9 compatibility: replace `DatatypeConverter.parseBase64Binary(..)` with `Base64.getDecoder().decode(..)`
 
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
