### PR TITLE
Avoid null pointer exceptions when calling getCapabilities

### DIFF
--- a/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
+++ b/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
@@ -157,7 +157,8 @@ abstract class DefaultGenericMobileDriver<T extends WebElement> extends RemoteWe
 
     @Override
     public String toString() {
+        Capabilities capabilities = getCapabilities();
         return String.format("%s, Capabilities: %s", getClass().getCanonicalName(),
-                getCapabilities().asMap().toString());
+                capabilities != null ? capabilities.asMap().toString() : "null");
     }
 }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -47,6 +47,7 @@ import org.openqa.selenium.remote.http.HttpClient;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Android driver implementation.
@@ -206,9 +207,12 @@ public class AndroidDriver<T extends WebElement>
      *
      * @return given {@link Capabilities}
      */
+    @Nullable
     public Capabilities getCapabilities() {
         MutableCapabilities capabilities = (MutableCapabilities) super.getCapabilities();
-        capabilities.setCapability(PLATFORM_NAME, ANDROID_PLATFORM);
+        if (capabilities != null) {
+            capabilities.setCapability(PLATFORM_NAME, ANDROID_PLATFORM);
+        }
         return capabilities;
     }
 

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * iOS driver implementation.
@@ -207,9 +208,12 @@ public class IOSDriver<T extends WebElement>
      *
      * @return given {@link Capabilities}
      */
+    @Nullable
     public Capabilities getCapabilities() {
         MutableCapabilities capabilities = (MutableCapabilities) super.getCapabilities();
-        capabilities.setCapability(PLATFORM_NAME, IOS_PLATFORM);
+        if (capabilities != null) {
+            capabilities.setCapability(PLATFORM_NAME, IOS_PLATFORM);
+        }
         return capabilities;
     }
 


### PR DESCRIPTION
## Change list

Add null checks to `getCapabilities()` that prevent spurious null pointer exceptions.

## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The `capabilities` field in `RemoteWebDriver` remains null until a new session is successfully created.  If something fails before the Selenium client can consolidate the returned capabilities, a `NullPointerException` is thrown from the Appium overriden `getCapabilities` methods that masks the real failure.

In other words:

- Appium [overrides `getCapabilities`][2]
- Selenium first [requests a new session][3], then [saves the returned capabilities][1]
- If the new session command fails, [`getCapabilities` is called][4]
- Because `RemoteWebDriver` returns null, the Appium override [tries to call a method on a null value][5]

This exception masking results in very confusing and misleading troubleshooting.

The fix proposed by this pull request should fix the problem.

[1]: https://github.com/SeleniumHQ/selenium/blob/e82be7d3584062a0d16af8d562d387e3d4855aa1/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#L252
[2]: https://github.com/appium/java-client/blob/98daabe3943b606c5416818b73add493d889cc94/src/main/java/io/appium/java_client/android/AndroidDriver.java#L209-L213
[3]: https://github.com/SeleniumHQ/selenium/blob/e82be7d3584062a0d16af8d562d387e3d4855aa1/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#L213
[4]: https://github.com/SeleniumHQ/selenium/blob/e82be7d3584062a0d16af8d562d387e3d4855aa1/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java#L577
[5]: https://github.com/appium/java-client/blob/98daabe3943b606c5416818b73add493d889cc94/src/main/java/io/appium/java_client/android/AndroidDriver.java#L211

