### PR TITLE
build: relax constraints of Selenium dependencies versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,17 +33,20 @@ dependencies {
 
     api ('org.seleniumhq.selenium:selenium-api') {
         version {
-            strictly "${seleniumVersion}"
+            strictly '[4.0, 5.0)'
+            prefer "${seleniumVersion}"
         }
     }
     api ('org.seleniumhq.selenium:selenium-remote-driver') {
         version {
-            strictly "${seleniumVersion}"
+            strictly '[4.0, 5.0)'
+            prefer "${seleniumVersion}"
         }
     }
     implementation ('org.seleniumhq.selenium:selenium-support') {
         version {
-            strictly "${seleniumVersion}"
+            strictly '[4.0, 5.0)'
+            prefer "${seleniumVersion}"
         }
     }
     implementation 'com.google.code.gson:gson:2.8.9'
@@ -63,7 +66,8 @@ dependencies {
     }
     testImplementation ('org.seleniumhq.selenium:selenium-chrome-driver') {
         version {
-            strictly "${seleniumVersion}"
+            strictly '[4.0, 5.0)'
+            prefer "${seleniumVersion}"
         }
     }
 }


### PR DESCRIPTION
## Change list

In a favor of flexibility the constraints of selenium dependencies versions are relaxed.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html: "conflicting strict dependencies will trigger a build failure that you have to resolve".

An attempt to use `java-client:8.0.0-beta` in conjunction with Selenium 4.1.0 leads to build failures, like:
```
   > Could not resolve org.seleniumhq.selenium:selenium-remote-driver:{strictly 4.0.0}.
     Required by:
         project :xxxxxxx > io.appium:java-client:8.0.0-beta
```
In a favor of flexibility the constraints of selenium dependencies versions are relaxed.