### PR TITLE
fix: bump Selenium from `4.0.0` to `4.1.1`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ signing.secretKeyRingFile=PathToYourKeyRingFile
 ossrhUsername=your-jira-id
 ossrhPassword=your-jira-password
 
-selenium.version=4.0.0
+selenium.version=4.1.1


### PR DESCRIPTION
Fixes #1608.

## Change list

Bump Selenium from `4.0.0` to `4.1.1`
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Selenium `4.1.1` contains bug fix: HttpClient follows redirects by default. This fix is crucial for some cloud testing providers.
