### PR TITLE
refactor: Deprecate Appium `ByAll`

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/DefaultElementByBuilder.java
+++ b/src/main/java/io/appium/java_client/pagefactory/DefaultElementByBuilder.java
@@ -23,7 +23,6 @@ import static java.util.Optional.ofNullable;
 import io.appium.java_client.pagefactory.bys.ContentMappedBy;
 import io.appium.java_client.pagefactory.bys.ContentType;
 import io.appium.java_client.pagefactory.bys.builder.AppiumByBuilder;
-import io.appium.java_client.pagefactory.bys.builder.ByAll;
 import io.appium.java_client.pagefactory.bys.builder.ByChained;
 import io.appium.java_client.pagefactory.bys.builder.HowToUseSelectors;
 import org.openqa.selenium.By;
@@ -32,6 +31,7 @@ import org.openqa.selenium.support.CacheLookup;
 import org.openqa.selenium.support.FindAll;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.pagefactory.ByAll;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/AppiumByBuilder.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/AppiumByBuilder.java
@@ -24,6 +24,7 @@ import static io.appium.java_client.remote.MobilePlatform.WINDOWS;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.pagefactory.AbstractAnnotations;
+import org.openqa.selenium.support.pagefactory.ByAll;
 
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/ByAll.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/ByAll.java
@@ -13,7 +13,20 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-
+/**
+ * Mechanism used to locate elements within a document using a series of  lookups. This class will
+ * find all DOM elements that matches any of the locators in sequence, e.g.
+ *
+ * <pre>
+ * driver.findElements(new ByAll(by1, by2))
+ * </pre>
+ *
+ * will find all elements that match <var>by1</var> and then all elements that match <var>by2</var>.
+ * This means that the list of elements returned may not be in document order.
+ * 
+ * @deprecated Use {@link org.openqa.selenium.support.pagefactory.ByAll}
+ */
+@Deprecated
 public class ByAll extends org.openqa.selenium.support.pagefactory.ByAll {
 
     private final List<By> bys;


### PR DESCRIPTION
## Change list

Deprecate Appium `ByAll` in favour of Selenium `ByAll`
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Appium `io.appium.java_client.pagefactory.bys.builder.ByAll` was implemented as an extension of Selenium `org.openqa.selenium.support.pagefactory.ByAll` and introduced a performance improvement: "By All was re-implemented, now it returns the first founded element for single search." (https://github.com/appium/java-client/pull/686 on 3 Aug 2017).
However Selenium team introduced the same performance fix "https://github.com/SeleniumHQ/selenium/commit/18028ac9f065b81fbe99a9e84feabfa5d0091f13 ByAll.findElement should not not use remaining locators if an element is already found" on 7 Sep 2017.
So there is no reason to keep Appium `ByAll`, this commit deprecates it.

