### PR TITLE
fix: Add fallback commands for file management APIs

### DIFF
--- a/src/main/java/io/appium/java_client/PullsFiles.java
+++ b/src/main/java/io/appium/java_client/PullsFiles.java
@@ -19,11 +19,14 @@ package io.appium.java_client;
 import com.google.common.collect.ImmutableMap;
 
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
 import java.util.Base64;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.appium.java_client.MobileCommand.PULL_FILE;
+import static io.appium.java_client.MobileCommand.PULL_FOLDER;
 
-public interface PullsFiles extends ExecutesMethod {
+public interface PullsFiles extends ExecutesMethod, CanRememberExtensionPresence {
 
     /**
      * Pull a file from the remote system.
@@ -38,11 +41,22 @@ public interface PullsFiles extends ExecutesMethod {
      * @return A byte array of Base64 encoded data.
      */
     default byte[] pullFile(String remotePath) {
-        String base64String = checkNotNull(
-            CommandExecutionHelper.executeScript(this, "mobile: pullFile", ImmutableMap.of(
-                "remotePath", remotePath
-            ))
-        );
+        final String extName = "mobile: pullFile";
+        String base64String;
+        try {
+            base64String = checkNotNull(
+                CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName,
+                        ImmutableMap.of("remotePath", remotePath)
+                )
+            );
+        } catch (UnsupportedOperationException e) {
+            // TODO: Remove the fallback
+            base64String = checkNotNull(
+                CommandExecutionHelper.execute(markExtensionAbsence(extName),
+                        new AbstractMap.SimpleEntry<>(PULL_FILE, ImmutableMap.of("path", remotePath))
+                )
+            );
+        }
         return Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -59,11 +73,22 @@ public interface PullsFiles extends ExecutesMethod {
      * @return A byte array of Base64 encoded zip archive data.
      */
     default byte[] pullFolder(String remotePath) {
-        String base64String = checkNotNull(
-            CommandExecutionHelper.executeScript(this, "mobile: pullFolder", ImmutableMap.of(
-                "remotePath", remotePath
-            ))
-        );
+        final String extName = "mobile: pullFolder";
+        String base64String;
+        try {
+            base64String = checkNotNull(
+                CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName,
+                        ImmutableMap.of("remotePath", remotePath)
+                )
+            );
+        } catch (UnsupportedOperationException e) {
+            // TODO: Remove the fallback
+            base64String = checkNotNull(
+                CommandExecutionHelper.execute(markExtensionAbsence(extName),
+                        new AbstractMap.SimpleEntry<>(PULL_FOLDER, ImmutableMap.of("path", remotePath))
+                )
+            );
+        }
         return Base64.getDecoder().decode(base64String.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/main/java/io/appium/java_client/PushesFiles.java
+++ b/src/main/java/io/appium/java_client/PushesFiles.java
@@ -18,13 +18,16 @@ package io.appium.java_client;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
+import org.openqa.selenium.UnsupportedCommandException;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-public interface PushesFiles extends ExecutesMethod {
+import static io.appium.java_client.MobileCommand.pushFileCommand;
+
+public interface PushesFiles extends ExecutesMethod, CanRememberExtensionPresence {
 
     /**
      * Saves base64-encoded data as a file on the remote system.
@@ -36,10 +39,16 @@ public interface PushesFiles extends ExecutesMethod {
      * @param base64Data Base64 encoded byte array of media file data to write to remote device
      */
     default void pushFile(String remotePath, byte[] base64Data) {
-        CommandExecutionHelper.executeScript(this, "mobile: pushFile", ImmutableMap.of(
-                "remotePath", remotePath,
-                "payload", new String(base64Data, StandardCharsets.UTF_8)
-        ));
+        final String extName = "mobile: pushFile";
+        try {
+            CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, ImmutableMap.of(
+                    "remotePath", remotePath,
+                    "payload", new String(base64Data, StandardCharsets.UTF_8)
+            ));
+        } catch (UnsupportedCommandException e) {
+            // TODO: Remove the fallback
+            CommandExecutionHelper.execute(markExtensionAbsence(extName), pushFileCommand(remotePath, base64Data));
+        }
     }
 
     /**


### PR DESCRIPTION
## Change list

Add fallback commands for file management APIs if mobile extensions are not available
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)