### PR TITLE
Publish Java client through Jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Java client project is available to use even before it is officially published t
  
 ```
     dependencies {
-		implementation 'com.github.User:Repo:Tag'
+		implementation 'com.github.appium:java-client:latest commit id from master branch'
 	}
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,54 @@ This is the Java language binding for writing Appium Tests, conforms to [Mobile 
 
 [WIKI](https://github.com/appium/java-client/wiki)
 
+## How to install latest java client Beta/Snapshots
+
+Java client project is available to use even before it is officially published to maven central. Refer [jitpack.io](https://jitpack.io/#appium/java-client)
+
+### Maven
+
+ - Add the following to pom.xml:
+
+```
+    <repositories>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://jitpack.io</url>
+		</repository>
+    </repositories>
+```
+
+ - Add the dependency:
+ 
+```
+    <dependency>
+    	  <groupId>com.github.appium</groupId>
+    	  <artifactId>java-client</artifactId>
+    	  <version>latest commit ID from master branch</version>
+    </dependency>
+``` 
+
+### Gradle
+
+ - Add the JitPack repository to your build file. Add it in your root build.gradle at the end of repositories:
+ 
+```
+    allprojects {
+		repositories {
+			...
+			maven { url 'https://jitpack.io' }
+		}
+	}
+```
+
+ - Add the dependency:
+ 
+```
+    dependencies {
+		implementation 'com.github.User:Repo:Tag'
+	}
+```
+
 ## Changelog
 
 *7.0.0 (under construction yet)*

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 import org.apache.tools.ant.filters.*
 
 group 'io.appium'
-version '6.1.0'
+version '6.1.1-SNAPSHOT'
 
 repositories {
     jcenter()

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk8
+install:
+   - ./gradlew clean install -x test -x signArchives


### PR DESCRIPTION
## Change list

Publish Java client through Jitpack
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

@mykola-mokhnach @jlipps This PR will allow us to publish java client through jitpack. This will unblock users to use latest commit even before its available in maven central.
