### PR TITLE
Page factory list element not initialized when parameterized by gener…

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -132,8 +132,8 @@ public class AppiumFieldDecorator implements FieldDecorator {
                     }
                 }
 
-                if ((listType instanceof TypeVariable) &&
-                        Arrays.asList(((TypeVariable<?>) listType).getBounds())
+                if ((listType instanceof TypeVariable)
+                        && Arrays.asList(((TypeVariable<?>) listType).getBounds())
                         .stream().anyMatch(item -> availableElementClasses.contains(item))) {
                     return true;
                 }

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -45,8 +45,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -128,6 +130,12 @@ public class AppiumFieldDecorator implements FieldDecorator {
                     if (webElementClass.equals(listType)) {
                         return true;
                     }
+                }
+
+                if ((listType instanceof TypeVariable) &&
+                        Arrays.asList(((TypeVariable<?>) listType).getBounds())
+                        .stream().anyMatch(item -> availableElementClasses.contains(item))) {
+                    return true;
                 }
                 return false;
             }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/GenericTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/GenericTest.java
@@ -1,30 +1,156 @@
 package io.appium.java_client.pagefactory_tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
+import io.appium.java_client.remote.AutomationName;
+import io.appium.java_client.remote.MobileCapabilityType;
+
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.support.PageFactory;
+import io.appium.java_client.MobileElement;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 public class GenericTest {
 
-    static class TempGenericPage<T> {
+    /**
+     * The Generic types are null on an unbound page.
+     */
+    private static <T> void assertUnboundGenericsNull(T genericItem,
+            List<? extends T> genericItems) {
+        assertNull(genericItem);
+        assertNull(genericItems);
+    }
 
-        public List<T> items;
+    /**
+     * The Generic types are not null on a page bound by a WebElement (or WebElement
+     * sub type).
+     */
+    private static <T extends WebElement> void assertBoundGenericsNotNull(T genericItem,
+            List<? extends T> genericItems) {
+        assertNotNull(genericItem);
+        assertNotNull(genericItems);
+    }
 
-        public List<T> getItems() {
-            return items;
+    /**
+     * The Element types are never null.
+     */
+    private static void assertElementsNotNull(WebElement elementItem,
+            List<? extends WebElement> elementItems) {
+        assertNotNull(elementItem);
+        assertNotNull(elementItems);
+    }
+
+    /**
+     * The Object types are always null.
+     */
+    private static void assertObjectsNull(Object objectItem, List<? extends Object> objectItems) {
+        assertNull(objectItem);
+        assertNull(objectItems);
+    }
+
+    /**
+     * A page with no generic types. The Object types are never initialized.
+     */
+    static class TempNoGenericsPage {
+        public WebElement webElementItem;
+        public MobileElement mobileElementItem;
+        public Object objectItem;
+
+        public List<WebElement> webElementItems;
+        public List<MobileElement> mobileElementItems;
+        public List<Object> objectItems;
+
+        public void assertInit() {
+            assertElementsNotNull(webElementItem, webElementItems);
+            assertElementsNotNull(mobileElementItem, mobileElementItems);
+            assertObjectsNull(objectItem, objectItems);
         }
     }
 
-    static class MockWebDriver implements WebDriver {
+    /**
+     * A page with an unbound generic type. The generic and Object types are never
+     * initialized.
+     */
+    static class TempUnboundPage<T> {
+        public T genericItem;
+        public WebElement webElementItem;
+        public MobileElement mobileElementItem;
+        public Object objectItem;
+
+        public List<T> genericItems;
+        public List<WebElement> webElementItems;
+        public List<MobileElement> mobileElementItems;
+        public List<Object> objectItems;
+
+        public void assertInit() {
+            assertUnboundGenericsNull(genericItem, genericItems);
+            assertElementsNotNull(webElementItem, webElementItems);
+            assertElementsNotNull(mobileElementItem, mobileElementItems);
+            assertObjectsNull(objectItem, objectItems);
+        }
+    }
+
+    /**
+     * A page with a WebElement bound generic type. The Object types are never
+     * initialized.
+     */
+    static class TempWebBoundPage<T extends WebElement> {
+        public T genericItem;
+        public WebElement webElementItem;
+        public MobileElement mobileElementItem;
+        public Object objectItem;
+
+        public List<T> genericItems;
+        public List<WebElement> webElementItems;
+        public List<MobileElement> mobileElementItems;
+        public List<Object> objectItems;
+
+        public void assertInit() {
+            assertBoundGenericsNotNull(genericItem, genericItems);
+            assertElementsNotNull(webElementItem, webElementItems);
+            assertElementsNotNull(mobileElementItem, mobileElementItems);
+            assertObjectsNull(objectItem, objectItems);
+        }
+    }
+
+    /**
+     * A page with a MobileElement bound generic type. The Object types are never
+     * initialized.
+     */
+    static class TempMobileBoundPage<T extends MobileElement> {
+        public T genericItem;
+        public WebElement webElementItem;
+        public MobileElement mobileElementItem;
+        public Object objectItem;
+
+        public List<T> genericItems;
+        public List<WebElement> webElementItems;
+        public List<MobileElement> mobileElementItems;
+        public List<Object> objectItems;
+
+        public void assertInit() {
+            assertBoundGenericsNotNull(genericItem, genericItems);
+            assertElementsNotNull(webElementItem, webElementItems);
+            assertElementsNotNull(mobileElementItem, mobileElementItems);
+            assertObjectsNull(objectItem, objectItems);
+        }
+    }
+
+    static class MockWebDriver implements WebDriver, HasCapabilities {
 
         @Override
         public void get(String url) {
@@ -42,13 +168,13 @@ public class GenericTest {
         }
 
         @Override
-        public List<WebElement> findElements(By by) {
-            return null;
+        public <T extends WebElement> List<T> findElements(By by) {
+            throw new NotImplementedException("MockWebDriver did not expect to findElements");
         }
 
         @Override
-        public WebElement findElement(By by) {
-            return null;
+        public <T extends WebElement> T findElement(By by) {
+            throw new NotImplementedException("MockWebDriver did not expect to findElement");
         }
 
         @Override
@@ -90,16 +216,85 @@ public class GenericTest {
         public Options manage() {
             return null;
         }
+
+        @Override
+        public Capabilities getCapabilities() {
+
+            final Map<String, Object> capabilities = new HashMap<>();
+
+            // These are needed to map the proxy element to a MobileElement.
+            capabilities.put(CapabilityType.PLATFORM_NAME, Platform.ANY.toString());
+            capabilities.put(MobileCapabilityType.AUTOMATION_NAME,
+                    AutomationName.IOS_XCUI_TEST.toString());
+
+            return new Capabilities() {
+
+                @Override
+                public Object getCapability(String capabilityName) {
+                    return capabilities.get(capabilityName);
+                }
+
+                @Override
+                public Map<String, Object> asMap() {
+                    return capabilities;
+                }
+            };
+        }
     }
 
     @Test
-    public void genericTestCse() {
-        Supplier<Boolean> result = () -> {
-            PageFactory
-                    .initElements(new AppiumFieldDecorator(new MockWebDriver()),
-                            new TempGenericPage<>());
-            return true;
-        };
-        assertTrue(result.get());
+    public void noGenericsTestCase() {
+        TempNoGenericsPage page = new TempNoGenericsPage();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void unBoundTestCase() {
+        TempUnboundPage<?> page = new TempUnboundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void unboundWebElementTestCase() {
+        TempUnboundPage<WebElement> page = new TempUnboundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void webBoundUnknownElementTestCase() {
+        TempWebBoundPage<?> page = new TempWebBoundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void webBoundWebElementTestCase() {
+        TempWebBoundPage<WebElement> page = new TempWebBoundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void webBoundMobileElementTestCase() {
+        TempWebBoundPage<MobileElement> page = new TempWebBoundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void mobileBoundUnknownElementTestCase() {
+        TempMobileBoundPage<?> page = new TempMobileBoundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
+    }
+
+    @Test
+    public void mobileBoundMobileElementTestCase() {
+        TempMobileBoundPage<MobileElement> page = new TempMobileBoundPage<>();
+        PageFactory.initElements(new AppiumFieldDecorator(new MockWebDriver()), page);
+        page.assertInit();
     }
 }


### PR DESCRIPTION
…ic type (#1150)

## Change list

When a page factory field is a list of a generic type, add an an addition check to see if the generic type is bound to one of the "availableElementClasses" (Web, Remote, Mobile, etc Element).
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

https://github.com/appium/java-client/issues/1150