### PR TITLE
Use the latest official ECJ 3.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ configurations {
 }
 
 dependencies {
-    ecj 'org.eclipse.jdt.core.compiler:ecj:4.6.1'
+    ecj 'org.eclipse.jdt:ecj:3.14.0'
 }
 
 compileJava {


### PR DESCRIPTION
## Change list

Use the latest official ECJ 3.14.0
 
## Types of changes

- [X] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
The old ECJ reference was bogus (see official confirmation: https://bugs.eclipse.org/bugs/show_bug.cgi?id=499019#c19) and didn't work properly with JDK9
