### PR TITLE
fix: Use ipv4 address instead of localhost

### DIFF
--- a/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
+++ b/src/main/java/io/appium/java_client/android/ListensToLogcatMessages.java
@@ -38,7 +38,7 @@ public interface ListensToLogcatMessages extends ExecutesMethod {
      * is assigned to the default port (4723).
      */
     default void startLogcatBroadcast() {
-        startLogcatBroadcast("localhost", DEFAULT_APPIUM_PORT);
+        startLogcatBroadcast("127.0.0.1", DEFAULT_APPIUM_PORT);
     }
 
     /**


### PR DESCRIPTION
## Change list

On some systems `localhost` is resolved to `::1`, which won'y work for as a proper default
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

