### PR TITLE
Setting API should accept String type

### DIFF
--- a/src/main/java/io/appium/java_client/HasSettings.java
+++ b/src/main/java/io/appium/java_client/HasSettings.java
@@ -37,6 +37,18 @@ public interface HasSettings extends ExecutesMethod {
      * @param value   value of the setting.
      */
     default void setSetting(Setting setting, Object value) {
+        CommandExecutionHelper.execute(this, setSettingsCommand(setting.toString(), value));
+    }
+
+    /**
+     * Set a setting for this test session It's probably better to use a
+     * convenience function, rather than use this function directly. Try finding
+     * the method for the specific setting you want to change.
+     *
+     * @param setting Setting you wish to set.
+     * @param value   value of the setting.
+     */
+    default void setSetting(String setting, Object value) {
         CommandExecutionHelper.execute(this, setSettingsCommand(setting, value));
     }
 

--- a/src/main/java/io/appium/java_client/MobileCommand.java
+++ b/src/main/java/io/appium/java_client/MobileCommand.java
@@ -469,9 +469,9 @@ public class MobileCommand {
         return new AbstractMap.SimpleEntry<>(GET_SETTINGS, ImmutableMap.of());
     }
 
-    public static Map.Entry<String, Map<String, ?>> setSettingsCommand(Setting setting, Object value) {
+    public static Map.Entry<String, Map<String, ?>> setSettingsCommand(String setting, Object value) {
         return new AbstractMap.SimpleEntry<>(SET_SETTINGS, prepareArguments("settings",
-                prepareArguments(setting.toString(), value)));
+                prepareArguments(setting, value)));
     }
 
     /**

--- a/src/test/java/io/appium/java_client/android/SettingTest.java
+++ b/src/test/java/io/appium/java_client/android/SettingTest.java
@@ -92,6 +92,17 @@ public class SettingTest extends BaseAndroidTest {
             .get(Setting.TRACK_SCROLL_EVENTS.toString()));
     }
 
+    @Test public void testSettingByString() {
+        assertEquals(true, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+        driver.setSetting("shouldUseCompactResponses", false);
+        assertEquals(false, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+        driver.setSetting("shouldUseCompactResponses", true);
+        assertEquals(true, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+    }
+
     private void assertJSONElementContains(Setting setting, long value) {
         assertEquals(driver.getSettings().get(setting.toString()), value);
     }

--- a/src/test/java/io/appium/java_client/ios/SettingTest.java
+++ b/src/test/java/io/appium/java_client/ios/SettingTest.java
@@ -83,5 +83,16 @@ public class SettingTest extends AppIOSTest {
             .get(Setting.KEYBOARD_PREDICTION.toString()));
     }
 
+    @Test public void testSettingByString() {
+        assertEquals(true, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+        driver.setSetting("shouldUseCompactResponses", false);
+        assertEquals(false, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+        driver.setSetting("shouldUseCompactResponses", true);
+        assertEquals(true, driver.getSettings()
+                .get("shouldUseCompactResponses"));
+    }
+
 
 }


### PR DESCRIPTION
## Change list

Java-client Setting API `setSetting(Setting, Object)` only accepts enum `Setting`. It's good for type safe. But, when new settings are added on server, user cannot use it until client update.  I think this API should be more flexible. 

I propose that Setting API can also accept String type like capabilities.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
