### PR TITLE
ci: update Azure pipeline to use `macos-11` VM image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,15 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/java
 
 pool:
-  vmImage: 'macOS-10.15'
+  vmImage: 'macos-11'
 
 variables:
   ANDROID_EMU_NAME: test
   ANDROID_EMU_ABI: x86
   ANDROID_EMU_TARGET: android-28
   ANDROID_EMU_TAG: default
-  XCODE_VERSION: 11.5
-  IOS_PLATFORM_VERSION: 13.5
+  XCODE_VERSION: 13.2
+  IOS_PLATFORM_VERSION: 15.2
   IOS_DEVICE_NAME: iPhone X
   NODE_VERSION: 16.x
   JDK_VERSION: 1.8


### PR DESCRIPTION
## Change list

Update Azure pipeline config to use `macos-11` VM image
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The current VM image is deprecated:
<img width="1202" alt="azure-pipeline-warnings" src="https://user-images.githubusercontent.com/5081226/181513124-eefdba2a-1efc-4642-8b72-082528179635.png">

