### PR TITLE
chore: Mark Windows page object annotations as deprecated

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/WindowsBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsBy.java
@@ -18,7 +18,9 @@ package io.appium.java_client.pagefactory;
 
 /**
  * Used to build a complex Windows automation locator.
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 public @interface WindowsBy {
 
     /**

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindAll.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindAll.java
@@ -29,7 +29,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of {@link WindowsBy} tags
  * It will then search for all elements that match any criteria. Note that elements
  * are not guaranteed to be in document order.
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Retention(RUNTIME) @Target({FIELD, TYPE})
 @Repeatable(WindowsFindByAllSet.class)
 public @interface WindowsFindAll {

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindBy.java
@@ -30,7 +30,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * {@link org.openqa.selenium.support.PageFactory}
  * this allows users to quickly and easily create PageObjects.
  * using Windows automation selectors, accessibility, id, name, class name, tag and xpath
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Retention(RUNTIME) @Target({FIELD, TYPE})
 @Repeatable(WindowsFindBySet.class)
 public @interface WindowsFindBy {

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindByAllSet.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindByAllSet.java
@@ -10,7 +10,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Defines set of chained/possible locators. Each one locator
  * should be defined with {@link WindowsFindAll}
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Target(value = {TYPE, FIELD})
 @Retention(value = RUNTIME)
 public @interface WindowsFindByAllSet {

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindByChainSet.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindByChainSet.java
@@ -10,7 +10,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Defines set of chained/possible locators. Each one locator
  * should be defined with {@link WindowsFindBys}
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Target(value = {TYPE, FIELD})
 @Retention(value = RUNTIME)
 public @interface WindowsFindByChainSet {

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindBySet.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindBySet.java
@@ -26,7 +26,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Defines set of chained/possible locators. Each one locator
  * should be defined with {@link WindowsFindBy}
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Target(value = {TYPE, FIELD})
 @Retention(value = RUNTIME)
 public @interface WindowsFindBySet {

--- a/src/main/java/io/appium/java_client/pagefactory/WindowsFindBys.java
+++ b/src/main/java/io/appium/java_client/pagefactory/WindowsFindBys.java
@@ -27,7 +27,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Used to mark a field on a Page Object to indicate that lookup should use
  * a series of {@link WindowsBy} tags.
+ * @deprecated This annotation is deprecated and will be removed.
  */
+@Deprecated
 @Retention(RUNTIME) @Target({FIELD, TYPE})
 @Repeatable(WindowsFindByChainSet.class)
 public @interface WindowsFindBys {


### PR DESCRIPTION
These annotations are not used anywhere and we don't need them