### PR TITLE
build: Remove Checkstyle exclusion of removed Selenium package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,6 @@ checkstyle {
     showViolations = true
     ignoreFailures = false
 }
-checkstyleMain.excludes = ['**/org/openqa/selenium/**']
 
 javadoc {
     options.addStringOption('encoding', 'UTF-8')


### PR DESCRIPTION
## Change list

Overridden Selenium package was dropped some time ago, but Checkstyle exclusion wasn't deleted. Now it's time to removed leftovers.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
