### PR TITLE
fix: Automatically retrieve the host and port in ListensToLogcatMessages

### DIFF
--- a/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
+++ b/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
@@ -33,13 +33,13 @@ import java.util.function.Consumer;
 public interface ListensToLogcatMessages extends ExecutesMethod {
     StringWebSocketClient getLogcatClient();
 
+
     /**
      * Start logcat messages broadcast via web socket.
-     * This method assumes that Appium server is running on localhost and
-     * is assigned to the default port (4723).
      */
     default void startLogcatBroadcast() {
-        startLogcatBroadcast("localhost", DEFAULT_APPIUM_PORT);
+        URL remoteAdress = ((RemoteWebDriver) this).getRemoteAddress();
+        this.startLogcatBroadcast(remoteAdress.getHost(), remoteAdress.getPort());
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
+++ b/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
@@ -21,11 +21,13 @@ import static org.openqa.selenium.remote.DriverCommand.EXECUTE_SCRIPT;
 
 import com.google.common.collect.ImmutableMap;
 
+import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.ExecutesMethod;
 import io.appium.java_client.ws.StringWebSocketClient;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.URI;
+import java.net.URL;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.function.Consumer;
@@ -33,13 +35,12 @@ import java.util.function.Consumer;
 public interface ListensToLogcatMessages extends ExecutesMethod {
     StringWebSocketClient getLogcatClient();
 
-
     /**
      * Start logcat messages broadcast via web socket.
      */
     default void startLogcatBroadcast() {
-        URL remoteAdress = ((RemoteWebDriver) this).getRemoteAddress();
-        this.startLogcatBroadcast(remoteAdress.getHost(), remoteAdress.getPort());
+        URL remoteAddress = ((AppiumDriver) this).getRemoteAddress();
+        this.startLogcatBroadcast(remoteAddress.getHost(), remoteAddress.getPort());
     }
 
     /**


### PR DESCRIPTION
## Change list

Related to #1352
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

[ ] No changes in production code.
[x] Bugfix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Automatically retrieve the host and port instead of assuming they are the defaults.
