### PR TITLE
fix: AppiumClientConfig#readTimeout to call super.readTimeout

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumClientConfig.java
+++ b/src/main/java/io/appium/java_client/AppiumClientConfig.java
@@ -129,7 +129,7 @@ public class AppiumClientConfig extends ClientConfig {
 
     @Override
     public AppiumClientConfig readTimeout(Duration timeout) {
-        ClientConfig clientConfig = super.connectionTimeout(timeout);
+        ClientConfig clientConfig = super.readTimeout(timeout);
         return buildAppiumClientConfig(clientConfig, directConnect);
     }
 


### PR DESCRIPTION
## Change list

https://github.com/appium/java-client/pull/1747/files#r1260247871
Bad copy & paste thing.

 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Should call super.readTimeout instead of super.connectionTimeout in readTimeout
