### PR TITLE
chore: Bump the minimum selenium client version to 4.8.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=true
 
-selenium.version=4.7.0
+selenium.version=4.8.2
 # Please increment the value in a release
 appiumClient.version=8.3.0

--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -123,11 +123,7 @@ public final class AppiumDriverLocalService extends DriverService {
     public boolean isRunning() {
         lock.lock();
         try {
-            if (process == null) {
-                return false;
-            }
-
-            if (!process.isRunning()) {
+            if (process == null || !process.isRunning()) {
                 return false;
             }
 

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -406,7 +406,7 @@ public final class AppiumServiceBuilder
     @Override
     public AppiumDriverLocalService build() {
         File driverExecutable = ReflectionHelpers.getPrivateFieldValue(
-                AppiumServiceBuilder.class, this, "exe", File.class
+                DriverService.Builder.class, this, "exe", File.class
         );
         if (driverExecutable == null) {
             usingDriverExecutable(findDefaultExecutable());

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -405,7 +405,7 @@ public final class AppiumServiceBuilder
 
     @Override
     public AppiumDriverLocalService build() {
-        File driverExecutable =  ReflectionHelpers.getPrivateFieldValue(
+        File driverExecutable = ReflectionHelpers.getPrivateFieldValue(
                 AppiumServiceBuilder.class, this, "exe", File.class
         );
         if (driverExecutable == null) {

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -19,6 +19,7 @@ package io.appium.java_client.service.local;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.appium.java_client.internal.ReflectionHelpers;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.appium.java_client.remote.MobileBrowserType;
 import io.appium.java_client.remote.MobileCapabilityType;
@@ -160,7 +161,6 @@ public final class AppiumServiceBuilder
         return mainAppiumJs;
     }
 
-    @Override
     protected File findDefaultExecutable() {
         if (this.node != null) {
             validatePath(this.node.getAbsolutePath(), NODE_JS_NOT_EXIST_ERROR.apply(this.node));
@@ -228,8 +228,10 @@ public final class AppiumServiceBuilder
 
     private static String sanitizeBasePath(String basePath) {
         basePath = checkNotNull(basePath).trim();
-        checkArgument(!basePath.isEmpty(),
-            "Given base path is not valid - blank or empty values are not allowed for base path");
+        checkArgument(
+                !basePath.isEmpty(),
+                "Given base path is not valid - blank or empty values are not allowed for base path"
+        );
         return basePath.endsWith("/") ? basePath : basePath + "/";
     }
 
@@ -399,6 +401,17 @@ public final class AppiumServiceBuilder
         }
 
         return new ImmutableList.Builder<String>().addAll(argList).build();
+    }
+
+    @Override
+    public AppiumDriverLocalService build() {
+        File driverExecutable =  ReflectionHelpers.getPrivateFieldValue(
+                AppiumServiceBuilder.class, this, "exe", File.class
+        );
+        if (driverExecutable == null) {
+            usingDriverExecutable(findDefaultExecutable());
+        }
+        return super.build();
     }
 
     /**


### PR DESCRIPTION
## Change list

Due to the [breaking change](https://github.com/appium/java-client/issues/1872#issuecomment-1494233769) in the recent Selenium client release we need to update the service builder class to make it great again.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)