### PR TITLE
chore: Mute all confusing warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,9 @@ compileJava {
     options.fork = true
     options.fork executable: 'java', jvmArgs: [ '-javaagent:'+lombokjar.path+'=ECJ', '-jar', ecjJar.path, '-cp', lombokjar.path]
     options.define compilerArgs: [
-            '-encoding', 'utf-8'
+            '-encoding', 'utf-8',
+            // https://www.ibm.com/support/knowledgecenter/SS8PJ7_9.7.0/org.eclipse.jdt.doc.user/tasks/task-using_batch_compiler.htm
+            '-warn:-unused,-unchecked,-raw,-serial,-suppress',
     ]
 }
 

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -168,7 +168,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
             throw new SessionNotCreatedException("Session already exists");
         }
         ProtocolHandshake handshake = new ProtocolHandshake() {
-            @SuppressWarnings({"unchecked", "UnstableApiUsage"})
+            @SuppressWarnings("unchecked")
             public Result createSession(HttpClient client, Command command) throws IOException {
                 Capabilities desiredCapabilities = (Capabilities) command.getParameters().get("desiredCapabilities");
                 Capabilities desired = desiredCapabilities == null ? new ImmutableCapabilities() : desiredCapabilities;


### PR DESCRIPTION
## Change list

The previous warnings list has about 170 items. This is confusing and is hard to read. Now we only have 9 and most of these are meaningful.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
