### PR TITLE
fix: bind mac2element in element map for mac platform

### DIFF
--- a/src/main/java/io/appium/java_client/internal/ElementMap.java
+++ b/src/main/java/io/appium/java_client/internal/ElementMap.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.android.AndroidElement;
 import io.appium.java_client.ios.IOSElement;
+import io.appium.java_client.mac.Mac2Element;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.remote.MobilePlatform;
 import io.appium.java_client.windows.WindowsElement;
@@ -37,8 +38,8 @@ public enum ElementMap {
     IOS_XCUI_TEST(AutomationName.IOS_XCUI_TEST.toLowerCase(), IOSElement.class),
     ANDROID_UI_AUTOMATOR(MobilePlatform.ANDROID.toLowerCase(), AndroidElement.class),
     IOS_UI_AUTOMATION(MobilePlatform.IOS.toLowerCase(), IOSElement.class),
-    WINDOWS(MobilePlatform.WINDOWS.toLowerCase(), WindowsElement.class);
-
+    WINDOWS(MobilePlatform.WINDOWS.toLowerCase(), WindowsElement.class),
+    MAC(MobilePlatform.MAC.toLowerCase(), Mac2Element.class);
 
     private static final Map<String, ElementMap> mobileElementMap;
 


### PR DESCRIPTION
## Change list

Bind MAC platform with Mac2Element to fix ClassCastException while Mac2Driver usage
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)