### PR TITLE
fix: remove appiumVersion from MobileCapabilityType

### DIFF
--- a/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
@@ -65,10 +65,6 @@ public interface MobileCapabilityType extends CapabilityType {
      */
     String UDID = "udid";
 
-    /**
-     * Sauce-specific.
-     */
-    String APPIUM_VERSION = "appiumVersion";
 
     /**
      * Language to set for iOS (XCUITest driver only) and Android.


### PR DESCRIPTION
## Change list

- Removed appiumVersion from MobileCapabilityType
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The capability `appiumVersion` is a Sauce specific capability.
This should not be included in the Java bindings since Appium does not do anything with this capability and should be handled either manually by the user or via some other third party tool.

This fixes this being included on the Appium Java client.