### PR TITLE
fix: Increase the timeout for graceful service termination

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -68,8 +68,7 @@ public final class AppiumDriverLocalService extends DriverService {
     private final ReentrantLock lock = new ReentrantLock(true); //uses "fair" thread ordering policy
     private final ListOutputStream stream = new ListOutputStream().add(System.out);
     private final URL url;
-
-
+    
     private CommandLine process = null;
 
     AppiumDriverLocalService(String ipAddress, File nodeJSExec, int nodeJSPort,


### PR DESCRIPTION
## Change list

Selenium lib hardcodes the graceful shutdown timeout to 2 seconds (zero on Windows). This is not enough for Appium to properly shutdown all the drivers and clean up the leftovers.

 
## Types of changes
- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

