### PR TITLE
feat: Make settings available for all AppiumDriver instances

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -68,7 +68,7 @@ import java.util.Set;
 @SuppressWarnings("unchecked")
 public class AppiumDriver<T extends WebElement>
         extends DefaultGenericMobileDriver<T> implements ComparesImages, FindsByImage<T>, FindsByCustom<T>,
-        ExecutesDriverScript, LogsEvents {
+        ExecutesDriverScript, LogsEvents, HasSettings {
 
     private static final ErrorHandler errorHandler = new ErrorHandler(new ErrorCodesMobile(), true);
     // frequently used command parameters

--- a/src/main/java/io/appium/java_client/HasSettings.java
+++ b/src/main/java/io/appium/java_client/HasSettings.java
@@ -19,12 +19,9 @@ package io.appium.java_client;
 import static io.appium.java_client.MobileCommand.getSettingsCommand;
 import static io.appium.java_client.MobileCommand.setSettingsCommand;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.openqa.selenium.remote.Response;
 
 import java.util.Map;
-
 
 public interface HasSettings extends ExecutesMethod {
 
@@ -34,10 +31,12 @@ public interface HasSettings extends ExecutesMethod {
      * the method for the specific setting you want to change.
      *
      * @param setting Setting you wish to set.
-     * @param value   value of the setting.
+     * @param value   Value of the setting.
+     * @return        Self instance for chaining.
      */
-    default void setSetting(Setting setting, Object value) {
+    default HasSettings setSetting(Setting setting, Object value) {
         CommandExecutionHelper.execute(this, setSettingsCommand(setting.toString(), value));
+        return this;
     }
 
     /**
@@ -45,11 +44,13 @@ public interface HasSettings extends ExecutesMethod {
      * convenience function, rather than use this function directly. Try finding
      * the method for the specific setting you want to change.
      *
-     * @param setting Setting you wish to set.
-     * @param value   value of the setting.
+     * @param settingName Setting name you wish to set.
+     * @param value       Value of the setting.
+     * @return            Self instance for chaining.
      */
-    default void setSetting(String setting, Object value) {
-        CommandExecutionHelper.execute(this, setSettingsCommand(setting, value));
+    default HasSettings setSetting(String settingName, Object value) {
+        CommandExecutionHelper.execute(this, setSettingsCommand(settingName, value));
+        return this;
     }
 
     /**

--- a/src/main/java/io/appium/java_client/HasSettings.java
+++ b/src/main/java/io/appium/java_client/HasSettings.java
@@ -35,8 +35,7 @@ public interface HasSettings extends ExecutesMethod {
      * @return        Self instance for chaining.
      */
     default HasSettings setSetting(Setting setting, Object value) {
-        CommandExecutionHelper.execute(this, setSettingsCommand(setting.toString(), value));
-        return this;
+        return setSetting(setting.toString(), value);
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/HasAndroidSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasAndroidSettings.java
@@ -33,8 +33,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings ignoreUnimportantViews(Boolean compress) {
-        setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.IGNORE_UNIMPORTANT_VIEWS, compress);
     }
 
     /**
@@ -45,8 +44,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetWaitForIdleTimeout(Duration timeout) {
-        setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, timeout.toMillis());
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, timeout.toMillis());
     }
 
     /**
@@ -57,8 +55,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetWaitForSelectorTimeout(Duration timeout) {
-        setSetting(Setting.WAIT_FOR_SELECTOR_TIMEOUT, timeout.toMillis());
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.WAIT_FOR_SELECTOR_TIMEOUT, timeout.toMillis());
     }
 
     /**
@@ -69,8 +66,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetScrollAcknowledgmentTimeout(Duration timeout) {
-        setSetting(Setting.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.WAIT_SCROLL_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
     }
 
     /**
@@ -81,8 +77,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetKeyInjectionDelay(Duration delay) {
-        setSetting(Setting.KEY_INJECTION_DELAY, delay.toMillis());
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.KEY_INJECTION_DELAY, delay.toMillis());
     }
 
     /**
@@ -93,8 +88,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetActionAcknowledgmentTimeout(Duration timeout) {
-        setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
-        return this;
+       return (HasAndroidSettings) setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
     }
 
     /**
@@ -111,8 +105,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings normalizeTagNames(boolean enabled) {
-        setSetting(Setting.NORMALIZE_TAG_NAMES, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.NORMALIZE_TAG_NAMES, enabled);
     }
 
     /**
@@ -124,8 +117,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings setShouldUseCompactResponses(boolean enabled) {
-        setSetting(Setting.SHOULD_USE_COMPACT_RESPONSES, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.SHOULD_USE_COMPACT_RESPONSES, enabled);
     }
 
     /**
@@ -136,8 +128,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings setElementResponseAttributes(String attrNames) {
-        setSetting(Setting.ELEMENT_RESPONSE_ATTRIBUTES, attrNames);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.ELEMENT_RESPONSE_ATTRIBUTES, attrNames);
     }
 
     /**
@@ -148,8 +139,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings allowInvisibleElements(boolean enabled) {
-        setSetting(Setting.ALLOW_INVISIBLE_ELEMENTS, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.ALLOW_INVISIBLE_ELEMENTS, enabled);
     }
 
     /**
@@ -162,8 +152,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings enableNotificationListener(boolean enabled) {
-        setSetting(Setting.ENABLE_NOTIFICATION_LISTENER, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.ENABLE_NOTIFICATION_LISTENER, enabled);
     }
 
     /**
@@ -174,8 +163,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings shutdownOnPowerDisconnect(boolean enabled) {
-        setSetting(Setting.SHUTDOWN_ON_POWER_DISCONNECT, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.SHUTDOWN_ON_POWER_DISCONNECT, enabled);
     }
 
     /**
@@ -188,7 +176,6 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings setTrackScrollEvents(boolean enabled) {
-        setSetting(Setting.TRACK_SCROLL_EVENTS, enabled);
-        return this;
+        return (HasAndroidSettings) setSetting(Setting.TRACK_SCROLL_EVENTS, enabled);
     }
 }

--- a/src/main/java/io/appium/java_client/android/HasAndroidSettings.java
+++ b/src/main/java/io/appium/java_client/android/HasAndroidSettings.java
@@ -88,7 +88,7 @@ interface HasAndroidSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasAndroidSettings configuratorSetActionAcknowledgmentTimeout(Duration timeout) {
-       return (HasAndroidSettings) setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
+        return (HasAndroidSettings) setSetting(Setting.WAIT_ACTION_ACKNOWLEDGMENT_TIMEOUT, timeout.toMillis());
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/HasIOSSettings.java
+++ b/src/main/java/io/appium/java_client/ios/HasIOSSettings.java
@@ -28,8 +28,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings nativeWebTap(Boolean enabled) {
-        setSetting(Setting.NATIVE_WEB_TAP, enabled);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.NATIVE_WEB_TAP, enabled);
     }
 
     /**
@@ -41,8 +40,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setShouldUseCompactResponses(boolean enabled) {
-        setSetting(Setting.SHOULD_USE_COMPACT_RESPONSES, enabled);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.SHOULD_USE_COMPACT_RESPONSES, enabled);
     }
 
     /**
@@ -53,8 +51,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setElementResponseAttributes(String attrNames) {
-        setSetting(Setting.ELEMENT_RESPONSE_ATTRIBUTES, attrNames);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.ELEMENT_RESPONSE_ATTRIBUTES, attrNames);
     }
 
     /**
@@ -66,8 +63,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setMjpegServerScreenshotQuality(int quality) {
-        setSetting(Setting.MJPEG_SERVER_SCREENSHOT_QUALITY, quality);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.MJPEG_SERVER_SCREENSHOT_QUALITY, quality);
     }
 
     /**
@@ -79,8 +75,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setMjpegServerFramerate(int framerate) {
-        setSetting(Setting.MJPEG_SERVER_FRAMERATE, framerate);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.MJPEG_SERVER_FRAMERATE, framerate);
     }
 
     /**
@@ -92,8 +87,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setScreenshotQuality(int quality) {
-        setSetting(Setting.SCREENSHOT_QUALITY, quality);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.SCREENSHOT_QUALITY, quality);
     }
 
     /**
@@ -104,8 +98,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setMjpegScalingFactor(int scale) {
-        setSetting(Setting.MJPEG_SCALING_FACTOR, scale);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.MJPEG_SCALING_FACTOR, scale);
     }
 
     /**
@@ -115,8 +108,7 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setKeyboardAutocorrection(boolean enabled) {
-        setSetting(Setting.KEYBOARD_AUTOCORRECTION, enabled);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.KEYBOARD_AUTOCORRECTION, enabled);
     }
 
     /**
@@ -126,7 +118,6 @@ interface HasIOSSettings extends HasSettings {
      * @return self instance for chaining
      */
     default HasIOSSettings setKeyboardPrediction(boolean enabled) {
-        setSetting(Setting.KEYBOARD_PREDICTION, enabled);
-        return this;
+        return (HasIOSSettings) setSetting(Setting.KEYBOARD_PREDICTION, enabled);
     }
 }

--- a/src/test/java/io/appium/java_client/ios/IOSAlertTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSAlertTest.java
@@ -38,7 +38,7 @@ public class IOSAlertTest extends AppIOSTest {
     private static final long ALERT_TIMEOUT_SECONDS = 5;
     private static final int CLICK_RETRIES = 2;
 
-    private WebDriverWait waiting = new WebDriverWait(driver, ALERT_TIMEOUT_SECONDS);
+    private final WebDriverWait waiter = new WebDriverWait(driver, ALERT_TIMEOUT_SECONDS);
     private static final String iOSAutomationText = "show alert";
 
     private void ensureAlertPresence() {
@@ -47,7 +47,11 @@ public class IOSAlertTest extends AppIOSTest {
         while (true) {
             try {
                 driver.findElement(MobileBy.AccessibilityId(iOSAutomationText)).click();
-                waiting.until(alertIsPresent());
+            } catch (WebDriverException e) {
+                // ignore
+            }
+            try {
+                waiter.until(alertIsPresent());
                 return;
             } catch (TimeoutException e) {
                 retry++;


### PR DESCRIPTION
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

It makes sense to make settings available for all AppiumDriver descendants by default, since on the server side the API is declared in base-driver, which means it works for all Appium drivers