### PR TITLE
chore: Bump minimum Selenium client version to 4.9.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=true
 
-selenium.version=4.8.2
+selenium.version=4.9.1
 # Please increment the value in a release
 appiumClient.version=8.4.0

--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -290,8 +290,8 @@ public class AppiumDriver extends RemoteWebDriver implements
         }
 
         @SuppressWarnings("unchecked") Map<String, Object> rawCapabilities = (Map<String, Object>) responseValue;
-        // A workaround for Selenium API enforcing some legacy capability values
-        rawCapabilities.remove(CapabilityType.PLATFORM);
+        // TODO: remove this workaround for Selenium API enforcing some legacy capability values in major version
+        rawCapabilities.remove("platform");
         if (rawCapabilities.containsKey(CapabilityType.BROWSER_NAME)
                 && isBlank((String) rawCapabilities.get(CapabilityType.BROWSER_NAME))) {
             rawCapabilities.remove(CapabilityType.BROWSER_NAME);

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -404,14 +404,13 @@ public final class AppiumServiceBuilder
     }
 
     @Override
-    public AppiumDriverLocalService build() {
+    protected void loadSystemProperties() {
         File driverExecutable = ReflectionHelpers.getPrivateFieldValue(
                 DriverService.Builder.class, this, "exe", File.class
         );
         if (driverExecutable == null) {
             usingDriverExecutable(findDefaultExecutable());
         }
-        return super.build();
     }
 
     /**


### PR DESCRIPTION
Selenium 4.9.1 introduced 2 breaking changes that cause compilation errors:
- https://github.com/SeleniumHQ/selenium/commit/66e51be38cbd492c11605397e1b50c1cb786a579
- https://github.com/SeleniumHQ/selenium/commit/3d8c6fa7a950ce129f4bd8fb347c71a2cdd4bf07

## Change list

Make Appium Java client compatible with the newest Selenium client
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
