### PR TITLE
chore: Deprecate obsolete capabilities constants

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/AndroidMobileCapabilityType.java
@@ -23,7 +23,10 @@ import org.openqa.selenium.remote.CapabilityType;
  * Read: <br>
  * <a href="https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md#android-only">
  * https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md#android-only</a>
+ *
+ * @deprecated This interface will be removed. Use Options instead.
  */
+@Deprecated
 public interface AndroidMobileCapabilityType extends CapabilityType {
 
     /**

--- a/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/IOSMobileCapabilityType.java
@@ -27,7 +27,10 @@ import org.openqa.selenium.remote.CapabilityType;
  * and<br>
  * <a href="https://github.com/appium/appium-xcuitest-driver#desired-capabilities">
  * https://github.com/appium/appium-xcuitest-driver#desired-capabilities</a>
+ *
+ * @deprecated This interface will be removed. Use Options instead.
  */
+@Deprecated
 public interface IOSMobileCapabilityType extends CapabilityType {
 
     /**

--- a/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/MobileCapabilityType.java
@@ -23,7 +23,10 @@ import org.openqa.selenium.remote.CapabilityType;
  * Read: <br>
  * <a href="https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md#general-capabilities">
  * https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md#general-capabilities</a>
+ *
+ * @deprecated This interface will be removed. Use Options instead.
  */
+@Deprecated
 public interface MobileCapabilityType extends CapabilityType {
 
     /**

--- a/src/main/java/io/appium/java_client/remote/YouiEngineCapabilityType.java
+++ b/src/main/java/io/appium/java_client/remote/YouiEngineCapabilityType.java
@@ -4,7 +4,10 @@ import org.openqa.selenium.remote.CapabilityType;
 
 /**
  * The list of youiengine-specific capabilities.
+ *
+ * @deprecated This interface will be removed. Use Options instead.
  */
+@Deprecated
 public interface YouiEngineCapabilityType extends CapabilityType {
     /**
      * IP address of the app to execute commands against.


### PR DESCRIPTION
We only want to have a single place where options are defined.