### PR TITLE
change capabilities to use w3c compliant prefixes

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
@@ -32,13 +32,13 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * instead of {@code MainActivity}). By default this capability is received from the package
      * manifest (action: android.intent.action.MAIN , category: android.intent.category.LAUNCHER)
      */
-    String APP_ACTIVITY = "appActivity";
+    String APP_ACTIVITY = "appium:appActivity";
 
     /**
      * Java package of the Android app you want to run. By default this capability is received
      * from the package manifest ({@literal @}package attribute value)
      */
-    String APP_PACKAGE = "appPackage";
+    String APP_PACKAGE = "appium:appPackage";
 
     /**
      * Activity name/names, comma separated, for the Android activity you want to wait for.
@@ -47,42 +47,42 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * from the one which is set as {@code appActivity} if your capability has {@code appActivity}
      * and {@code appPackage}. You can also use wildcards ({@code *}).
      */
-    String APP_WAIT_ACTIVITY = "appWaitActivity";
+    String APP_WAIT_ACTIVITY = "appium:appWaitActivity";
 
     /**
      * Java package of the Android app you want to wait for.
      * By default the value of this capability is the same as for {@code appActivity}
      */
-    String APP_WAIT_PACKAGE = "appWaitPackage";
+    String APP_WAIT_PACKAGE = "appium:appWaitPackage";
 
     /**
      * Timeout in milliseconds used to wait for the appWaitActivity to launch (default 20000).
      * @since 1.6.0
      */
-    String APP_WAIT_DURATION = "appWaitDuration";
+    String APP_WAIT_DURATION = "appium:appWaitDuration";
 
     /**
      * Timeout in seconds while waiting for device to become ready.
      */
-    String DEVICE_READY_TIMEOUT = "deviceReadyTimeout";
+    String DEVICE_READY_TIMEOUT = "appium:deviceReadyTimeout";
 
     /**
      * Allow to install a test package which has {@code android:testOnly="true"} in the manifest.
      * {@code false} by default
      */
-    String ALLOW_TEST_PACKAGES = "allowTestPackages";
+    String ALLOW_TEST_PACKAGES = "appium:allowTestPackages";
 
     /**
      * Fully qualified instrumentation class. Passed to -w in adb shell
      * am instrument -e coverage true -w.
      */
-    String ANDROID_COVERAGE = "androidCoverage";
+    String ANDROID_COVERAGE = "appium:androidCoverage";
 
     /**
      * A broadcast action implemented by yourself which is used to dump coverage into file system.
      * Passed to -a in adb shell am broadcast -a
      */
-    String ANDROID_COVERAGE_END_INTENT = "androidCoverageEndIntent";
+    String ANDROID_COVERAGE_END_INTENT = "appium:androidCoverageEndIntent";
 
     /**
      * (Chrome and webview only) Enable Chromedriver's performance logging (default false).
@@ -90,92 +90,92 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * @deprecated move to {@link MobileCapabilityType#ENABLE_PERFORMANCE_LOGGING}
      */
     @Deprecated
-    String ENABLE_PERFORMANCE_LOGGING = "enablePerformanceLogging";
+    String ENABLE_PERFORMANCE_LOGGING = "appium:enablePerformanceLogging";
 
     /**
      * Timeout in seconds used to wait for a device to become ready after booting.
      */
-    String ANDROID_DEVICE_READY_TIMEOUT = "androidDeviceReadyTimeout";
+    String ANDROID_DEVICE_READY_TIMEOUT = "appium:androidDeviceReadyTimeout";
 
     /**
      * Port used to connect to the ADB server (default 5037).
      */
-    String ADB_PORT = "adbPort";
+    String ADB_PORT = "appium:adbPort";
 
     /**
      * Devtools socket name. Needed only when tested app is a Chromium embedding browser.
      * The socket is open by the browser and Chromedriver connects to it as a devtools client.
      */
-    String ANDROID_DEVICE_SOCKET = "androidDeviceSocket";
+    String ANDROID_DEVICE_SOCKET = "appium:androidDeviceSocket";
 
     /**
      * Timeout in milliseconds used to wait for an apk to install to the device. Defaults to `90000`.
      * @since 1.6.0
      */
-    String ANDROID_INSTALL_TIMEOUT = "androidInstallTimeout";
+    String ANDROID_INSTALL_TIMEOUT = "appium:androidInstallTimeout";
 
     /**
      * The name of the directory on the device in which the apk will be push before install.
      * Defaults to {@code /data/local/tmp}
      * @since 1.6.5
      */
-    String ANDROID_INSTALL_PATH = "androidInstallPath";
+    String ANDROID_INSTALL_PATH = "appium:androidInstallPath";
 
     /**
      * Name of avd to launch.
      */
-    String AVD = "avd";
+    String AVD = "appium:avd";
 
     /**
      * How long to wait in milliseconds for an avd to launch and connect to
      * ADB (default 120000).
      * @since 0.18.0
      */
-    String AVD_LAUNCH_TIMEOUT = "avdLaunchTimeout";
+    String AVD_LAUNCH_TIMEOUT = "appium:avdLaunchTimeout";
 
     /**
      * How long to wait in milliseconds for an avd to finish its
      * boot animations (default 120000).
      * @since 0.18.0
      */
-    String AVD_READY_TIMEOUT = "avdReadyTimeout";
+    String AVD_READY_TIMEOUT = "appium:avdReadyTimeout";
 
     /**
      * Additional emulator arguments used when launching an avd.
      */
-    String AVD_ARGS = "avdArgs";
+    String AVD_ARGS = "appium:avdArgs";
 
     /**
      * Use a custom keystore to sign apks, default false.
      */
-    String USE_KEYSTORE = "useKeystore";
+    String USE_KEYSTORE = "appium:useKeystore";
 
     /**
      * Path to custom keystore, default ~/.android/debug.keystore.
      */
-    String KEYSTORE_PATH = "keystorePath";
+    String KEYSTORE_PATH = "appium:keystorePath";
 
     /**
      * Password for custom keystore.
      */
-    String KEYSTORE_PASSWORD = "keystorePassword";
+    String KEYSTORE_PASSWORD = "appium:keystorePassword";
 
     /**
      * Alias for key.
      */
-    String KEY_ALIAS = "keyAlias";
+    String KEY_ALIAS = "appium:keyAlias";
 
     /**
      * Password for key.
      */
-    String KEY_PASSWORD = "keyPassword";
+    String KEY_PASSWORD = "appium:keyPassword";
 
     /**
      * The absolute local path to webdriver executable (if Chromium embedder provides
      * its own webdriver, it should be used instead of original chromedriver
      * bundled with Appium).
      */
-    String CHROMEDRIVER_EXECUTABLE = "chromedriverExecutable";
+    String CHROMEDRIVER_EXECUTABLE = "appium:chromedriverExecutable";
 
     /**
      * An array of arguments to be passed to the chromedriver binary when it's run by Appium.
@@ -183,34 +183,34 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * {@code --adb-port}, and {@code --log-path}.
      * @since 1.12.0
      */
-    String CHROMEDRIVER_ARGS = "chromedriverArgs";
+    String CHROMEDRIVER_ARGS = "appium:chromedriverArgs";
 
     /**
      * The absolute path to a directory to look for Chromedriver executables in, for automatic discovery of compatible
      * Chromedrivers. Ignored if {@code chromedriverUseSystemExecutable} is {@code true}
      * @since 1.8.0
      */
-    String CHROMEDRIVER_EXECUTABLE_DIR = "chromedriverExecutableDir";
+    String CHROMEDRIVER_EXECUTABLE_DIR = "appium:chromedriverExecutableDir";
 
     /**
      * The absolute path to a file which maps Chromedriver versions to the minimum Chrome that it supports.
      * Ignored if {@code chromedriverUseSystemExecutable} is {@code true}
      * @since 1.8.0
      */
-    String CHROMEDRIVER_CHROME_MAPPING_FILE = "chromedriverChromeMappingFile";
+    String CHROMEDRIVER_CHROME_MAPPING_FILE = "appium:chromedriverChromeMappingFile";
 
     /**
      * If true, bypasses automatic Chromedriver configuration and uses the version that comes downloaded with Appium.
      * Ignored if {@code chromedriverExecutable} is set. Defaults to {@code false}
      * @since 1.9.0
      */
-    String CHROMEDRIVER_USE_SYSTEM_EXECUTABLE = "chromedriverUseSystemExecutable";
+    String CHROMEDRIVER_USE_SYSTEM_EXECUTABLE = "appium:chromedriverUseSystemExecutable";
 
     /**
      * Numeric port to start Chromedriver on. Note that use of this capability is discouraged as it will cause undefined
      * behavior in case there are multiple webviews present. By default Appium will find a free port.
      */
-    String CHROMEDRIVER_PORT = "chromedriverPort";
+    String CHROMEDRIVER_PORT = "appium:chromedriverPort";
 
     /**
      * A list of valid ports for Appium to use for communication with Chromedrivers. This capability supports multiple
@@ -219,43 +219,43 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * By default, Appium will use any free port.
      * @since 1.13.0
      */
-    String CHROMEDRIVER_PORTS = "chromedriverPorts";
+    String CHROMEDRIVER_PORTS = "appium:chromedriverPorts";
 
     /**
      * Sets the chromedriver flag {@code --disable-build-check} for Chrome webview tests.
      * @since 1.11.0
      */
-    String CHROMEDRIVER_DISABLE_BUILD_CHECK = "chromedriverDisableBuildCheck";
+    String CHROMEDRIVER_DISABLE_BUILD_CHECK = "appium:chromedriverDisableBuildCheck";
 
     /**
      * Amount of time to wait for Webview context to become active, in ms. Defaults to 2000.
      * @since 1.5.2
      */
-    String AUTO_WEBVIEW_TIMEOUT = "autoWebviewTimeout";
+    String AUTO_WEBVIEW_TIMEOUT = "appium:autoWebviewTimeout";
 
     /**
      * Intent action which will be used to start activity
      * (default android.intent.action.MAIN).
      */
-    String INTENT_ACTION = "intentAction";
+    String INTENT_ACTION = "appium:intentAction";
 
     /**
      * Intent category which will be used to start
      * activity (default android.intent.category.LAUNCHER).
      */
-    String INTENT_CATEGORY = "intentCategory";
+    String INTENT_CATEGORY = "appium:intentCategory";
 
     /**
      * Flags that will be used to start activity (default 0x10200000).
      */
-    String INTENT_FLAGS = "intentFlags";
+    String INTENT_FLAGS = "appium:intentFlags";
 
     /**
      * Additional intent arguments that will be used to start activity. See
      * <a href="https://developer.android.com/reference/android/content/Intent.html">
      * Intent arguments</a>.
      */
-    String OPTIONAL_INTENT_ARGUMENTS = "optionalIntentArguments";
+    String OPTIONAL_INTENT_ARGUMENTS = "appium:optionalIntentArguments";
 
     /**
      * Doesn't stop the process of the app under test, before starting the app using adb.
@@ -266,26 +266,26 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * With this capability omitted or set to false, we include the -S flag. Default false
      * @since 1.4.0
      */
-    String DONT_STOP_APP_ON_RESET = "dontStopAppOnReset";
+    String DONT_STOP_APP_ON_RESET = "appium:dontStopAppOnReset";
 
     /**
      * Enable Unicode input, default false.
      * @since 1.2.0
      */
-    String UNICODE_KEYBOARD = "unicodeKeyboard";
+    String UNICODE_KEYBOARD = "appium:unicodeKeyboard";
 
     /**
      * Reset keyboard to its original state, after running Unicode tests with
      * unicodeKeyboard capability. Ignored if used alone. Default false
      */
-    String RESET_KEYBOARD = "resetKeyboard";
+    String RESET_KEYBOARD = "appium:resetKeyboard";
 
     /**
      * Skip checking and signing of app with debug keys, will work only with
      * UiAutomator and not with selendroid, default false.
      * @since 1.2.2
      */
-    String NO_SIGN = "noSign";
+    String NO_SIGN = "appium:noSign";
 
     /**
      * Calls the setCompressedLayoutHierarchy() uiautomator function.
@@ -294,7 +294,7 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * which is why this capability has also been implemented as a toggle-able
      * setting as well as a capability. Defaults to false.
      */
-    String IGNORE_UNIMPORTANT_VIEWS = "ignoreUnimportantViews";
+    String IGNORE_UNIMPORTANT_VIEWS = "appium:ignoreUnimportantViews";
 
     /**
      * Disables android watchers that watch for application not responding and application crash,
@@ -302,7 +302,7 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * UiAutomator and not with selendroid, default false.
      * @since 1.4.0
      */
-    String DISABLE_ANDROID_WATCHERS = "disableAndroidWatchers";
+    String DISABLE_ANDROID_WATCHERS = "appium:disableAndroidWatchers";
 
     /**
      * Allows passing chromeOptions capability for ChromeDriver.
@@ -310,55 +310,55 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * <a href="https://sites.google.com/a/chromium.org/chromedriver/capabilities">
      * chromeOptions</a>.
      */
-    String CHROME_OPTIONS = "chromeOptions";
+    String CHROME_OPTIONS = "appium:chromeOptions";
 
     /**
      * Kill ChromeDriver session when moving to a non-ChromeDriver webview.
      * Defaults to false
      */
-    String RECREATE_CHROME_DRIVER_SESSIONS = "recreateChromeDriverSessions";
+    String RECREATE_CHROME_DRIVER_SESSIONS = "appium:recreateChromeDriverSessions";
 
     /**
      * In a web context, use native (adb) method for taking a screenshot, rather than proxying
      * to ChromeDriver, default false.
      * @since 1.5.3
      */
-    String NATIVE_WEB_SCREENSHOT = "nativeWebScreenshot";
+    String NATIVE_WEB_SCREENSHOT = "appium:nativeWebScreenshot";
 
     /**
      * The name of the directory on the device in which the screenshot will be put.
      * Defaults to /data/local/tmp.
      * @since 1.6.0
      */
-    String ANDROID_SCREENSHOT_PATH = "androidScreenshotPath";
+    String ANDROID_SCREENSHOT_PATH = "appium:androidScreenshotPath";
 
     /**
      * Set the network speed emulation. Specify the maximum network upload and download speeds. Defaults to {@code full}
      */
-    String NETWORK_SPEED = "networkSpeed";
+    String NETWORK_SPEED = "appium:networkSpeed";
 
     /**
      * Toggle gps location provider for emulators before starting the session. By default the emulator will have this
      * option enabled or not according to how it has been provisioned.
      */
-    String GPS_ENABLED = "gpsEnabled";
+    String GPS_ENABLED = "appium:gpsEnabled";
 
     /**
      * Set this capability to {@code true} to run the Emulator headless when device display is not needed to be visible.
      * {@code false} is the default value. isHeadless is also support for iOS, check XCUITest-specific capabilities.
      */
-    String IS_HEADLESS = "isHeadless";
+    String IS_HEADLESS = "appium:isHeadless";
 
     /**
      * Timeout in milliseconds used to wait for adb command execution. Defaults to {@code 20000}
      */
-    String ADB_EXEC_TIMEOUT = "adbExecTimeout";
+    String ADB_EXEC_TIMEOUT = "appium:adbExecTimeout";
 
     /**
      * Sets the locale <a href="https://developer.android.com/reference/java/util/Locale">script</a>.
      * @since 1.10.0
      */
-    String LOCALE_SCRIPT = "localeScript";
+    String LOCALE_SCRIPT = "appium:localeScript";
 
     /**
      * Skip device initialization which includes i.a.: installation and running of Settings app or setting of
@@ -366,14 +366,14 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * it's prepared for the next automation. Defaults to {@code false}
      * @since 1.11.0
      */
-    String SKIP_DEVICE_INITIALIZATION = "skipDeviceInitialization";
+    String SKIP_DEVICE_INITIALIZATION = "appium:skipDeviceInitialization";
 
     /**
      * Have Appium automatically determine which permissions your app requires and
      * grant them to the app on install. Defaults to {@code false}. If noReset is {@code true}, this capability doesn't
      * work.
      */
-    String AUTO_GRANT_PERMISSIONS = "autoGrantPermissions";
+    String AUTO_GRANT_PERMISSIONS = "appium:autoGrantPermissions";
 
     /**
      * Allow for correct handling of orientation on landscape-oriented devices.
@@ -381,7 +381,7 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * Defaults to {@code false}.
      * @since 1.6.4
      */
-    String ANDROID_NATURAL_ORIENTATION = "androidNaturalOrientation";
+    String ANDROID_NATURAL_ORIENTATION = "appium:androidNaturalOrientation";
 
     /**
      * {@code systemPort} used to connect to <a href="https://github.com/appium/appium-uiautomator2-server">
@@ -393,18 +393,18 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * <a href="https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/parallel-tests.md#parallel-android-tests">
      * Parallel Testing Setup Guide</a> for more details.
      */
-    String SYSTEM_PORT = "systemPort";
+    String SYSTEM_PORT = "appium:systemPort";
 
     /**
      * Optional remote ADB server host.
      * @since 1.7.0
      */
-    String REMOTE_ADB_HOST = "remoteAdbHost";
+    String REMOTE_ADB_HOST = "appium:remoteAdbHost";
 
     /**
      * Skips unlock during session creation. Defaults to {@code false}
      */
-    String SKIP_UNLOCK = "skipUnlock";
+    String SKIP_UNLOCK = "appium:skipUnlock";
 
     /**
      * Unlock the target device with particular lock pattern instead of just waking up the device with a helper app.
@@ -413,25 +413,25 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * Read <a href="https://github.com/appium/appium-android-driver/blob/master/docs/UNLOCK.md">unlock doc</a> in
      * android driver.
      */
-    String UNLOCK_TYPE = "unlockType";
+    String UNLOCK_TYPE = "appium:unlockType";
 
     /**
      * A key pattern to unlock used by {@code unlockType}.
      */
-    String UNLOCK_KEY = "unlockKey";
+    String UNLOCK_KEY = "appium:unlockKey";
 
     /**
      * Initializing the app under test automatically.
      * Appium does not launch the app under test if this is {@code false}. Defaults to {@code true}
      */
-    String AUTO_LAUNCH = "autoLaunch";
+    String AUTO_LAUNCH = "appium:autoLaunch";
 
     /**
      * Skips to start capturing logcat. It might improve performance such as network.
      * Log related commands will not work. Defaults to {@code false}.
      * @since 1.12.0
      */
-    String SKIP_LOGCAT_CAPTURE = "skipLogcatCapture";
+    String SKIP_LOGCAT_CAPTURE = "appium:skipLogcatCapture";
 
     /**
      * A package, list of packages or * to uninstall package/s before installing apks for test.
@@ -440,12 +440,12 @@ public interface AndroidMobileCapabilityType extends CapabilityType {
      * manage them.
      * @since 1.12.0
      */
-    String UNINSTALL_OTHER_PACKAGES = "uninstallOtherPackages";
+    String UNINSTALL_OTHER_PACKAGES = "appium:uninstallOtherPackages";
 
     /**
      * Set device animation scale zero if the value is {@code true}. After session is complete, Appium restores the
      * animation scale to it's original value. Defaults to {@code false}
      * @since 1.9.0
      */
-    String DISABLE_WINDOW_ANIMATION = "disableWindowAnimation";
+    String DISABLE_WINDOW_ANIMATION = "appium:disableWindowAnimation";
 }

--- a/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
@@ -33,7 +33,7 @@ public interface IOSMobileCapabilityType extends CapabilityType {
     /**
      * (Sim-only) Calendar format to set for the iOS Simulator.
      */
-    String CALENDAR_FORMAT = "calendarFormat";
+    String CALENDAR_FORMAT = "appium:calendarFormat";
 
     /**
      * Bundle ID of the app under test. Useful for starting an app on a real device
@@ -41,19 +41,19 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * To run a test on a real device using the bundle ID,
      * you may omit the 'app' capability, but you must provide 'udid'.
      */
-    String BUNDLE_ID = "bundleId";
+    String BUNDLE_ID = "appium:bundleId";
 
     /**
      * Amount of time in ms to wait for instruments before assuming it hung and
      * failing the session.
      */
-    String LAUNCH_TIMEOUT = "launchTimeout";
+    String LAUNCH_TIMEOUT = "appium:launchTimeout";
 
     /**
      * (Sim-only) Force location services to be either on or off.
      * Default is to keep current sim setting.
      */
-    String LOCATION_SERVICES_ENABLED = "locationServicesEnabled";
+    String LOCATION_SERVICES_ENABLED = "appium:locationServicesEnabled";
 
     /**
      * (Sim-only) Set location services to be authorized or not authorized for app via plist,
@@ -61,123 +61,123 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * setting. Note that if you use this setting you MUST also use the bundleId
      * capability to send in your app's bundle ID.
      */
-    String LOCATION_SERVICES_AUTHORIZED = "locationServicesAuthorized";
+    String LOCATION_SERVICES_AUTHORIZED = "appium:locationServicesAuthorized";
 
     /**
      * Accept all iOS alerts automatically if they pop up.
      * This includes privacy access permission alerts
      * (e.g., location, contacts, photos). Default is false.
      */
-    String AUTO_ACCEPT_ALERTS = "autoAcceptAlerts";
+    String AUTO_ACCEPT_ALERTS = "appium:autoAcceptAlerts";
 
     /**
      * Dismiss all iOS alerts automatically if they pop up.
      * This includes privacy access permission alerts (e.g.,
      * location, contacts, photos). Default is false.
      */
-    String AUTO_DISMISS_ALERTS = "autoDismissAlerts";
+    String AUTO_DISMISS_ALERTS = "appium:autoDismissAlerts";
 
     /**
      * Use native intruments lib (ie disable instruments-without-delay).
      */
-    String NATIVE_INSTRUMENTS_LIB = "nativeInstrumentsLib";
+    String NATIVE_INSTRUMENTS_LIB = "appium:nativeInstrumentsLib";
 
     /**
      * Enable "real", non-javascript-based web taps in Safari.
      * Default: false.
      * Warning: depending on viewport size/ratio this might not accurately tap an element.
      */
-    String NATIVE_WEB_TAP = "nativeWebTap";
+    String NATIVE_WEB_TAP = "appium:nativeWebTap";
 
     /**
      * (Sim-only) (&gt;= 8.1) Initial safari url, default is a local welcome page.
      */
-    String SAFARI_INITIAL_URL = "safariInitialUrl";
+    String SAFARI_INITIAL_URL = "appium:safariInitialUrl";
 
     /**
      * (Sim-only) Allow javascript to open new windows in Safari. Default keeps current sim
      * setting.
      */
-    String SAFARI_ALLOW_POPUPS = "safariAllowPopups";
+    String SAFARI_ALLOW_POPUPS = "appium:safariAllowPopups";
 
     /**
      * (Sim-only) Prevent Safari from showing a fraudulent website warning.
      * Default keeps current sim setting.
      */
-    String SAFARI_IGNORE_FRAUD_WARNING = "safariIgnoreFraudWarning";
+    String SAFARI_IGNORE_FRAUD_WARNING = "appium:safariIgnoreFraudWarning";
 
     /**
      * (Sim-only) Whether Safari should allow links to open in new windows.
      * Default keeps current sim setting.
      */
-    String SAFARI_OPEN_LINKS_IN_BACKGROUND = "safariOpenLinksInBackground";
+    String SAFARI_OPEN_LINKS_IN_BACKGROUND = "appium:safariOpenLinksInBackground";
 
     /**
      * (Sim-only) Whether to keep keychains (Library/Keychains) when appium
      * session is started/finished.
      */
-    String KEEP_KEY_CHAINS = "keepKeyChains";
+    String KEEP_KEY_CHAINS = "appium:keepKeyChains";
 
     /**
      * Where to look for localizable strings. Default en.lproj.
      */
-    String LOCALIZABLE_STRINGS_DIR = "localizableStringsDir";
+    String LOCALIZABLE_STRINGS_DIR = "appium:localizableStringsDir";
 
     /**
      * Arguments to pass to the AUT using instruments.
      */
-    String PROCESS_ARGUMENTS = "processArguments";
+    String PROCESS_ARGUMENTS = "appium:processArguments";
 
     /**
      * The delay, in ms, between keystrokes sent to an element when typing.
      */
-    String INTER_KEY_DELAY = "interKeyDelay";
+    String INTER_KEY_DELAY = "appium:interKeyDelay";
 
     /**
      * Whether to show any logs captured from a device in the appium logs. Default false.
      */
-    String SHOW_IOS_LOG = "showIOSLog";
+    String SHOW_IOS_LOG = "appium:showIOSLog";
 
     /**
      * strategy to use to type test into a test field. Simulator default: oneByOne.
      * Real device default: grouped.
      */
-    String SEND_KEY_STRATEGY = "sendKeyStrategy";
+    String SEND_KEY_STRATEGY = "appium:sendKeyStrategy";
 
     /**
      * Max timeout in sec to wait for a screenshot to be generated. default: 10.
      */
-    String SCREENSHOT_WAIT_TIMEOUT = "screenshotWaitTimeout";
+    String SCREENSHOT_WAIT_TIMEOUT = "appium:screenshotWaitTimeout";
 
     /**
      * The ios automation script used to determined if the app has been launched,
      * by default the system wait for the page source not to be empty.
      * The result must be a boolean.
      */
-    String WAIT_FOR_APP_SCRIPT = "waitForAppScript";
+    String WAIT_FOR_APP_SCRIPT = "appium:waitForAppScript";
 
     /**
      * Number of times to send connection message to remote debugger, to get webview.
      * Default: 8.
      */
-    String WEBVIEW_CONNECT_RETRIES = "webviewConnectRetries";
+    String WEBVIEW_CONNECT_RETRIES = "appium:webviewConnectRetries";
 
     /**
      * The display name of the application under test. Used to automate backgrounding
      * the app in iOS 9+.
      */
-    String APP_NAME = "appName";
+    String APP_NAME = "appium:appName";
 
     /**
      * (Sim only) Add an SSL certificate to IOS Simulator.
      */
-    String CUSTOM_SSL_CERT = "customSSLCert";
+    String CUSTOM_SSL_CERT = "appium:customSSLCert";
 
     /**
      * The desired capability to specify a length for tapping, if the regular
      * tap is too long for the app under test. The  XCUITest specific capability.
      */
-    String TAP_WITH_SHORT_PRESS_DURATION = "tapWithShortPressDuration";
+    String TAP_WITH_SHORT_PRESS_DURATION = "appium:tapWithShortPressDuration";
 
     /**
      * Simulator scale factor.
@@ -186,7 +186,7 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * to see the whole device screen without scrolling.
      * This capability only works below Xcode9.
      */
-    String SCALE_FACTOR = "scaleFactor";
+    String SCALE_FACTOR = "appium:scaleFactor";
 
     /**
      * This value if specified, will be used to forward traffic from Mac
@@ -194,21 +194,21 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * number used by WDA on device.
      * eg: 8100
      */
-    String WDA_LOCAL_PORT = "wdaLocalPort";
+    String WDA_LOCAL_PORT = "appium:wdaLocalPort";
 
     /**
      * Whether to display the output of the Xcode command
      * used to run the tests.If this is true,
      * there will be lots of extra logging at startup. Defaults to false
      */
-    String SHOW_XCODE_LOG = "showXcodeLog";
+    String SHOW_XCODE_LOG = "appium:showXcodeLog";
 
     /**
      * Time in milliseconds to pause between installing the application
      * and starting WebDriverAgent on the device. Used particularly for larger applications.
      * Defaults to 0
      */
-    String IOS_INSTALL_PAUSE = "iosInstallPause";
+    String IOS_INSTALL_PAUSE = "appium:iosInstallPause";
 
     /**
      * Full path to an optional Xcode configuration file that
@@ -216,19 +216,19 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * and team for running the WebDriverAgent on the real device.
      * e.g., /path/to/myconfig.xcconfig
      */
-    String XCODE_CONFIG_FILE = "xcodeConfigFile";
+    String XCODE_CONFIG_FILE = "appium:xcodeConfigFile";
 
     /**
      * Password for unlocking keychain specified in keychainPath.
      */
-    String KEYCHAIN_PASSWORD = "keychainPassword";
+    String KEYCHAIN_PASSWORD = "appium:keychainPassword";
 
     /**
      * Skips the build phase of running the WDA app.
      * Building is then the responsibility of the user.
      * Only works for Xcode 8+. Defaults to false
      */
-    String USE_PREBUILT_WDA = "usePrebuiltWDA";
+    String USE_PREBUILT_WDA = "appium:usePrebuiltWDA";
 
     /**
      * Sets read only permissons to Attachments subfolder of WebDriverAgent
@@ -241,14 +241,14 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * @deprecated This capability was deleted at Appium 1.14.0
      */
     @Deprecated
-    String PREVENT_WDAATTACHMENTS = "preventWDAAttachments";
+    String PREVENT_WDAATTACHMENTS = "appium:preventWDAAttachments";
 
     /**
      * Appium will connect to an existing WebDriverAgent,
      * instance at this URL instead of starting a new one.
      * eg : http://localhost:8100
      */
-    String WEB_DRIVER_AGENT_URL = "webDriverAgentUrl";
+    String WEB_DRIVER_AGENT_URL = "appium:webDriverAgentUrl";
 
     /**
      * Full path to the private development key exported
@@ -256,7 +256,7 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * with keychainPassword when testing on real devices.
      * e.g., /path/to/MyPrivateKey.p12
      */
-    String KEYCHAIN_PATH = "keychainPath";
+    String KEYCHAIN_PATH = "appium:keychainPath";
 
     /**
      * If {@code true}, forces uninstall of any existing WebDriverAgent app on device.
@@ -272,38 +272,38 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * listening and {@code webDriverAgentUrl} capability is not set. The negative/unset value of {@code useNewWDA}
      * capability has no effect prior to xcuitest driver version 2.35.0.
      */
-    String USE_NEW_WDA = "useNewWDA";
+    String USE_NEW_WDA = "appium:useNewWDA";
 
     /**
      * Time, in ms, to wait for WebDriverAgent to be pingable. Defaults to 60000ms.
      */
-    String WDA_LAUNCH_TIMEOUT = "wdaLaunchTimeout";
+    String WDA_LAUNCH_TIMEOUT = "appium:wdaLaunchTimeout";
 
     /**
      * Timeout, in ms, for waiting for a response from WebDriverAgent. Defaults to 240000ms.
      */
-    String WDA_CONNECTION_TIMEOUT = "wdaConnectionTimeout";
+    String WDA_CONNECTION_TIMEOUT = "appium:wdaConnectionTimeout";
 
     /**
      * Apple developer team identifier string.
      * Must be used in conjunction with xcodeSigningId to take effect.
      * e.g., JWL241K123
      */
-    String XCODE_ORG_ID = "xcodeOrgId";
+    String XCODE_ORG_ID = "appium:xcodeOrgId";
 
     /**
      * String representing a signing certificate.
      * Must be used in conjunction with xcodeOrgId.
      * This is usually just iPhone Developer, so the default (if not included) is iPhone Developer
      */
-    String XCODE_SIGNING_ID = "xcodeSigningId";
+    String XCODE_SIGNING_ID = "appium:xcodeSigningId";
 
     /**
      * Bundle id to update WDA to before building and launching on real devices.
      * This bundle id must be associated with a valid provisioning profile.
      * e.g., io.appium.WebDriverAgentRunner.
      */
-    String UPDATE_WDA_BUNDLEID = "updatedWDABundleId";
+    String UPDATE_WDA_BUNDLEID = "appium:updatedWDABundleId";
 
     /**
      * Whether to perform reset on test session finish (false) or not (true).
@@ -312,7 +312,7 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * duration of test session initialization.
      * Defaults to true.
      */
-    String RESET_ON_SESSION_START_ONLY = "resetOnSessionStartOnly";
+    String RESET_ON_SESSION_START_ONLY = "appium:resetOnSessionStartOnly";
 
     /**
      * Custom timeout(s) in milliseconds for WDA backend commands execution.
@@ -326,32 +326,32 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * timeouts in milliseconds. You can also set the 'default' key to assign
      * the timeout for all other commands not explicitly enumerated as JSON keys.
      */
-    String COMMAND_TIMEOUTS = "commandTimeouts";
+    String COMMAND_TIMEOUTS = "appium:commandTimeouts";
 
     /**
      * Number of times to try to build and launch WebDriverAgent onto the device.
      * Defaults to 2.
      */
-    String WDA_STARTUP_RETRIES = "wdaStartupRetries";
+    String WDA_STARTUP_RETRIES = "appium:wdaStartupRetries";
 
     /**
      * Time, in ms, to wait between tries to build and launch WebDriverAgent.
      * Defaults to 10000ms.
      */
-    String WDA_STARTUP_RETRY_INTERVAL = "wdaStartupRetryInterval";
+    String WDA_STARTUP_RETRY_INTERVAL = "appium:wdaStartupRetryInterval";
 
     /**
      * Set this option to true in order to enable hardware keyboard in Simulator.
      * It is set to false by default, because this helps to workaround some XCTest bugs.
      */
-    String CONNECT_HARDWARE_KEYBOARD = "connectHardwareKeyboard";
+    String CONNECT_HARDWARE_KEYBOARD = "appium:connectHardwareKeyboard";
 
     /**
      * Maximum frequency of keystrokes for typing and clear.
      * If your tests are failing because of typing errors, you may want to adjust this.
      * Defaults to 60 keystrokes per minute.
      */
-    String MAX_TYPING_FREQUENCY = "maxTypingFrequency";
+    String MAX_TYPING_FREQUENCY = "appium:maxTypingFrequency";
 
     /**
      * Use native methods for determining visibility of elements.
@@ -361,19 +361,19 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * This can, however, lead to false results in some situations.
      * Defaults to false, except iOS 9.3, where it defaults to true.
      */
-    String SIMPLE_ISVISIBLE_CHECK = "simpleIsVisibleCheck";
+    String SIMPLE_ISVISIBLE_CHECK = "appium:simpleIsVisibleCheck";
 
     /**
      * Use SSL to download dependencies for WebDriverAgent. Defaults to false.
      */
-    String USE_CARTHAGE_SSL = "useCarthageSsl";
+    String USE_CARTHAGE_SSL = "appium:useCarthageSsl";
 
     /**
      * Use default proxy for test management within WebDriverAgent.
      * Setting this to false sometimes helps with socket hangup problems.
      * Defaults to true.
      */
-    String SHOULD_USE_SINGLETON_TESTMANAGER = "shouldUseSingletonTestManager";
+    String SHOULD_USE_SINGLETON_TESTMANAGER = "appium:shouldUseSingletonTestManager";
 
     /**
      * Set this to true if you want to start ios_webkit_debug proxy server
@@ -381,11 +381,11 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * The capatibility only works for real device automation.
      * Defaults to false.
      */
-    String START_IWDP = "startIWDP";
+    String START_IWDP = "appium:startIWDP";
 
     /**
      * Enrolls simulator for touch id. Defaults to false.
      */
-    String ALLOW_TOUCHID_ENROLL = "allowTouchIdEnroll";
+    String ALLOW_TOUCHID_ENROLL = "appium:allowTouchIdEnroll";
 
 }

--- a/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
@@ -29,23 +29,23 @@ public interface MobileCapabilityType extends CapabilityType {
     /**
      * Which automation engine to use.
      */
-    String AUTOMATION_NAME = "automationName";
+    String AUTOMATION_NAME = "appium:automationName";
 
     /**
      * Mobile OS version.
      */
-    String PLATFORM_VERSION = "platformVersion";
+    String PLATFORM_VERSION = "appium:platformVersion";
 
     /**
      * The kind of mobile device or emulator to use.
      */
-    String DEVICE_NAME = "deviceName";
+    String DEVICE_NAME = "appium:deviceName";
 
     /**
      * How long (in seconds) Appium will wait for a new command from the
      * client before assuming the client quit and ending the session.
      */
-    String NEW_COMMAND_TIMEOUT = "newCommandTimeout";
+    String NEW_COMMAND_TIMEOUT = "appium:newCommandTimeout";
 
     /**
      * The absolute local path or remote http URL to a {@code .ipa} file (IOS),
@@ -58,38 +58,38 @@ public interface MobileCapabilityType extends CapabilityType {
      * here</a>
      * about {@code .apks} file.
      */
-    String APP = "app";
+    String APP = "appium:app";
 
     /**
      * Unique device identifier of the connected physical device.
      */
-    String UDID = "udid";
+    String UDID = "appium:udid";
 
     /**
      * Sauce-specific.
      */
-    String APPIUM_VERSION = "appiumVersion";
+    String APPIUM_VERSION = "sauce:appiumVersion";
 
     /**
      * Language to set for iOS (XCUITest driver only) and Android.
      */
-    String LANGUAGE = "language";
+    String LANGUAGE = "appium:language";
 
     /**
      * Locale to set for iOS (XCUITest driver only) and Android.
      * {@code fr_CA} format for iOS. {@code CA} format (country name abbreviation) for Android
      */
-    String LOCALE = "locale";
+    String LOCALE = "appium:locale";
 
     /**
      * (Sim/Emu-only) start in a certain orientation.
      */
-    String ORIENTATION = "orientation";
+    String ORIENTATION = "appium:orientation";
 
     /**
      * Move directly into Webview context. Default false.
      */
-    String AUTO_WEBVIEW = "autoWebview";
+    String AUTO_WEBVIEW = "appium:autoWebview";
 
     /**
      * Don't reset app state before this session. See
@@ -97,7 +97,7 @@ public interface MobileCapabilityType extends CapabilityType {
      * here</a>
      * for more detail.
      */
-    String NO_RESET = "noReset";
+    String NO_RESET = "appium:noReset";
 
     /**
      * Perform a complete reset. See
@@ -105,13 +105,13 @@ public interface MobileCapabilityType extends CapabilityType {
      * here</a>
      * for more detail.
      */
-    String FULL_RESET = "fullReset";
+    String FULL_RESET = "appium:fullReset";
 
     /**
      * The desired capability which specifies whether to delete any generated files at
      * the end of a session (see iOS and Android entries for particulars).
      */
-    String CLEAR_SYSTEM_FILES = "clearSystemFiles";
+    String CLEAR_SYSTEM_FILES = "appium:clearSystemFiles";
 
     /**
      * Enable or disable the reporting of the timings for various Appium-internal events
@@ -121,13 +121,13 @@ public interface MobileCapabilityType extends CapabilityType {
      * <a href="https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/event-timings.md">
      * event timing docs</a> for the the structure of this response.
      */
-    String EVENT_TIMINGS = "eventTimings";
+    String EVENT_TIMINGS = "appium:eventTimings";
 
     /**
-     * This is the flag which forces server to switch to the mobile WSONWP.
+     * This is the flag which forces server to switch to the mobile JSONWP.
      * If {@code false} then it is switched to W3C mode.
      */
-    String FORCE_MJSONWP = "forceMjsonwp";
+    String FORCE_MJSONWP = "appium:forceMjsonwp";
 
     /**
      * (Web and webview only) Enable ChromeDriver's (on Android)


### PR DESCRIPTION
## Change list

* updated mobile capabilities to use w3c compliant prefix `appium:`
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

This makes java-client compliant with required w3c syntax, which will likely be necessary when users update to Selenium 4.

The tests like `startingAndroidAppWithCapabilitiesOnlyTest` fail with this PR, but I would consider these more unit tests than user facing changes because no one should be checking the input to Capabilities with the output from the server.

That said, if we have #1319 we could override `getCapability` to add `appium:` if we need the inputs to match the outputs.

I also do not know if or how settings might need to be adjusted to ensure compatible versions of things are used.