### PR TITLE
Fix for AUTO_WEBVIEW in MobileCapabilityType

### DIFF
--- a/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
@@ -85,7 +85,7 @@ public interface MobileCapabilityType extends CapabilityType {
     /**
      * Move directly into Webview context. Default false.
      */
-    String AUTO_WEBVIEW = "autoWebview";
+    String AUTO_WEBVIEW = "autoWebView";
 
     /**
      * Don't reset app state before this session. See


### PR DESCRIPTION
Changed value for AUTO_WEBVIEW from 'autoWebview' to 'autoWebView'.

## Change list

Please provide briefly described change list which are you going to propose. 

- Changing the value for MobileCapabilityType.AUTO_WEBVIEW from 'autoWebview' to 'autoWebView'.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 

I realized while using the MobileCapabilityType.AUTO_WEBVIEW that the value for the type is 'autoWebview' and not 'autoWebView'. The latter seems to be the correct value though as my app test actually crashed on me until I used the 'autoWebView' string instead of the type itself. This is why I propose this change to be in the project itself to I can use the type in the future and not depend on the 'autoWebView' capability using the string anymore.
