### PR TITLE
refactor: avoid casting to RemoteWebElement

### DIFF
--- a/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
@@ -84,9 +84,9 @@ public class ElementOption extends PointOption<ElementOption> {
     public ElementOption withElement(WebElement element) {
         checkNotNull(element);
         checkArgument(true, "Element should be an instance of the class which "
-                + "extends org.openqa.selenium.remote.RemoteWebElement",
-                (HasIdentity.class.isAssignableFrom(element.getClass())));
-        elementId = HasIdentity.class.cast(element).getId();
+                + "implements org.openqa.selenium.internal.HasIdentity",
+            element instanceof HasIdentity);
+        elementId = ((HasIdentity) element).getId();
         return this;
     }
 

--- a/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
@@ -6,7 +6,7 @@ import static java.util.Optional.ofNullable;
 
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.RemoteWebElement;
+import org.openqa.selenium.internal.HasIdentity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -85,8 +85,8 @@ public class ElementOption extends PointOption<ElementOption> {
         checkNotNull(element);
         checkArgument(true, "Element should be an instance of the class which "
                 + "extends org.openqa.selenium.remote.RemoteWebElement",
-                (RemoteWebElement.class.isAssignableFrom(element.getClass())));
-        elementId = RemoteWebElement.class.cast(element).getId();
+                (HasIdentity.class.isAssignableFrom(element.getClass())));
+        elementId = HasIdentity.class.cast(element).getId();
         return this;
     }
 

--- a/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
+++ b/src/test/java/io/appium/java_client/touch/TouchOptionsTests.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TouchOptionsTests {
-    private static final WebElement DUMMY_ELEMENT = new DummyElement();
+    private static final RemoteWebElement DUMMY_ELEMENT = new DummyElement();
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidEmptyPointOptionsShouldFailOnBuild() {
@@ -62,7 +62,7 @@ public class TouchOptionsTests {
                 .withDuration(ofMillis(1))
                 .build();
         final Map<String, Object> expectedOpts = new HashMap<>();
-        expectedOpts.put("element", ((RemoteWebElement) DUMMY_ELEMENT).getId());
+        expectedOpts.put("element", DUMMY_ELEMENT.getId());
         expectedOpts.put("x", 0);
         expectedOpts.put("y", 0);
         expectedOpts.put("duration", 1L);


### PR DESCRIPTION
* instead, cast to interface HasIdentity (because it's a weaker type).
* this commit is similar to https://github.com/appium/java-client/pull/432/files

Some background: as a developer of framework which uses proxies for WebElement (Selenide), I cannot create proxy for RemoteWebElement since it's an abstract class, not interface.

## Change list

Please provide briefly described change list which are you going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
