### PR TITLE
fix: Avoid throwing null pointer exception if any of settings is equal to null

### DIFF
--- a/src/main/java/io/appium/java_client/HasSettings.java
+++ b/src/main/java/io/appium/java_client/HasSettings.java
@@ -63,8 +63,6 @@ public interface HasSettings extends ExecutesMethod {
     default Map<String, Object> getSettings() {
         Map.Entry<String, Map<String, ?>> keyValuePair = getSettingsCommand();
         Response response = execute(keyValuePair.getKey(), keyValuePair.getValue());
-
-        return ImmutableMap.<String, Object>builder()
-                .putAll(Map.class.cast(response.getValue())).build();
+        return (Map<String, Object>) response.getValue();
     }
 }


### PR DESCRIPTION
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Recently Appium started retuning `null` as setting value. This breaks ImmutableMap implementation, which does not allow nulls as values.
Addresses https://dev.azure.com/srinivasansekar/java-client/_build/results?buildId=290&view=ms.vss-test-web.build-test-results-tab&runId=1000428&resultId=100049&paneView=debug