### PR TITLE
chore: Deprecate touch actions

### DIFF
--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -22,6 +22,18 @@ import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Touch actions are deprecated.
+ * Please use W3C Actions instead or the corresponding
+ * extension methods for the driver (if available).
+ * Check
+ * - https://www.youtube.com/watch?v=oAJ7jwMNFVU
+ * - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+ * - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ * for more details.
+ */
+@Deprecated
+@SuppressWarnings({"unchecked", "rawtypes"})
 public interface PerformsTouchActions extends ExecutesMethod {
     /**
      * Performs a chain of touch actions, which together can be considered an
@@ -53,9 +65,10 @@ public interface PerformsTouchActions extends ExecutesMethod {
      *
      * @param multiAction the MultiTouchAction object to perform.
      */
-    default void performMultiTouchAction(MultiTouchAction multiAction) {
+    default MultiTouchAction performMultiTouchAction(MultiTouchAction multiAction) {
         Map<String, List<Object>> parameters = multiAction.getParameters();
         execute(PERFORM_MULTI_TOUCH, parameters);
         multiAction.clearActions();
+        return multiAction.clearActions();
     }
 }

--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -48,6 +48,7 @@ public interface PerformsTouchActions extends ExecutesMethod {
      *                    touch actions to perform
      * @return the same touch action object
      */
+    @Deprecated
     default TouchAction performTouchAction(TouchAction touchAction) {
         Map<String, List<Object>> parameters = touchAction.getParameters();
         execute(PERFORM_TOUCH_ACTION, parameters);
@@ -65,6 +66,7 @@ public interface PerformsTouchActions extends ExecutesMethod {
      *
      * @param multiAction the MultiTouchAction object to perform.
      */
+    @Deprecated
     default MultiTouchAction performMultiTouchAction(MultiTouchAction multiAction) {
         Map<String, List<Object>> parameters = multiAction.getParameters();
         execute(PERFORM_MULTI_TOUCH, parameters);

--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -68,7 +68,6 @@ public interface PerformsTouchActions extends ExecutesMethod {
     default MultiTouchAction performMultiTouchAction(MultiTouchAction multiAction) {
         Map<String, List<Object>> parameters = multiAction.getParameters();
         execute(PERFORM_MULTI_TOUCH, parameters);
-        multiAction.clearActions();
         return multiAction.clearActions();
     }
 }

--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -42,7 +42,17 @@ import java.util.Map;
  * action.press(element).waitAction(300).moveTo(element1).release().perform();
  * Calling perform() sends the action command to the Mobile Driver. Otherwise,
  * more and more actions can be chained.
+ *
+ * Touch actions are deprecated.
+ * Please use W3C Actions instead or the corresponding
+ * extension methods for the driver (if available).
+ * Check
+ * - https://www.youtube.com/watch?v=oAJ7jwMNFVU
+ * - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+ * - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ * for more details.
  */
+@Deprecated
 public class TouchAction<T extends TouchAction<T>> implements PerformsActions<T> {
 
     protected ImmutableList.Builder<ActionParameter> parameterBuilder;

--- a/src/main/java/io/appium/java_client/android/AndroidTouchAction.java
+++ b/src/main/java/io/appium/java_client/android/AndroidTouchAction.java
@@ -20,6 +20,17 @@ import io.appium.java_client.PerformsTouchActions;
 import io.appium.java_client.TouchAction;
 
 
+/**
+ * Touch actions are deprecated.
+ * Please use W3C Actions instead or the corresponding
+ * extension methods for the driver (if available).
+ * Check
+ * - https://www.youtube.com/watch?v=oAJ7jwMNFVU
+ * - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+ * - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ * for more details.
+ */
+@Deprecated
 public class AndroidTouchAction extends TouchAction<AndroidTouchAction> {
 
     public AndroidTouchAction(PerformsTouchActions performsTouchActions) {

--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -54,7 +54,6 @@ import java.util.Map;
 
 /**
  * iOS driver implementation.
- *
  */
 public class IOSDriver extends AppiumDriver implements
         SupportsContextSwitching,

--- a/src/main/java/io/appium/java_client/ios/IOSTouchAction.java
+++ b/src/main/java/io/appium/java_client/ios/IOSTouchAction.java
@@ -22,6 +22,17 @@ import io.appium.java_client.ios.touch.IOSPressOptions;
 import io.appium.java_client.touch.offset.ElementOption;
 import io.appium.java_client.touch.offset.PointOption;
 
+/**
+ * Touch actions are deprecated.
+ * Please use W3C Actions instead or the corresponding
+ * extension methods for the driver (if available).
+ * Check
+ * - https://www.youtube.com/watch?v=oAJ7jwMNFVU
+ * - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+ * - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ * for more details.
+ */
+@Deprecated
 public class IOSTouchAction extends TouchAction<IOSTouchAction> {
 
     public IOSTouchAction(PerformsTouchActions performsTouchActions) {

--- a/src/main/java/io/appium/java_client/mac/Mac2Driver.java
+++ b/src/main/java/io/appium/java_client/mac/Mac2Driver.java
@@ -17,6 +17,7 @@
 package io.appium.java_client.mac;
 
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.PerformsTouchActions;
 import io.appium.java_client.internal.CapabilityHelpers;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.remote.MobileCapabilityType;
@@ -43,6 +44,7 @@ import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
  * @since Appium 1.20.0
  */
 public class Mac2Driver extends AppiumDriver implements
+        PerformsTouchActions,
         CanRecordScreen {
     public Mac2Driver(HttpCommandExecutor executor, Capabilities capabilities) {
         super(executor, prepareCaps(capabilities));

--- a/src/main/java/io/appium/java_client/windows/WindowsDriver.java
+++ b/src/main/java/io/appium/java_client/windows/WindowsDriver.java
@@ -20,6 +20,7 @@ import static io.appium.java_client.remote.MobilePlatform.WINDOWS;
 
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.HidesKeyboardWithKeyName;
+import io.appium.java_client.PerformsTouchActions;
 import io.appium.java_client.screenrecording.CanRecordScreen;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 import io.appium.java_client.service.local.AppiumServiceBuilder;
@@ -30,6 +31,7 @@ import org.openqa.selenium.remote.http.HttpClient;
 import java.net.URL;
 
 public class WindowsDriver extends AppiumDriver implements
+        PerformsTouchActions,
         PressesKeyCode,
         HidesKeyboardWithKeyName,
         CanRecordScreen {


### PR DESCRIPTION
## Change list

Touch actions specification is not part of W3C and has been effectively replaced by [W3C Actions](https://www.w3.org/TR/webdriver/#actions) spec. 

The same change has been already done for Python and Ruby clients.
 
## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
