### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ configurations {
 }
 
 dependencies {
-    ecj 'org.eclipse.jdt:ecj:3.18.0'
+    ecj 'org.eclipse.jdt:ecj:3.20.0'
     lombok 'org.projectlombok:lombok:1.18.8'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.owasp:dependency-check-gradle:5.3.0'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ configurations {
 
 dependencies {
     ecj 'org.eclipse.jdt:ecj:3.20.0'
-    lombok 'org.projectlombok:lombok:1.18.8'
+    lombok 'org.projectlombok:lombok:1.18.12'
 }
 
 compileJava {
@@ -52,8 +52,8 @@ compileJava {
 }
 
 dependencies {
-    compileOnly('org.projectlombok:lombok:1.18.8')
-    annotationProcessor('org.projectlombok:lombok:1.18.8')
+    compileOnly('org.projectlombok:lombok:1.18.12')
+    annotationProcessor('org.projectlombok:lombok:1.18.12')
     compile ("org.seleniumhq.selenium:selenium-java:${project.property('selenium.version')}") {
         force = true
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
         force = true
     }
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.apache.httpcomponents:httpclient:4.5.9'
+    compile 'org.apache.httpcomponents:httpclient:4.5.11'
     compile 'cglib:cglib:3.2.12'
     compile 'commons-validator:commons-validator:1.6'
     compile 'org.apache.commons:commons-lang3:3.9'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:5.1.0'
+        classpath 'org.owasp:dependency-check-gradle:5.3.0'
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     compile 'org.aspectj:aspectjweaver:1.9.5'
     compile 'org.slf4j:slf4j-api:1.7.30'
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13'
     testCompile 'org.hamcrest:hamcrest:2.1'
     testCompile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.6.1') {
         exclude group: 'org.seleniumhq.selenium'

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     testCompile 'junit:junit:4.13'
     testCompile 'org.hamcrest:hamcrest:2.2'
-    testCompile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.6.1') {
+    testCompile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.8.1') {
         exclude group: 'org.seleniumhq.selenium'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.30'
 
     testCompile 'junit:junit:4.13'
-    testCompile 'org.hamcrest:hamcrest:2.1'
+    testCompile 'org.hamcrest:hamcrest:2.2'
     testCompile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.6.1') {
         exclude group: 'org.seleniumhq.selenium'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     compile 'commons-validator:commons-validator:1.6'
     compile 'org.apache.commons:commons-lang3:3.9'
     compile 'commons-io:commons-io:2.6'
-    compile 'org.springframework:spring-context:5.1.8.RELEASE'
+    compile 'org.springframework:spring-context:5.2.3.RELEASE'
     compile 'org.aspectj:aspectjweaver:1.9.4'
     compile 'org.slf4j:slf4j-api:1.7.26'
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     }
     compile 'com.google.code.gson:gson:2.8.6'
     compile 'org.apache.httpcomponents:httpclient:4.5.11'
-    compile 'cglib:cglib:3.2.12'
+    compile 'cglib:cglib:3.3.0'
     compile 'commons-validator:commons-validator:1.6'
     compile 'org.apache.commons:commons-lang3:3.9'
     compile 'commons-io:commons-io:2.6'

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.9'
     compile 'commons-io:commons-io:2.6'
     compile 'org.springframework:spring-context:5.2.3.RELEASE'
-    compile 'org.aspectj:aspectjweaver:1.9.4'
+    compile 'org.aspectj:aspectjweaver:1.9.5'
     compile 'org.slf4j:slf4j-api:1.7.26'
 
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     compile ("org.seleniumhq.selenium:selenium-api:${project.property('selenium.version')}") {
         force = true
     }
-    compile 'com.google.code.gson:gson:2.8.5'
+    compile 'com.google.code.gson:gson:2.8.6'
     compile 'org.apache.httpcomponents:httpclient:4.5.9'
     compile 'cglib:cglib:3.2.12'
     compile 'commons-validator:commons-validator:1.6'

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     compile 'commons-io:commons-io:2.6'
     compile 'org.springframework:spring-context:5.2.3.RELEASE'
     compile 'org.aspectj:aspectjweaver:1.9.5'
-    compile 'org.slf4j:slf4j-api:1.7.26'
+    compile 'org.slf4j:slf4j-api:1.7.30'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest:2.1'


### PR DESCRIPTION
## Change list

- Bump dependency-check-gradle from 5.1.0 to 5.3.0
- Bump Gradle shadow plugin from 5.1.0 to 5.2.0
- Bump ECJ from 3.18.0 to 3.20.0
- Bump Lombok from 1.18.8 to 1.18.12
- Bump Gson from 2.8.5 to 2.8.6
- Bump Apache HttpClient from 4.5.9 to 4.5.11
- Bump cglib from 3.2.12 to 3.3.0
- Bump Spring from 5.1.8.RELEASE to 5.2.3.RELEASE
- Bump AspectJ from 1.9.4 to 1.9.5
- Bump SLF4J from 1.7.26 to 1.7.30
- Bump JUnit from 4.12 to 4.13
- Bump Hamcrest from 2.1 to 2.2
- Bump WebDriverManager from 3.6.1 to 3.8.1
 
## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)