### PR TITLE
Filter out proxyClassLookup method from Proxy class (for Java 16+) in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ dependencies {
 ```
 
 ## Changelog
+*7.6.1*
+- **[BUG FIX]**
+  - Filter out proxyClassLookup method from Proxy class (for Java 16+) in AppiumByBuilder. [#1575](https://github.com/appium/java-client/issues/1575)
+  
 *7.6.0*
 - **[ENHANCEMENTS]**
   - Add custom commands dynamically [Appium 2.0]. [#1506](https://github.com/appium/java-client/pull/1506)

--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = 'io.appium'
             artifactId = 'java-client'
-            version = '7.6.0'
+            version = '7.6.1'
             from components.java
             pom {
                 name = 'java-client'

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/AppiumByBuilder.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/AppiumByBuilder.java
@@ -30,6 +30,7 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,6 +53,10 @@ public abstract class AppiumByBuilder extends AbstractAnnotations {
                     getMethodNames(Annotation.class.getDeclaredMethods());
                 annotationClassMethodNames.removeAll(objectClassMethodNames);
                 addAll(annotationClassMethodNames);
+                List<String> proxyClassMethodNames =
+                        getMethodNames(Proxy.class.getDeclaredMethods());
+                proxyClassMethodNames.removeAll(objectClassMethodNames);
+                addAll(proxyClassMethodNames);
             }
         };
     protected final AnnotatedElementContainer annotatedElementContainer;
@@ -73,13 +78,13 @@ public abstract class AppiumByBuilder extends AbstractAnnotations {
     }
 
     private static Method[] prepareAnnotationMethods(Class<? extends Annotation> annotation) {
-        List<String> targeAnnotationMethodNamesList =
+        List<String> targetAnnotationMethodNamesList =
             getMethodNames(annotation.getDeclaredMethods());
-        targeAnnotationMethodNamesList.removeAll(METHODS_TO_BE_EXCLUDED_WHEN_ANNOTATION_IS_READ);
-        Method[] result = new Method[targeAnnotationMethodNamesList.size()];
-        for (String methodName : targeAnnotationMethodNamesList) {
+        targetAnnotationMethodNamesList.removeAll(METHODS_TO_BE_EXCLUDED_WHEN_ANNOTATION_IS_READ);
+        Method[] result = new Method[targetAnnotationMethodNamesList.size()];
+        for (String methodName : targetAnnotationMethodNamesList) {
             try {
-                result[targeAnnotationMethodNamesList.indexOf(methodName)] =
+                result[targetAnnotationMethodNamesList.indexOf(methodName)] =
                     annotation.getMethod(methodName, DEFAULT_ANNOTATION_METHOD_ARGUMENTS);
             } catch (NoSuchMethodException | SecurityException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
… AppiumByBuilder. [#1575](https://github.com/appium/java-client/issues/1575)

## Change list
Filter out proxyClassLookup method from Proxy class (for Java 16+) in AppiumByBuilder
 
## Types of changes
- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
Avoid getting java.lang.NoSuchMethodException when loading PageFactory elements in Java16+
