### PR TITLE
fix: Enforce usage of Base64 compliant with RFC 4648 for all operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ dependencies {
         }
     }
     implementation 'com.google.code.gson:gson:2.9.1'
-    implementation 'commons-codec:commons-codec:1.15'
     implementation 'cglib:cglib:3.3.0'
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'org.apache.commons:commons-lang3:3.12.0'

--- a/src/main/java/io/appium/java_client/ComparesImages.java
+++ b/src/main/java/io/appium/java_client/ComparesImages.java
@@ -25,11 +25,11 @@ import io.appium.java_client.imagecomparison.OccurrenceMatchingOptions;
 import io.appium.java_client.imagecomparison.OccurrenceMatchingResult;
 import io.appium.java_client.imagecomparison.SimilarityMatchingOptions;
 import io.appium.java_client.imagecomparison.SimilarityMatchingResult;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -93,8 +93,8 @@ public interface ComparesImages extends ExecutesMethod {
      */
     default FeaturesMatchingResult matchImagesFeatures(File image1, File image2,
                                                        @Nullable FeaturesMatchingOptions options) throws IOException {
-        return matchImagesFeatures(Base64.encodeBase64(FileUtils.readFileToByteArray(image1)),
-                Base64.encodeBase64(FileUtils.readFileToByteArray(image2)), options);
+        return matchImagesFeatures(Base64.getEncoder().encode(FileUtils.readFileToByteArray(image1)),
+                Base64.getEncoder().encode(FileUtils.readFileToByteArray(image2)), options);
     }
 
     /**
@@ -160,8 +160,8 @@ public interface ComparesImages extends ExecutesMethod {
     default OccurrenceMatchingResult findImageOccurrence(File fullImage, File partialImage,
                                                          @Nullable OccurrenceMatchingOptions options)
             throws IOException {
-        return findImageOccurrence(Base64.encodeBase64(FileUtils.readFileToByteArray(fullImage)),
-                Base64.encodeBase64(FileUtils.readFileToByteArray(partialImage)), options);
+        return findImageOccurrence(Base64.getEncoder().encode(FileUtils.readFileToByteArray(fullImage)),
+                Base64.getEncoder().encode(FileUtils.readFileToByteArray(partialImage)), options);
     }
 
     /**
@@ -227,7 +227,7 @@ public interface ComparesImages extends ExecutesMethod {
     default SimilarityMatchingResult getImagesSimilarity(File image1, File image2,
                                                          @Nullable SimilarityMatchingOptions options)
             throws IOException {
-        return getImagesSimilarity(Base64.encodeBase64(FileUtils.readFileToByteArray(image1)),
-                Base64.encodeBase64(FileUtils.readFileToByteArray(image2)), options);
+        return getImagesSimilarity(Base64.getEncoder().encode(FileUtils.readFileToByteArray(image1)),
+                Base64.getEncoder().encode(FileUtils.readFileToByteArray(image2)), options);
     }
 }

--- a/src/main/java/io/appium/java_client/PushesFiles.java
+++ b/src/main/java/io/appium/java_client/PushesFiles.java
@@ -19,11 +19,11 @@ package io.appium.java_client;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.appium.java_client.MobileCommand.pushFileCommand;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Base64;
 
 public interface PushesFiles extends ExecutesMethod {
 
@@ -57,7 +57,7 @@ public interface PushesFiles extends ExecutesMethod {
             throw new IOException(String.format("The given file %s doesn't exist",
                     file.getAbsolutePath()));
         }
-        pushFile(remotePath, Base64.encodeBase64(FileUtils.readFileToByteArray(file)));
+        pushFile(remotePath, Base64.getEncoder().encode(FileUtils.readFileToByteArray(file)));
     }
 
 }

--- a/src/main/java/io/appium/java_client/imagecomparison/ComparisonResult.java
+++ b/src/main/java/io/appium/java_client/imagecomparison/ComparisonResult.java
@@ -18,7 +18,6 @@ package io.appium.java_client.imagecomparison;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import org.apache.commons.codec.binary.Base64;
 
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
@@ -28,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 public abstract class ComparisonResult {
@@ -70,7 +70,7 @@ public abstract class ComparisonResult {
      * @throws IOException On file system I/O error.
      */
     public void storeVisualization(File destination) throws IOException {
-        final byte[] data = Base64.decodeBase64(getVisualization());
+        final byte[] data = Base64.getDecoder().decode(getVisualization());
         try (OutputStream stream = new FileOutputStream(destination)) {
             stream.write(data);
         }

--- a/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
+++ b/src/test/java/io/appium/java_client/android/AndroidDriverTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import io.appium.java_client.appmanagement.ApplicationState;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -37,6 +36,7 @@ import org.openqa.selenium.html5.Location;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 public class AndroidDriverTest extends BaseAndroidTest {
@@ -155,7 +155,7 @@ public class AndroidDriverTest extends BaseAndroidTest {
 
     @Test
     public void pushFileTest() {
-        byte[] data = Base64.encodeBase64(
+        byte[] data = Base64.getEncoder().encode(
                 "The eventual code is no more than the deposit of your understanding. ~E. W. Dijkstra"
                         .getBytes());
         driver.pushFile("/data/local/tmp/remote.txt", data);

--- a/src/test/java/io/appium/java_client/android/ImagesComparisonTest.java
+++ b/src/test/java/io/appium/java_client/android/ImagesComparisonTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Base64;
+
 import io.appium.java_client.imagecomparison.FeatureDetector;
 import io.appium.java_client.imagecomparison.FeaturesMatchingOptions;
 import io.appium.java_client.imagecomparison.FeaturesMatchingResult;
@@ -30,7 +32,6 @@ import io.appium.java_client.imagecomparison.OccurrenceMatchingOptions;
 import io.appium.java_client.imagecomparison.OccurrenceMatchingResult;
 import io.appium.java_client.imagecomparison.SimilarityMatchingOptions;
 import io.appium.java_client.imagecomparison.SimilarityMatchingResult;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.OutputType;
 
@@ -38,7 +39,7 @@ public class ImagesComparisonTest extends BaseAndroidTest {
 
     @Test
     public void verifyFeaturesMatching() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         FeaturesMatchingResult result = driver
                 .matchImagesFeatures(screenshot, screenshot, new FeaturesMatchingOptions()
                         .withDetectorName(FeatureDetector.ORB)
@@ -56,7 +57,7 @@ public class ImagesComparisonTest extends BaseAndroidTest {
 
     @Test
     public void verifyOccurrencesLookup() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         OccurrenceMatchingResult result = driver
                 .findImageOccurrence(screenshot, screenshot, new OccurrenceMatchingOptions()
                         .withEnabledVisualization());
@@ -66,7 +67,7 @@ public class ImagesComparisonTest extends BaseAndroidTest {
 
     @Test
     public void verifySimilarityCalculation() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         SimilarityMatchingResult result = driver
                 .getImagesSimilarity(screenshot, screenshot, new SimilarityMatchingOptions()
                         .withEnabledVisualization());

--- a/src/test/java/io/appium/java_client/ios/ImagesComparisonTest.java
+++ b/src/test/java/io/appium/java_client/ios/ImagesComparisonTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Base64;
+
 import io.appium.java_client.imagecomparison.FeatureDetector;
 import io.appium.java_client.imagecomparison.FeaturesMatchingOptions;
 import io.appium.java_client.imagecomparison.FeaturesMatchingResult;
@@ -30,7 +32,6 @@ import io.appium.java_client.imagecomparison.OccurrenceMatchingOptions;
 import io.appium.java_client.imagecomparison.OccurrenceMatchingResult;
 import io.appium.java_client.imagecomparison.SimilarityMatchingOptions;
 import io.appium.java_client.imagecomparison.SimilarityMatchingResult;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.OutputType;
 
@@ -38,7 +39,7 @@ public class ImagesComparisonTest extends AppIOSTest {
 
     @Test
     public void verifyFeaturesMatching() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         FeaturesMatchingResult result = driver
                 .matchImagesFeatures(screenshot, screenshot, new FeaturesMatchingOptions()
                         .withDetectorName(FeatureDetector.ORB)
@@ -56,7 +57,7 @@ public class ImagesComparisonTest extends AppIOSTest {
 
     @Test
     public void verifyOccurrencesSearch() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         OccurrenceMatchingResult result = driver
                 .findImageOccurrence(screenshot, screenshot, new OccurrenceMatchingOptions()
                         .withEnabledVisualization());
@@ -66,7 +67,7 @@ public class ImagesComparisonTest extends AppIOSTest {
 
     @Test
     public void verifySimilarityCalculation() {
-        byte[] screenshot = Base64.encodeBase64(driver.getScreenshotAs(OutputType.BYTES));
+        byte[] screenshot = Base64.getEncoder().encode(driver.getScreenshotAs(OutputType.BYTES));
         SimilarityMatchingResult result = driver
                 .getImagesSimilarity(screenshot, screenshot, new SimilarityMatchingOptions()
                         .withEnabledVisualization());


### PR DESCRIPTION
## Change list

Enforce usage of Base64 encoding scheme compliant with `RFC 4648` for all operations (instead of `RFC 2045`).
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

I'm not sure whether it's really necessary. However the wave of conversations around encoding of screenshots makes me think that following single standard ([W3C WebDriver spec sticks to `RFC 4648`](https://www.w3.org/TR/webdriver/#index)) for all operations will be more consistent approach.
