### PR TITLE
add a new constructor for creating a client attached to an existing s…

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -139,9 +139,8 @@ public class AppiumDriver<T extends WebElement>
         this.setSessionId(sessionId);
         
         AppiumCommandExecutor executor = new AppiumCommandExecutor(MobileCommand.commandRepository, remoteAddress);
-        executor.setCommandCodec(new AppiumW3CHttpCommandCodec());
-        executor.setResponseCodec(Dialect.W3C.getResponseCodec());
         executor.configureW3CMode();
+        executor.setResponseCodec(Dialect.W3C.getResponseCodec());
         
         this.setCommandExecutor(executor);
         init(executor);

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -147,7 +147,7 @@ public class AppiumDriver<T extends WebElement>
     }
 
     /**
-     * Used by constructors
+     * Used by constructors.
      */
     private void init(HttpCommandExecutor executor) {
         this.executeMethod = new AppiumExecutionMethod(this);

--- a/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
+++ b/src/main/java/io/appium/java_client/DefaultGenericMobileDriver.java
@@ -37,6 +37,10 @@ abstract class DefaultGenericMobileDriver<T extends WebElement> extends RemoteWe
         super(executor, desiredCapabilities);
     }
 
+    protected DefaultGenericMobileDriver() {
+        super();
+    }
+
     @Override public Response execute(String driverCommand, Map<String, ?> parameters) {
         return super.execute(driverCommand, parameters);
     }

--- a/src/main/java/io/appium/java_client/android/AndroidDriver.java
+++ b/src/main/java/io/appium/java_client/android/AndroidDriver.java
@@ -30,9 +30,11 @@ import io.appium.java_client.FindsByAndroidUIAutomator;
 import io.appium.java_client.FindsByAndroidViewTag;
 import io.appium.java_client.HasOnScreenKeyboard;
 import io.appium.java_client.LocksDevice;
+import io.appium.java_client.MobileCommand;
 import io.appium.java_client.android.connection.HasNetworkConnection;
 import io.appium.java_client.android.nativekey.PressesKey;
 import io.appium.java_client.battery.HasBattery;
+import io.appium.java_client.remote.AppiumCommandExecutor;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.screenrecording.CanRecordScreen;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -40,6 +42,7 @@ import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.http.HttpClient;
 
@@ -161,6 +164,15 @@ public class AndroidDriver<T extends WebElement>
      */
     public AndroidDriver(HttpClient.Factory httpClientFactory, Capabilities desiredCapabilities) {
         super(httpClientFactory, updateDefaultPlatformName(desiredCapabilities, ANDROID_PLATFORM));
+    }
+    
+    /**
+     * Creates a new instance which is attached to an existing Appium automation session.
+     * The other constructors all create a new session, sending the POST /session request.
+     * This constructor does not.
+     */
+    public AndroidDriver(URL remoteAddress, String sessionId) {
+        super(remoteAddress, sessionId);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -168,6 +168,19 @@ public class IOSDriver<T extends WebElement>
     public IOSDriver(Capabilities desiredCapabilities) {
         super(updateDefaultPlatformName(desiredCapabilities, IOS_DEFAULT_PLATFORM));
     }
+    
+    /**
+     * Creates a new instance which is attached to an existing Appium automation session.
+     * The other constructors all create a new session, sending the POST /session request.
+     * This constructor does not.
+     * 
+     * @param remoteAddress is the address of remotely/locally started Appium server
+     * @param sessionId is an Appium session ID, can be gotten from another client by
+     *        calling `getSessionId()`
+     */
+    public IOSDriver(URL remoteAddress, String sessionId) {
+        super(remoteAddress, sessionId);
+    }
 
     /**
      * Runs the current app as a background app for the number of seconds

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -260,7 +260,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
 
         if (DriverCommand.NEW_SESSION.equals(command.getName())
                 && getCommandCodec() instanceof W3CHttpCommandCodec) {
-        	configureW3CMode();
+            configureW3CMode();
         }
 
         return response;

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -267,7 +267,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
     }
     
     public void configureW3CMode() {
-    	setCommandCodec(new AppiumW3CHttpCommandCodec());
+        setCommandCodec(new AppiumW3CHttpCommandCodec());
         getAdditionalCommands().forEach(this::defineCommand);
     }
 }

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -136,16 +136,16 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         return getPrivateFieldValue("additionalCommands", Map.class);
     }
 
-    protected CommandCodec<HttpRequest> getCommandCodec() {
+    public CommandCodec<HttpRequest> getCommandCodec() {
         //noinspection unchecked
         return getPrivateFieldValue("commandCodec", CommandCodec.class);
     }
 
-    protected void setCommandCodec(CommandCodec<HttpRequest> newCodec) {
+    public void setCommandCodec(CommandCodec<HttpRequest> newCodec) {
         setPrivateFieldValue("commandCodec", newCodec);
     }
 
-    protected void setResponseCodec(ResponseCodec<HttpResponse> codec) {
+    public void setResponseCodec(ResponseCodec<HttpResponse> codec) {
         setPrivateFieldValue("responseCodec", codec);
     }
 
@@ -260,10 +260,14 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
 
         if (DriverCommand.NEW_SESSION.equals(command.getName())
                 && getCommandCodec() instanceof W3CHttpCommandCodec) {
-            setCommandCodec(new AppiumW3CHttpCommandCodec());
-            getAdditionalCommands().forEach(this::defineCommand);
+        	configureW3CMode();
         }
 
         return response;
+    }
+    
+    public void configureW3CMode() {
+    	setCommandCodec(new AppiumW3CHttpCommandCodec());
+        getAdditionalCommands().forEach(this::defineCommand);
     }
 }

--- a/src/test/java/io/appium/java_client/ios/ConstructorTest.java
+++ b/src/test/java/io/appium/java_client/ios/ConstructorTest.java
@@ -49,11 +49,11 @@ public class ConstructorTest extends AppIOSTest {
 
     @Test
     public void attachToSessionTest() {
-		String sessionId = driver.getSessionId().toString();
-		
-		URL address = driver.getRemoteAddress();
-		AppiumDriver newDriver = new AppiumDriver(driver.getRemoteAddress() ,sessionId);
-    	//TODO IOSDriver and AndroidDriver
+        String sessionId = driver.getSessionId().toString();
+	
+        URL address = driver.getRemoteAddress();
+        AppiumDriver newDriver = new AppiumDriver(driver.getRemoteAddress() ,sessionId);
+        //TODO IOSDriver and AndroidDriver
         String time = newDriver.getDeviceTime();
         assertFalse(time.isEmpty());
     }

--- a/src/test/java/io/appium/java_client/ios/ConstructorTest.java
+++ b/src/test/java/io/appium/java_client/ios/ConstructorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appium.java_client.ios;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.MobileElement;
+import io.appium.java_client.appmanagement.ApplicationState;
+import io.appium.java_client.remote.HideKeyboardStrategy;
+import io.appium.java_client.remote.MobileCapabilityType;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.ScreenOrientation;
+import org.openqa.selenium.html5.Location;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.net.URL;
+import java.time.Duration;
+
+public class ConstructorTest extends AppIOSTest {
+
+    @Test
+    public void attachToSessionTest() {
+		String sessionId = driver.getSessionId().toString();
+		
+		URL address = driver.getRemoteAddress();
+		AppiumDriver newDriver = new AppiumDriver(driver.getRemoteAddress() ,sessionId);
+    	//TODO IOSDriver and AndroidDriver
+        String time = newDriver.getDeviceTime();
+        assertFalse(time.isEmpty());
+    }
+}

--- a/src/test/java/io/appium/java_client/ios/ConstructorTest.java
+++ b/src/test/java/io/appium/java_client/ios/ConstructorTest.java
@@ -52,8 +52,8 @@ public class ConstructorTest extends AppIOSTest {
         String sessionId = driver.getSessionId().toString();
 	
         URL address = driver.getRemoteAddress();
-        AppiumDriver newDriver = new AppiumDriver(driver.getRemoteAddress() ,sessionId);
-        //TODO IOSDriver and AndroidDriver
+        IOSDriver newDriver = new IOSDriver(driver.getRemoteAddress() ,sessionId);
+        
         String time = newDriver.getDeviceTime();
         assertFalse(time.isEmpty());
     }


### PR DESCRIPTION
…ession

## Change list

A new constructor which attaches to an existing Appium session
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Related to https://github.com/appium/java-client/issues/1044

It was rather tricky to do something so simple. The reason being that the selenium client constructor calls the POST /session command. We needed to construct a client with all the right values but _can't_ call the original constructor, because if we do, it will attempt to create a session.