### PR TITLE
feat: Add idempotency key to session creation requests

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -190,9 +190,8 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
                                 .getDeclaredMethod("createSession", HttpClient.class, InputStream.class, long.class);
                         createSessionMethod.setAccessible(true);
 
-                        Optional<Result> result = (Optional<Result>) createSessionMethod
-                                .invoke(this, withRequestsPatchedByIdempotencyKey(client),
-                                        contentStream, counter.getCount());
+                        Optional<Result> result = (Optional<Result>) createSessionMethod.invoke(this,
+                                withRequestsPatchedByIdempotencyKey(client), contentStream, counter.getCount());
 
                         return result.map(result1 -> {
                             Result toReturn = result.get();


### PR DESCRIPTION
## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

This PR adds a random idempotency key to each session creation request. This is necessary to properly handle HTTP request retries. Read https://github.com/appium/appium-base-driver/pull/400 for more details.