### PR TITLE
chore: Change getDeviceTime to call the `mobile` implementation

### DIFF
--- a/src/main/java/io/appium/java_client/HasDeviceTime.java
+++ b/src/main/java/io/appium/java_client/HasDeviceTime.java
@@ -35,6 +35,7 @@ public interface HasDeviceTime extends ExecutesMethod {
      *               https://momentjs.com/docs/ to get the full list of supported
      *               datetime format specifiers. The default format is
      *               `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601
+     * @since Appium 1.18
      * @return Device time string
      */
     default String getDeviceTime(String format) {

--- a/src/main/java/io/appium/java_client/HasDeviceTime.java
+++ b/src/main/java/io/appium/java_client/HasDeviceTime.java
@@ -18,9 +18,13 @@ package io.appium.java_client;
 
 import static io.appium.java_client.MobileCommand.GET_DEVICE_TIME;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.Response;
+
+import java.util.Map;
 
 public interface HasDeviceTime extends ExecutesMethod {
 
@@ -34,7 +38,11 @@ public interface HasDeviceTime extends ExecutesMethod {
      * @return Device time string
      */
     default String getDeviceTime(String format) {
-        Response response = execute(GET_DEVICE_TIME, ImmutableMap.of("format", format));
+        Map<String, ?> params = ImmutableMap.of(
+                "script", "mobile: getDeviceTime",
+                "args", ImmutableList.of(ImmutableMap.of("format", format))
+        );
+        Response response = execute(DriverCommand.EXECUTE_SCRIPT, params);
         return response.getValue().toString();
     }
 


### PR DESCRIPTION
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Selenium webdriver implementation ignores parameters passed into GET requests. This PR replaces the call with parameters with the corresponding `mobile:` endpoint implementation to make it working properly. See https://github.com/appium/appium/issues/14141