### PR TITLE
test: fix open notification test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,6 +213,7 @@ task uiAutomationTest( type: Test ) {
     filter {
         includeTestsMatching 'io.appium.java_client.android.SettingTest'
         includeTestsMatching 'io.appium.java_client.android.ClipboardTest'
+        includeTestsMatching 'io.appium.java_client.android.OpenNotificationsTest'
         includeTestsMatching '*.AndroidAppStringsTest'
         includeTestsMatching '*.pagefactory_tests.widget.tests.android.*'
         includeTestsMatching '*.pagefactory_tests.widget.tests.AndroidPageObjectTest'

--- a/src/test/java/io/appium/java_client/android/OpenNotificationsTest.java
+++ b/src/test/java/io/appium/java_client/android/OpenNotificationsTest.java
@@ -1,7 +1,7 @@
 package io.appium.java_client.android;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.openqa.selenium.By.id;
+import static org.openqa.selenium.By.xpath;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
@@ -18,7 +18,7 @@ public class OpenNotificationsTest extends BaseAndroidTest {
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20));
         assertNotEquals(0, wait.until(input -> {
             List<WebElement> result = input
-                    .findElements(id("com.android.systemui:id/settings_button"));
+                    .findElements(xpath("//android.widget.Switch[contains(@content-desc, 'Wi-Fi')]"));
 
             return result.isEmpty() ? null : result;
         }).size());


### PR DESCRIPTION
## Change list

Test openNotification was failing because on the current version 'settings_button' is not visible, so added check for different element. Also add the test to CI.
 
## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


