### PR TITLE
feat: Add fileFieldName default value of ScreenRecordingUploadOptions

### DIFF
--- a/src/main/java/io/appium/java_client/screenrecording/ScreenRecordingUploadOptions.java
+++ b/src/main/java/io/appium/java_client/screenrecording/ScreenRecordingUploadOptions.java
@@ -32,6 +32,13 @@ public class ScreenRecordingUploadOptions {
     private Map<String, String> headers;
     private Map<String, Object> formFields;
 
+    /**
+     * Creates new instance with default fileFieldName.
+     */
+    public ScreenRecordingUploadOptions() {
+        withFileFieldName("file");
+    }
+
     public static ScreenRecordingUploadOptions uploadOptions() {
         return new ScreenRecordingUploadOptions();
     }

--- a/src/test/java/io/appium/java_client/drivers/options/OptionsBuildingTest.java
+++ b/src/test/java/io/appium/java_client/drivers/options/OptionsBuildingTest.java
@@ -33,6 +33,7 @@ import io.appium.java_client.mac.options.Mac2Options;
 import io.appium.java_client.remote.AutomationName;
 import io.appium.java_client.safari.options.SafariOptions;
 import io.appium.java_client.safari.options.WebrtcData;
+import io.appium.java_client.screenrecording.ScreenRecordingUploadOptions;
 import io.appium.java_client.windows.options.PowerShellData;
 import io.appium.java_client.windows.options.WindowsOptions;
 import org.junit.Test;
@@ -41,6 +42,7 @@ import org.openqa.selenium.Platform;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -179,5 +181,22 @@ public class OptionsBuildingTest {
                 .doesDisableIceCandidateFiltering().orElse(false));
         assertTrue(options.getWebkitWebrtc().orElse(null)
                 .doesDisableInsecureMediaCapture().orElse(false));
+    }
+
+    @Test
+    public void canBuildScreenRecordingUploadOptions() {
+        ScreenRecordingUploadOptions options = ScreenRecordingUploadOptions.uploadOptions();
+        assertEquals("file", options.build().get("fileFieldName"));
+        Map<String, Object> optionsMap = options
+                .withRemotePath("http://yolo.com")
+                .withHttpMethod(ScreenRecordingUploadOptions.RequestMethod.POST)
+                .withFileFieldName("file123")
+                .withAuthCredentials("kim", "password")
+                .build();
+        assertEquals("http://yolo.com", optionsMap.get("remotePath"));
+        assertEquals("POST", optionsMap.get("method"));
+        assertEquals("file123", optionsMap.get("fileFieldName"));
+        assertEquals("kim", optionsMap.get("user"));
+        assertEquals("password", optionsMap.get("pass"));
     }
 }


### PR DESCRIPTION
## Change list
Added fileFieldName default value(file) of ScreenRecordingUploadOptions with some basic tests
 
## Types of changes
- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
In v7.4.0 earlier versions,STOP_RECORDING_SCREEN command is not working since appium-server v1.21.0.
One of the ways to solve this problem is upgrading java-client and adding the fileFieldName option in test code.
It looks like being provided fileFieldName default value is the better one.