### PR TITLE
chore: remove unnecessary annotation

### DIFF
--- a/src/main/java/io/appium/java_client/remote/DirectConnect.java
+++ b/src/main/java/io/appium/java_client/remote/DirectConnect.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 
 import static io.appium.java_client.internal.CapabilityHelpers.APPIUM_PREFIX;
 
-@Accessors
 public class DirectConnect {
     private static final String DIRECT_CONNECT_PROTOCOL = "directConnectProtocol";
     private static final String DIRECT_CONNECT_PATH = "directConnectPath";

--- a/src/main/java/io/appium/java_client/remote/DirectConnect.java
+++ b/src/main/java/io/appium/java_client/remote/DirectConnect.java
@@ -18,7 +18,6 @@ package io.appium.java_client.remote;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import javax.annotation.Nullable;
 import java.net.MalformedURLException;

--- a/src/main/java/io/appium/java_client/remote/DirectConnect.java
+++ b/src/main/java/io/appium/java_client/remote/DirectConnect.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.appium.java_client.remote;
 
 import lombok.AccessLevel;


### PR DESCRIPTION
## Change list

The accessors annotation can be removed when it has no arguments.
```
> Task :compileJava
/Users/kazu/GitHub/java-client/src/main/java/io/appium/java_client/remote/DirectConnect.java:16: warning: Accessors on its own does nothing. Set at least one parameter
@Accessors
^
```
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

It seems like the annotation is used only when we'd like to set non-default options
https://github.com/projectlombok/lombok/blob/560ded50127b12bd8168f8ae2bada47253f15bc8/src/core/lombok/core/AnnotationValues.java#L570

(i have tested without this annotation)