### PR TITLE
fix: Use correct exception type for fallback at file/folder pulling

### DIFF
--- a/src/main/java/io/appium/java_client/PullsFiles.java
+++ b/src/main/java/io/appium/java_client/PullsFiles.java
@@ -17,6 +17,7 @@
 package io.appium.java_client;
 
 import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.UnsupportedCommandException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
@@ -49,7 +50,7 @@ public interface PullsFiles extends ExecutesMethod, CanRememberExtensionPresence
                         ImmutableMap.of("remotePath", remotePath)
                 )
             );
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
             base64String = checkNotNull(
                 CommandExecutionHelper.execute(markExtensionAbsence(extName),
@@ -81,7 +82,7 @@ public interface PullsFiles extends ExecutesMethod, CanRememberExtensionPresence
                         ImmutableMap.of("remotePath", remotePath)
                 )
             );
-        } catch (UnsupportedOperationException e) {
+        } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
             base64String = checkNotNull(
                 CommandExecutionHelper.execute(markExtensionAbsence(extName),


### PR DESCRIPTION
## Change list

Use correct exception type for fallback at file/folder pulling. The issue was introduced by #1910: wrong exception type was used accidentally.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)