### PR TITLE
chore: delete all references to removed `MobileElement` class

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/ElementInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ElementInterceptor.java
@@ -26,7 +26,7 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 import java.lang.reflect.Method;
 
 /**
- * Intercepts requests to {@link io.appium.java_client.MobileElement}.
+ * Intercepts requests to {@link WebElement}.
  */
 class ElementInterceptor extends InterceptorOfASingleElement {
 

--- a/src/main/java/io/appium/java_client/pagefactory/ElementListInterceptor.java
+++ b/src/main/java/io/appium/java_client/pagefactory/ElementListInterceptor.java
@@ -26,7 +26,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 /**
- * Intercepts requests to the list of {@link io.appium.java_client.MobileElement}.
+ * Intercepts requests to the list of {@link WebElement}.
  */
 class ElementListInterceptor extends InterceptorOfAListOfElements {
 

--- a/src/main/java/io/appium/java_client/pagefactory/utils/WebDriverUnpackUtility.java
+++ b/src/main/java/io/appium/java_client/pagefactory/utils/WebDriverUnpackUtility.java
@@ -55,8 +55,8 @@ public final class WebDriverUnpackUtility {
                     ((WrapsDriver) searchContext).getWrappedDriver());
         }
 
-        // Search context it is not only Webdriver. Webelement is search context too.
-        // RemoteWebElement and MobileElement implement WrapsDriver
+        // Search context it is not only WebDriver. WebElement is search context too.
+        // RemoteWebElement implements WrapsDriver
         if (searchContext instanceof WrapsElement) {
             return unpackWebDriverFromSearchContext(
                     ((WrapsElement) searchContext).getWrappedElement());


### PR DESCRIPTION
## Change list

Delete confusing references to removed `MobileElement` class from JavaDocs and comments.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
