### PR TITLE
send both signalStrengh and signalStrength

### DIFF
--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -319,6 +319,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             GsmSignalStrength gsmSignalStrength) {
         return new AbstractMap.SimpleEntry<>(GSM_SIGNAL,
                 prepareArguments(
+                        // https://github.com/appium/appium/issues/12234
                         new String[] {"signalStrengh", "signalStrength" },
                         new Object[] {gsmSignalStrength.ordinal(), gsmSignalStrength.ordinal()}
                 ));

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -318,7 +318,10 @@ public class AndroidMobileCommandHelper extends MobileCommand {
     public static Map.Entry<String, Map<String, ?>> gsmSignalStrengthCommand(
             GsmSignalStrength gsmSignalStrength) {
         return new AbstractMap.SimpleEntry<>(GSM_SIGNAL,
-                prepareArguments("signalStrengh", gsmSignalStrength.ordinal()));
+                prepareArguments(
+                        new String[] {"signalStrengh", "signalStrength" },
+                        new Object[] {gsmSignalStrength.ordinal(), gsmSignalStrength.ordinal()}
+                ));
     }
 
     /**


### PR DESCRIPTION
## Change list

related to: https://github.com/appium/appium/issues/12234

Send both `signalStrengh` and `signalStrength` as backword compatibility.
The value should be same.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`signalStrength` is also accepted by Appium server after appium/appium-base-driver#308