### PR TITLE
ci: Run Gradle wrapper validation only on Gradle files changes

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
     - master
+    paths:
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/**'
+      - '.github/workflows/gradle-wrapper-validation.yml'
   pull_request:
     branches:
     - master
+    paths:
+      - 'gradlew'
+      - 'gradlew.bat'
+      - 'gradle/wrapper/**'
+      - '.github/workflows/gradle-wrapper-validation.yml'
 
 jobs:
   validation:


### PR DESCRIPTION
## Change list

It's not needed to validate Gradle wrapper for each and every change, it should be enough to run it only if particualr Gradle files are changed.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
