### PR TITLE
Avoid enforcing the platform name while creating drivers

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -137,7 +137,7 @@ public class AppiumDriver<T extends WebElement>
      * @param newPlatform          a {@link MobileCapabilityType#PLATFORM_NAME} value which has
      *                             to be set up
      * @return {@link Capabilities} with changed mobile platform value
-     * @deprecated Please use {@link #setDefaultPlatformName(Capabilities, String)} instead
+     * @deprecated Please use {@link #updateDefaultPlatformName(Capabilities, String)} instead
      */
     @Deprecated
     protected static Capabilities substituteMobilePlatform(Capabilities originalCapabilities,
@@ -151,15 +151,15 @@ public class AppiumDriver<T extends WebElement>
      * Changes platform name if it is not set and returns new capabilities.
      *
      * @param originalCapabilities the given {@link Capabilities}.
-     * @param newPlatform          a {@link MobileCapabilityType#PLATFORM_NAME} value which has
+     * @param defaultName          a {@link MobileCapabilityType#PLATFORM_NAME} value which has
      *                             to be set up
      * @return {@link Capabilities} with changed mobile platform name value or the original capabilities
      */
-    protected static Capabilities setDefaultPlatformName(Capabilities originalCapabilities,
-                                                         String newPlatform) {
+    protected static Capabilities updateDefaultPlatformName(Capabilities originalCapabilities,
+                                                            String defaultName) {
         if (originalCapabilities.getCapability(PLATFORM_NAME) == null) {
             DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
-            dc.setCapability(PLATFORM_NAME, newPlatform);
+            dc.setCapability(PLATFORM_NAME, defaultName);
             return dc;
         }
         return originalCapabilities;

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -130,18 +130,21 @@ public class AppiumDriver<T extends WebElement>
     }
 
     /**
-     * Changes platform name and returns new capabilities.
+     * Changes platform name if it is not set and returns new capabilities.
      *
      * @param originalCapabilities the given {@link Capabilities}.
      * @param newPlatform          a {@link MobileCapabilityType#PLATFORM_NAME} value which has
      *                             to be set up
-     * @return {@link Capabilities} with changed mobile platform value
+     * @return {@link Capabilities} with changed mobile platform name value or the original capabilities
      */
-    protected static Capabilities substituteMobilePlatform(Capabilities originalCapabilities,
-                                                           String newPlatform) {
-        DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
-        dc.setCapability(PLATFORM_NAME, newPlatform);
-        return dc;
+    protected static Capabilities setDefaultPlatformName(Capabilities originalCapabilities,
+                                                         String newPlatform) {
+        if (originalCapabilities.getCapability(PLATFORM_NAME) == null) {
+            DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
+            dc.setCapability(PLATFORM_NAME, newPlatform);
+            return dc;
+        }
+        return originalCapabilities;
     }
 
     @Override

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -31,6 +31,7 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.DeviceRotation;
+import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
@@ -314,5 +315,18 @@ public class AppiumDriver<T extends WebElement>
     public boolean isBrowser() {
         return super.isBrowser()
                 && !containsIgnoreCase(getContext(), "NATIVE_APP");
+    }
+
+    @Override
+    protected void startSession(Capabilities capabilities) {
+        super.startSession(capabilities);
+        // The RemoteWebDriver implementation overrides platformName
+        // so we need to restore it back to the original value
+        Object originalPlatformName = capabilities.getCapability(PLATFORM_NAME);
+        Capabilities originalCaps = super.getCapabilities();
+        if (originalPlatformName != null && originalCaps instanceof MutableCapabilities) {
+            ((MutableCapabilities) super.getCapabilities()).setCapability(PLATFORM_NAME,
+                    originalPlatformName);
+        }
     }
 }

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -130,6 +130,23 @@ public class AppiumDriver<T extends WebElement>
     }
 
     /**
+     * Changes platform name and returns new capabilities.
+     *
+     * @param originalCapabilities the given {@link Capabilities}.
+     * @param newPlatform          a {@link MobileCapabilityType#PLATFORM_NAME} value which has
+     *                             to be set up
+     * @return {@link Capabilities} with changed mobile platform value
+     * @deprecated Please use {@link #setDefaultPlatformName(Capabilities, String)} instead
+     */
+    @Deprecated
+    protected static Capabilities substituteMobilePlatform(Capabilities originalCapabilities,
+                                                           String newPlatform) {
+        DesiredCapabilities dc = new DesiredCapabilities(originalCapabilities);
+        dc.setCapability(PLATFORM_NAME, newPlatform);
+        return dc;
+    }
+
+    /**
      * Changes platform name if it is not set and returns new capabilities.
      *
      * @param originalCapabilities the given {@link Capabilities}.

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -19,7 +19,6 @@ package io.appium.java_client.android;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.endTestCoverageCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.openNotificationsCommand;
 import static io.appium.java_client.android.AndroidMobileCommandHelper.toggleLocationServicesCommand;
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 import static org.openqa.selenium.remote.DriverCommand.EXECUTE_SCRIPT;
 
 import com.google.common.collect.ImmutableMap;
@@ -40,7 +39,6 @@ import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.http.HttpClient;
@@ -48,7 +46,6 @@ import org.openqa.selenium.remote.http.HttpClient;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Android driver implementation.
@@ -84,7 +81,7 @@ public class AndroidDriver<T extends WebElement>
      * @param capabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, setDefaultPlatformName(capabilities, ANDROID_PLATFORM));
+        super(executor, updateDefaultPlatformName(capabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -94,7 +91,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+        super(remoteAddress, updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -107,7 +104,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(URL remoteAddress, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(remoteAddress, httpClientFactory,
-            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+            updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -117,7 +114,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+        super(service, updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -130,7 +127,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(service, httpClientFactory,
-            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+            updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -140,7 +137,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+        super(builder, updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -153,7 +150,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(builder, httpClientFactory,
-            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+            updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -163,7 +160,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+        super(httpClientFactory, updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -172,7 +169,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(Capabilities desiredCapabilities) {
-        super(setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+        super(updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -84,7 +84,7 @@ public class AndroidDriver<T extends WebElement>
      * @param capabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, substituteMobilePlatform(capabilities, ANDROID_PLATFORM));
+        super(executor, setDefaultPlatformName(capabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -94,7 +94,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -107,7 +107,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(URL remoteAddress, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(remoteAddress, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -117,7 +117,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+        super(service, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -130,7 +130,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(service, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -140,7 +140,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+        super(builder, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -153,7 +153,7 @@ public class AndroidDriver<T extends WebElement>
     public AndroidDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(builder, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+            setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -163,7 +163,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -172,7 +172,7 @@ public class AndroidDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public AndroidDriver(Capabilities desiredCapabilities) {
-        super(substituteMobilePlatform(desiredCapabilities, ANDROID_PLATFORM));
+        super(setDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
     }
 
     /**
@@ -201,20 +201,6 @@ public class AndroidDriver<T extends WebElement>
     public AndroidBatteryInfo getBatteryInfo() {
         return new AndroidBatteryInfo((Map<String, Object>) execute(EXECUTE_SCRIPT, ImmutableMap.of(
                 "script", "mobile: batteryInfo", "args", Collections.emptyList())).getValue());
-    }
-
-    /**
-     * Returns capabilities that were provided on instantiation.
-     *
-     * @return given {@link Capabilities}
-     */
-    @Nullable
-    public Capabilities getCapabilities() {
-        MutableCapabilities capabilities = (MutableCapabilities) super.getCapabilities();
-        if (capabilities != null) {
-            capabilities.setCapability(PLATFORM_NAME, ANDROID_PLATFORM);
-        }
-        return capabilities;
     }
 
     @Override

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -69,7 +69,7 @@ public class IOSDriver<T extends WebElement>
         PushesFiles, CanRecordScreen, HasIOSClipboard, ListensToSyslogMessages,
         HasBattery<IOSBatteryInfo> {
 
-    private static final String IOS_PLATFORM = MobilePlatform.IOS;
+    private static final String IOS_DEFAULT_PLATFORM = MobilePlatform.IOS;
 
     private StringWebSocketClient syslogClient;
 
@@ -82,7 +82,7 @@ public class IOSDriver<T extends WebElement>
      * @param capabilities take a look at {@link Capabilities}
      */
     public IOSDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, substituteMobilePlatform(capabilities, IOS_PLATFORM));
+        super(executor, setDefaultPlatformName(capabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -92,7 +92,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -105,7 +105,7 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(URL remoteAddress, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(remoteAddress, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+            setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -115,7 +115,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(service, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -127,8 +127,7 @@ public class IOSDriver<T extends WebElement>
      */
     public IOSDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
-        super(service, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(service, httpClientFactory, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -138,7 +137,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(builder, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -151,7 +150,7 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(builder, httpClientFactory,
-            substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+            setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -161,7 +160,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -170,7 +169,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(Capabilities desiredCapabilities) {
-        super(substituteMobilePlatform(desiredCapabilities, IOS_PLATFORM));
+        super(setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -202,21 +201,6 @@ public class IOSDriver<T extends WebElement>
             return new IOSAlert(super.alert());
         }
     }
-
-    /**
-     * Returns capabilities that were provided on instantiation.
-     *
-     * @return given {@link Capabilities}
-     */
-    @Nullable
-    public Capabilities getCapabilities() {
-        MutableCapabilities capabilities = (MutableCapabilities) super.getCapabilities();
-        if (capabilities != null) {
-            capabilities.setCapability(PLATFORM_NAME, IOS_PLATFORM);
-        }
-        return capabilities;
-    }
-
 
     class IOSAlert implements Alert {
 

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -18,7 +18,6 @@ package io.appium.java_client.ios;
 
 import static io.appium.java_client.MobileCommand.RUN_APP_IN_BACKGROUND;
 import static io.appium.java_client.MobileCommand.prepareArguments;
-import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 import static org.openqa.selenium.remote.DriverCommand.EXECUTE_SCRIPT;
 
 import com.google.common.collect.ImmutableMap;
@@ -37,7 +36,6 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
@@ -48,7 +46,6 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * iOS driver implementation.
@@ -82,7 +79,7 @@ public class IOSDriver<T extends WebElement>
      * @param capabilities take a look at {@link Capabilities}
      */
     public IOSDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, setDefaultPlatformName(capabilities, IOS_DEFAULT_PLATFORM));
+        super(executor, updateDefaultPlatformName(capabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -92,7 +89,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(remoteAddress, updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -105,7 +102,7 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(URL remoteAddress, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(remoteAddress, httpClientFactory,
-            setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+            updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -115,7 +112,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(service, updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -127,7 +124,7 @@ public class IOSDriver<T extends WebElement>
      */
     public IOSDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
-        super(service, httpClientFactory, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(service, httpClientFactory, updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -137,7 +134,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(builder, updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -150,7 +147,7 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
         Capabilities desiredCapabilities) {
         super(builder, httpClientFactory,
-            setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+            updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -160,7 +157,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(httpClientFactory, updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**
@@ -169,7 +166,7 @@ public class IOSDriver<T extends WebElement>
      * @param desiredCapabilities take a look at {@link Capabilities}
      */
     public IOSDriver(Capabilities desiredCapabilities) {
-        super(setDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
+        super(updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/windows/WindowsDriver.java
+++ b/src/main/java/io/appium/java_client/windows/WindowsDriver.java
@@ -35,40 +35,40 @@ public class WindowsDriver<T extends WebElement>
         FindsByWindowsAutomation<T> {
 
     public WindowsDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, setDefaultPlatformName(capabilities, WINDOWS));
+        super(executor, updateDefaultPlatformName(capabilities, WINDOWS));
     }
 
     public WindowsDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(remoteAddress, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(URL remoteAddress, HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(remoteAddress, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(remoteAddress, httpClientFactory, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(service, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
                          Capabilities desiredCapabilities) {
-        super(service, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(service, httpClientFactory, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(builder, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
                          Capabilities desiredCapabilities) {
-        super(builder, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(builder, httpClientFactory, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(httpClientFactory, updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(Capabilities desiredCapabilities) {
-        super(setDefaultPlatformName(desiredCapabilities, WINDOWS));
+        super(updateDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 }

--- a/src/main/java/io/appium/java_client/windows/WindowsDriver.java
+++ b/src/main/java/io/appium/java_client/windows/WindowsDriver.java
@@ -35,40 +35,40 @@ public class WindowsDriver<T extends WebElement>
         FindsByWindowsAutomation<T> {
 
     public WindowsDriver(HttpCommandExecutor executor, Capabilities capabilities) {
-        super(executor, substituteMobilePlatform(capabilities, WINDOWS));
+        super(executor, setDefaultPlatformName(capabilities, WINDOWS));
     }
 
     public WindowsDriver(URL remoteAddress, Capabilities desiredCapabilities) {
-        super(remoteAddress, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(remoteAddress, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(URL remoteAddress, HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(remoteAddress, httpClientFactory, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(remoteAddress, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumDriverLocalService service, Capabilities desiredCapabilities) {
-        super(service, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(service, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumDriverLocalService service, HttpClient.Factory httpClientFactory,
                          Capabilities desiredCapabilities) {
-        super(service, httpClientFactory, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(service, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumServiceBuilder builder, Capabilities desiredCapabilities) {
-        super(builder, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(builder, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(AppiumServiceBuilder builder, HttpClient.Factory httpClientFactory,
                          Capabilities desiredCapabilities) {
-        super(builder, httpClientFactory, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(builder, httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
-        super(httpClientFactory, substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(httpClientFactory, setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 
     public WindowsDriver(Capabilities desiredCapabilities) {
-        super(substituteMobilePlatform(desiredCapabilities, WINDOWS));
+        super(setDefaultPlatformName(desiredCapabilities, WINDOWS));
     }
 }


### PR DESCRIPTION
## Change list

Addresses https://github.com/appium/java-client/issues/1162
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

I hope the change won't affect much clients, but the current logic there is anyway incorrect and must be fixed.