### PR TITLE
Write W3C capabilities into firstMatch entity instead of alwaysMatch

### DIFF
--- a/src/main/java/io/appium/java_client/remote/NewAppiumSessionPayload.java
+++ b/src/main/java/io/appium/java_client/remote/NewAppiumSessionPayload.java
@@ -194,6 +194,7 @@ public class NewAppiumSessionPayload implements Closeable {
             throw new IllegalArgumentException("First match w3c capabilities is zero length");
         }
 
+        //noinspection ResultOfMethodCallIgnored
         firsts.stream()
                 .peek(map -> {
                     Set<String> overlap = Sets.intersection(always.keySet(), map.keySet());
@@ -256,14 +257,12 @@ public class NewAppiumSessionPayload implements Closeable {
                 json.name(CAPABILITIES);
                 json.beginObject();
 
-                json.name(ALWAYS_MATCH);
-                getW3C().forEach(json::write);
-
+                // Then write everything into the w3c payload. Because of the way we do this, it's easiest
+                // to just populate the "firstMatch" section. The spec says it's fine to omit the
+                // "alwaysMatch" field, so we do this.
                 json.name(FIRST_MATCH);
                 json.beginArray();
-                //noinspection unchecked
-                json.beginObject();
-                json.endObject();
+                getW3C().forEach(json::write);
                 json.endArray();
 
                 json.endObject();  // Close "capabilities" object
@@ -291,7 +290,7 @@ public class NewAppiumSessionPayload implements Closeable {
 
                     default:
                         out.name(name);
-                        out.write(input.<Object>read(Object.class));
+                        out.write(input.read(Object.class));
                         break;
                 }
             }
@@ -437,8 +436,7 @@ public class NewAppiumSessionPayload implements Closeable {
             return null;
         }
 
-        Map<String, Object> toReturn = new TreeMap<>();
-        toReturn.putAll(capabilities);
+        Map<String, Object> toReturn = new TreeMap<>(capabilities);
 
         // Platform name
         if (capabilities.containsKey(PLATFORM) && !capabilities.containsKey(PLATFORM_NAME)) {


### PR DESCRIPTION
## Change list

Just did the same what Selenium is already doing: https://github.com/SeleniumHQ/selenium/blob/479a801b39efa53966e35eec0bae55ca0bcc02da/java/client/src/org/openqa/selenium/remote/NewSessionPayload.java#L252
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)