### PR TITLE
build: remove redundant exclusion of Gradle task `signMavenJavaPublication`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,4 +21,4 @@ jobs:
         distribution: 'zulu'
         java-version: 8
     - name: Build with Gradle
-      run: ./gradlew clean build -x signMavenJavaPublication -x test -x checkstyleTest
+      run: ./gradlew clean build -x test -x checkstyleTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
       jdkArchitectureOption: 'x64'
       publishJUnitResults: true
       tasks: 'build'
-      options: 'uiAutomationTest -x checkstyleTest -x test -x signMavenJavaPublication'
+      options: 'uiAutomationTest -x checkstyleTest -x test'
 - job: iOS_E2E_Tests
 #  timeoutInMinutes: '90'
   steps:
@@ -60,4 +60,4 @@ jobs:
       jdkArchitectureOption: 'x64'
       publishJUnitResults: true
       tasks: 'build'
-      options: 'xcuiTest -x checkstyleTest -x test -x signMavenJavaPublication'
+      options: 'xcuiTest -x checkstyleTest -x test'


### PR DESCRIPTION
## Change list

The exclusion of Gradle task `signMavenJavaPublication` from build process in CI is not needed anymore.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

