### PR TITLE
chore: deprecate Windows UIAutomation selector

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumBy.java
+++ b/src/main/java/io/appium/java_client/AppiumBy.java
@@ -164,15 +164,6 @@ public abstract class AppiumBy extends By implements Remotable {
         return new ByIosNsPredicate(iOSNsPredicateString);
     }
 
-    /**
-     * The Windows UIAutomation selector.
-     * @param windowsAutomation The element name in the Windows UIAutomation selector
-     * @return an instance of {@link AppiumBy.ByWindowsAutomation}
-     */
-    public static By windowsAutomation(final String windowsAutomation) {
-        return new ByWindowsAutomation(windowsAutomation);
-    }
-
     public static class ByAccessibilityId extends AppiumBy implements Serializable {
 
         public ByAccessibilityId(String accessibilityId) {
@@ -240,13 +231,6 @@ public abstract class AppiumBy extends By implements Remotable {
 
         protected ByIosNsPredicate(String locatorString) {
             super("-ios predicate string", locatorString, "iOSNsPredicate");
-        }
-    }
-
-    public static class ByWindowsAutomation extends AppiumBy implements Serializable {
-
-        protected ByWindowsAutomation(String locatorString) {
-            super("-windows uiautomation", locatorString, "windowsAutomation");
         }
     }
 }

--- a/src/main/java/io/appium/java_client/MobileBy.java
+++ b/src/main/java/io/appium/java_client/MobileBy.java
@@ -16,6 +16,8 @@
 
 package io.appium.java_client;
 
+import java.io.Serializable;
+
 import org.openqa.selenium.By;
 
 /**
@@ -105,6 +107,17 @@ public abstract class MobileBy extends AppiumBy {
     @Deprecated
     public static By iOSNsPredicateString(final String iOSNsPredicateString) {
         return new ByIosNsPredicate(iOSNsPredicateString);
+    }
+
+    /**
+     * The Windows UIAutomation selector.
+     * @deprecated Not supported on the server side.
+     * @param windowsAutomation The element name in the Windows UIAutomation selector
+     * @return an instance of {@link MobileBy.ByWindowsAutomation}
+     */
+    @Deprecated
+    public static By windowsAutomation(final String windowsAutomation) {
+        return new ByWindowsAutomation(windowsAutomation);
     }
 
     /**
@@ -261,13 +274,17 @@ public abstract class MobileBy extends AppiumBy {
 
     /**
      * The Windows UIAutomation selector.
-     * @deprecated Use {@link AppiumBy.ByWindowsAutomation} instead.
+     * @deprecated Not supported on the server side.
      */
     @Deprecated
-    public static class ByWindowsAutomation extends AppiumBy.ByWindowsAutomation {
+    public static class ByWindowsAutomation extends MobileBy implements Serializable {
 
         protected ByWindowsAutomation(String locatorString) {
-            super(locatorString);
+            super("-windows uiautomation", locatorString, "windowsAutomation");
+        }
+
+        @Override public String toString() {
+            return "By.windowsAutomation: " + getRemoteParameters().value();
         }
     }
 

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
@@ -16,17 +16,18 @@
 
 package io.appium.java_client.pagefactory.bys.builder;
 
-import io.appium.java_client.AppiumBy;
-import io.appium.java_client.pagefactory.AndroidBy;
-import io.appium.java_client.pagefactory.AndroidFindBy;
-
-import org.openqa.selenium.By;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.openqa.selenium.By;
+
+import io.appium.java_client.AppiumBy;
+import io.appium.java_client.MobileBy;
+import io.appium.java_client.pagefactory.AndroidBy;
+import io.appium.java_client.pagefactory.AndroidFindBy;
 
 enum Strategies {
     BYUIAUTOMATOR("uiAutomator") {
@@ -84,10 +85,14 @@ enum Strategies {
                 .partialLinkText(getValue(annotation, this));
         }
     },
+    /**
+     * The Windows UIAutomation strategy.
+     * @deprecated Not supported on the server side.
+     */
+    @Deprecated
     BYWINDOWSAUTOMATION("windowsAutomation") {
         @Override By getBy(Annotation annotation) {
-            return AppiumBy
-                    .windowsAutomation(getValue(annotation, this));
+            return MobileBy.windowsAutomation(getValue(annotation, this));
         }
     },
     BY_CLASS_CHAIN("iOSClassChain") {

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/windows/WindowsWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/windows/WindowsWidgetTest.java
@@ -1,6 +1,6 @@
 package io.appium.java_client.pagefactory_tests.widget.tests.windows;
 
-import static io.appium.java_client.AppiumBy.windowsAutomation;
+import static io.appium.java_client.MobileBy.windowsAutomation;
 import static io.appium.java_client.pagefactory_tests.widget.tests.windows.AnnotatedWindowsWidget.WINDOWS_ROOT_WIDGET_LOCATOR;
 import static io.appium.java_client.pagefactory_tests.widget.tests.windows.DefaultWindowsWidget.WINDOWS_SUB_WIDGET_LOCATOR;
 import static io.appium.java_client.pagefactory_tests.widget.tests.windows.WindowsApp.WINDOWS_DEFAULT_WIDGET_LOCATOR;


### PR DESCRIPTION
## Change list

Deprecate Windows UIAutomation selector as it's not supported on the server side
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
As per discussion https://github.com/appium/java-client/pull/1559#discussion_r738039803