### PR TITLE
test: Verified disabled tests working and enabled them

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,17 @@ task uiAutomationTest( type: Test ) {
         includeTestsMatching 'io.appium.java_client.service.local.StartingAppLocallyAndroidTest'
         includeTestsMatching 'io.appium.java_client.service.local.ServerBuilderTest'
         includeTestsMatching 'io.appium.java_client.service.local.ThreadSafetyTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidActivityTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidAbilityToUseSupplierTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidAppStringsTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidContextTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidDriverTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidConnectionTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidElementTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidFunctionTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidLogcatListenerTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidScreenRecordTest'
+        includeTestsMatching 'io.appium.java_client.android.AndroidSearchingTest'
     }
 }
 

--- a/src/test/java/io/appium/java_client/android/AndroidConnectionTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidConnectionTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.appium.java_client.android.connection.ConnectionState;
 import io.appium.java_client.android.connection.ConnectionStateBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -29,15 +30,15 @@ import org.junit.jupiter.api.TestMethodOrder;
 public class AndroidConnectionTest extends BaseAndroidTest {
 
     @Test
-    public void test1() {
+    public void getWiFiEnabled() {
         ConnectionState state = driver.setConnection(new ConnectionStateBuilder()
                 .withWiFiEnabled()
                 .build());
         assertTrue(state.isWiFiEnabled());
     }
-
+    @Disabled("Disabled until https://github.com/appium/appium/issues/17422 is resolved")
     @Test
-    public void test2() {
+    public void testEnableAirplaneMode() {
         ConnectionState state = driver.setConnection(new ConnectionStateBuilder()
                 .withAirplaneModeDisabled()
                 .build());
@@ -50,8 +51,9 @@ public class AndroidConnectionTest extends BaseAndroidTest {
         assertTrue(state.isAirplaneModeEnabled());
     }
 
+    @Disabled("Disabled until https://github.com/appium/appium/issues/17422 is resolved")
     @Test
-    public void test3() {
+    public void testWiFiAndDataEnabled() {
         ConnectionState state = driver.setConnection(
                 new ConnectionStateBuilder(driver.getConnection())
                         .withAirplaneModeDisabled()

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -30,6 +30,7 @@ import io.appium.java_client.appmanagement.ApplicationState;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.ScreenOrientation;
 import org.openqa.selenium.html5.Location;
@@ -74,7 +75,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
             fail("Not able to toggle wifi");
         }
     }
-
+    @Disabled("Disabled until this issue is fixed https://github.com/appium/appium/issues/17422")
     @Test
     public void toggleAirplane() {
         try {
@@ -237,7 +238,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
     @Test
     public void pullFileTest() {
         byte[] data =
-                driver.pullFile("/data/system/users/userlist.xml");
+                driver.pullFile("/data/local/tmp/remote.txt");
         assert (data.length > 0);
     }
 

--- a/src/test/java/io/appium/java_client/android/BaseAndroidTest.java
+++ b/src/test/java/io/appium/java_client/android/BaseAndroidTest.java
@@ -20,10 +20,12 @@ import io.appium.java_client.android.options.UiAutomator2Options;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
 
 import io.appium.java_client.service.local.AppiumServiceBuilder;
+import io.appium.java_client.service.local.flags.GeneralServerFlag;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 import static io.appium.java_client.TestResources.apiDemosApk;
+import static io.appium.java_client.service.local.flags.GeneralServerFlag.ALLOW_INSECURE;
 
 public class BaseAndroidTest {
     public static final String APP_ID = "io.appium.android.apis";
@@ -39,11 +41,12 @@ public class BaseAndroidTest {
         service = new AppiumServiceBuilder()
                 .withIPAddress("127.0.0.1")
                 .usingPort(PORT)
+                .withArgument(ALLOW_INSECURE, "chromedriver_autodownload")
                 .build();
         service.start();
 
         UiAutomator2Options options = new UiAutomator2Options()
-                .setDeviceName("Android Emulator")
+                .setUdid("emulator-5554")
                 .setApp(apiDemosApk().toAbsolutePath().toString())
                 .eventTimings();
         driver = new AndroidDriver(service.getUrl(), options);


### PR DESCRIPTION
- Enable Android tests that were disabled and verified them working locally on Emulator 28
- Rename AndroidConnectionTest methods to have more descriptive names and disable the ones relying on #17422
- Refactor tests to work

## Change list

Enabling Android tests and made slight changes where applicable to make tests run successfully.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

As part of the Open Source Test Automation Summit we went through disabled Android tests and verified that disabled tests work on a local Emulator with the same API level as used by the CI/CD server. The tests where then enabled and failing ones were fixed and/or got a comment that indicates that enabling them would depend on an issue getting fixed first.
