### PR TITLE
build: Make unit tests execution a part of Gradle build lifecycle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,4 +33,4 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'gradle'
     - name: Build with Gradle
-      run: ./gradlew clean build unitTest
+      run: ./gradlew clean build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,7 @@ jobs:
       jdkVersionOption: "$(JDK_VERSION)"
       jdkArchitectureOption: 'x64'
       publishJUnitResults: true
-      tasks: 'build'
-      options: 'uiAutomationTest -x test'
+      tasks: 'build uiAutomationTest'
 - job: iOS_E2E_Tests
 #  timeoutInMinutes: '90'
   steps:
@@ -62,5 +61,4 @@ jobs:
       jdkVersionOption: "$(JDK_VERSION)"
       jdkArchitectureOption: 'x64'
       publishJUnitResults: true
-      tasks: 'build'
-      options: 'xcuiTest -x test'
+      tasks: 'build xcuiTest'

--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ processResources {
     ]
 }
 
-task unitTest( type: Test ) {
+test {
     useJUnitPlatform()
     testLogging.showStandardStreams = true
     testLogging.exceptionFormat = 'full'
@@ -212,6 +212,7 @@ task unitTest( type: Test ) {
         includeTestsMatching 'io.appium.java_client.remote.*'
         includeTestsMatching 'io.appium.java_client.touch.*'
     }
+    finalizedBy jacocoTestReport
 }
 
 task xcuiTest( type: Test ) {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk8
 install:
-   - ./gradlew clean build publishToMavenLocal -x signMavenJavaPublication -x test
+   - ./gradlew clean build publishToMavenLocal -x signMavenJavaPublication


### PR DESCRIPTION
## Change list

This change simplifies unit tests task management and execution:
- `test` task of type `Test` is created automatically
- in comparison with previous approach no need to invoke extra task (it was `unitTest`): whenever `build` task is run, `test` task will be executed (this happens because `test` task is attached to the `check` lifecycle task)

More details: https://docs.gradle.org/current/userguide/java_testing.html#sec:java_testing_basics

Also now:
 - JitPack build is failed if unit tests fail: no reason to publish invalid build
 - Successful run of unit tests is a mandatory prerequisite for execution of integration Android and iOS tests 
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
