### PR TITLE
fix: Parse platformName if it is passed as enum item

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 pool:
-  vmImage: 'macOS 10.15'
+  vmImage: 'macOS-10.15'
 
 variables:
   ANDROID_EMU_NAME: test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,24 +4,24 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 pool:
-  vmImage: 'macOS 10.14'
+  vmImage: 'macOS 10.15'
 
 variables:
   ANDROID_EMU_NAME: test
   ANDROID_EMU_ABI: x86
   ANDROID_EMU_TARGET: android-27
   ANDROID_EMU_TAG: google_apis
-  XCODE_VERSION: 10.2
-  IOS_PLATFORM_VERSION: 12.2
+  XCODE_VERSION: 11.5
+  IOS_PLATFORM_VERSION: 13.5
   IOS_DEVICE_NAME: iPhone X
 
 jobs:
 - job: E2E_Tests
-  timeoutInMinutes: 60
+  timeoutInMinutes: '60'
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '11.x'
+      versionSpec: '12.x'
 
   - script: |
       echo "Configuring Environment"
@@ -43,7 +43,7 @@ jobs:
       npm config set prefix $NVM_DIR/versions/node/`node --version`
       node --version
 
-      npm install -g appium@beta
+      npm install -g appium
       appium --version
 
       java -version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       npm config set prefix $NVM_DIR/versions/node/`node --version`
       node --version
 
-      npm install -g appium
+      npm install -g appium@beta
       appium --version
 
       java -version

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -317,7 +317,8 @@ public class AppiumDriver<T extends WebElement>
 
     @Override
     public boolean isBrowser() {
-        String browserName = CapabilityHelpers.getCapability(getCapabilities(), CapabilityType.BROWSER_NAME, String.class);
+        String browserName = CapabilityHelpers.getCapability(getCapabilities(),
+                CapabilityType.BROWSER_NAME, String.class);
         if (!isBlank(browserName)) {
             try {
                 return (boolean) executeScript("return !!window.navigator;");

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -40,6 +40,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.html5.Location;
 
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ErrorHandler;
@@ -316,7 +317,7 @@ public class AppiumDriver<T extends WebElement>
 
     @Override
     public boolean isBrowser() {
-        String browserName = CapabilityHelpers.getCapability(getCapabilities(), "browserName", String.class);
+        String browserName = CapabilityHelpers.getCapability(getCapabilities(), CapabilityType.BROWSER_NAME, String.class);
         if (!isBlank(browserName)) {
             try {
                 return (boolean) executeScript("return !!window.navigator;");

--- a/src/main/java/io/appium/java_client/internal/CapabilityHelpers.java
+++ b/src/main/java/io/appium/java_client/internal/CapabilityHelpers.java
@@ -43,8 +43,14 @@ public class CapabilityHelpers {
             possibleNames.add(APPIUM_PREFIX + name);
         }
         for (String capName : possibleNames) {
-            if (caps.getCapability(capName) != null
-                    && expectedType.isAssignableFrom(caps.getCapability(capName).getClass())) {
+            if (caps.getCapability(capName) == null) {
+                continue;
+            }
+            
+            if (expectedType == String.class) {
+                return expectedType.cast(String.valueOf(caps.getCapability(capName)));
+            }
+            if (expectedType.isAssignableFrom(caps.getCapability(capName).getClass())) {
                 return expectedType.cast(caps.getCapability(capName));
             }
         }

--- a/src/main/java/io/appium/java_client/internal/JsonToMobileElementConverter.java
+++ b/src/main/java/io/appium/java_client/internal/JsonToMobileElementConverter.java
@@ -18,8 +18,10 @@ package io.appium.java_client.internal;
 
 import static io.appium.java_client.internal.ElementMap.getElementClass;
 
+import io.appium.java_client.remote.MobileCapabilityType;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.remote.internal.JsonToWebElementConverter;
@@ -46,8 +48,8 @@ public class JsonToMobileElementConverter extends JsonToWebElementConverter {
         super(driver);
         this.driver = driver;
         Capabilities caps = driver.getCapabilities();
-        this.platform = CapabilityHelpers.getCapability(caps, "platformName", String.class);
-        this.automation = CapabilityHelpers.getCapability(caps, "automationName", String.class);
+        this.platform = CapabilityHelpers.getCapability(caps, CapabilityType.PLATFORM_NAME, String.class);
+        this.automation = CapabilityHelpers.getCapability(caps, MobileCapabilityType.AUTOMATION_NAME, String.class);
     }
 
     @Override

--- a/src/test/java/io/appium/java_client/ios/IOSTouchTest.java
+++ b/src/test/java/io/appium/java_client/ios/IOSTouchTest.java
@@ -5,7 +5,6 @@ import static io.appium.java_client.touch.TapOptions.tapOptions;
 import static io.appium.java_client.touch.WaitOptions.waitOptions;
 import static io.appium.java_client.touch.offset.ElementOption.element;
 import static java.time.Duration.ofMillis;
-import static java.time.Duration.ofSeconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
@@ -13,11 +12,9 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.alertIsPresent;
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.MultiTouchAction;
 import io.appium.java_client.TouchAction;
-import io.appium.java_client.touch.offset.ElementOption;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -33,7 +30,7 @@ public class IOSTouchTest extends AppIOSTest {
         intB.sendKeys("4");
 
         MobileElement e = driver.findElementByAccessibilityId("ComputeSumButton");
-        new TouchAction(driver).tap(tapOptions().withElement(element(e))).perform();
+        new IOSTouchAction(driver).tap(tapOptions().withElement(element(e))).perform();
         assertEquals(driver.findElementByXPath("//*[@name = \"Answer\"]").getText(), "6");
     }
 
@@ -57,28 +54,12 @@ public class IOSTouchTest extends AppIOSTest {
         assertEquals(driver.findElementByXPath("//*[@name = \"Answer\"]").getText(), "6");
     }
 
-    @Test public void swipeTest() {
-        WebDriverWait webDriverWait = new WebDriverWait(driver, 30);
-        IOSElement slider = webDriverWait.until(driver1 -> driver.findElementByClassName("XCUIElementTypeSlider"));
-        Dimension size = slider.getSize();
-
-        ElementOption press = element(slider, size.width / 2 + 2, size.height / 2);
-        ElementOption move = element(slider, 1, size.height / 2);
-
-        TouchAction swipe = new TouchAction(driver).press(press)
-                .waitAction(waitOptions(ofSeconds(2)))
-                .moveTo(move).release();
-
-        swipe.perform();
-        assertEquals("0%", slider.getAttribute("value"));
-    }
-
     @Test public void multiTouchTest() {
         MobileElement e = driver.findElementByAccessibilityId("ComputeSumButton");
         MobileElement e2 = driver.findElementByAccessibilityId("show alert");
 
-        TouchAction tap1 = new TouchAction(driver).tap(tapOptions().withElement(element(e)));
-        TouchAction tap2 = new TouchAction(driver).tap(tapOptions().withElement(element(e2)));
+        IOSTouchAction tap1 = new IOSTouchAction(driver).tap(tapOptions().withElement(element(e)));
+        IOSTouchAction tap2 = new IOSTouchAction(driver).tap(tapOptions().withElement(element(e2)));
 
         new MultiTouchAction(driver).add(tap1).add(tap2).perform();
 


### PR DESCRIPTION
## Change list

Related to https://github.com/appium/java-client/issues/1275
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

I don't know the reason why to pass enum value instead of a string as platformName, like this is required by the standard, but whatever. The fix should just make it working for both cases.
