### PR TITLE
chore: deprecate tapWithShortPressDuration cap

### DIFF
--- a/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
@@ -170,7 +170,10 @@ public interface IOSMobileCapabilityType extends CapabilityType {
     /**
      * The desired capability to specify a length for tapping, if the regular
      * tap is too long for the app under test. The  XCUITest specific capability.
+     * 
+     * @Deprecated This capability is not being used.
      */
+    @Deprecated
     String TAP_WITH_SHORT_PRESS_DURATION = "tapWithShortPressDuration";
 
     /**

--- a/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
@@ -171,7 +171,7 @@ public interface IOSMobileCapabilityType extends CapabilityType {
      * The desired capability to specify a length for tapping, if the regular
      * tap is too long for the app under test. The  XCUITest specific capability.
      * 
-     * @Deprecated This capability is not being used.
+     * @deprecated This capability is not being used.
      */
     @Deprecated
     String TAP_WITH_SHORT_PRESS_DURATION = "tapWithShortPressDuration";


### PR DESCRIPTION
## Change list
This PR removes tapWithShortPressDuration cap.
see https://github.com/appium/appium-xcuitest-driver/pull/1481
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

see https://github.com/appium/appium-xcuitest-driver/pull/1481