### PR TITLE
Caching Mechanism for ProxyListenerContainer

### DIFF
--- a/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
+++ b/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
@@ -18,10 +18,9 @@ package io.appium.java_client.proxy;
 
 import java.lang.ref.WeakReference;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 
 class ProxyListenersContainer {
@@ -39,19 +38,24 @@ class ProxyListenersContainer {
     // we had to change it to a list, which has O(N). The reason for that is that
     // maps implicitly call `hashCode` API on instances, which might not always
     // work as expected for arbitrary proxies
-    private final List<Pair<WeakReference<?>, Collection<MethodCallListener>>> listeners = new LinkedList<>();
+    // As of (this version?) we are now using a LinkedHashMap as a caching mechanism. This can be overridden by a System
+    // Property value "appium.override.listener.limit": default 5000.
+    private final LinkedHashMap<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>>
+        listeners =
+        new LinkedHashMap<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>>() {
+            protected boolean removeEldestEntry(
+                Map.Entry<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>> eldest) {
+                return size() > Integer.parseInt(
+                    System.getProperty("appium.override.listener.limit", "5000"));
+            }
+        };
+
 
     private static class Pair<K, V> {
-        private final K key;
         private final V value;
 
         public Pair(K key, V value) {
-            this.key = key;
             this.value = value;
-        }
-
-        public K getKey() {
-            return key;
         }
 
         public V getValue() {
@@ -66,7 +70,7 @@ class ProxyListenersContainer {
      * Assign listeners for the particular proxied instance.
      *
      * @param proxyInstance The proxied instance.
-     * @param listeners Collection of listeners.
+     * @param listeners     Collection of listeners.
      * @return The same given instance.
      */
     public <T> T setListeners(T proxyInstance, Collection<MethodCallListener> listeners) {
@@ -76,27 +80,9 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            int i = 0;
-            boolean wasInstancePresent = false;
-            while (i < this.listeners.size()) {
-                Pair<WeakReference<?>, Collection<MethodCallListener>> pair = this.listeners.get(i);
-                Object key = pair.getKey().get();
-                if (key == null) {
-                    // The instance has been garbage-collected
-                    this.listeners.remove(i);
-                    continue;
-                }
-
-                if (key == proxyInstance) {
-                    pair.getValue().clear();
-                    pair.getValue().addAll(listeners);
-                    wasInstancePresent = true;
-                }
-                i++;
-            }
-            if (!wasInstancePresent) {
-                this.listeners.add(new Pair<>(new WeakReference<>(proxyInstance), new HashSet<>(listeners)));
-            }
+            Pair<WeakReference<?>, HashSet<MethodCallListener>> pair =
+                new Pair<>(new WeakReference<>(proxyInstance), new HashSet<>(listeners));
+            this.listeners.put(String.valueOf(proxyInstance.getClass()), pair);
         } finally {
             listenersGuard.release();
         }
@@ -115,23 +101,7 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            int i = 0;
-            Collection<MethodCallListener> result = Collections.emptySet();
-            while (i < listeners.size()) {
-                Pair<WeakReference<?>, Collection<MethodCallListener>> pair = listeners.get(i);
-                Object key = pair.getKey().get();
-                if (key == null) {
-                    // The instance has been garbage-collected
-                    listeners.remove(i);
-                    continue;
-                }
-
-                if (key == proxyInstance) {
-                    result = pair.getValue();
-                }
-                i++;
-            }
-            return result;
+            return listeners.get(String.valueOf(proxyInstance.getClass())).getValue();
         } finally {
             listenersGuard.release();
         }

--- a/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
+++ b/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
@@ -66,7 +66,7 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            this.listeners.put(String.valueOf(proxyInstance.getClass()), new HashSet<>(listeners));
+            this.listeners.put(proxyInstance.getClass(), new HashSet<>(listeners));
         } finally {
             listenersGuard.release();
         }
@@ -85,7 +85,7 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            return listeners.get(String.valueOf(proxyInstance.getClass()));
+            return listeners.get(proxyInstance.getClass());
         } finally {
             listenersGuard.release();
         }

--- a/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
+++ b/src/main/java/io/appium/java_client/proxy/ProxyListenersContainer.java
@@ -16,7 +16,6 @@
 
 package io.appium.java_client.proxy;
 
-import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -40,28 +39,15 @@ class ProxyListenersContainer {
     // work as expected for arbitrary proxies
     // As of (this version?) we are now using a LinkedHashMap as a caching mechanism. This can be overridden by a System
     // Property value "appium.override.listener.limit": default 5000.
-    private final LinkedHashMap<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>>
+    private final LinkedHashMap<Object, HashSet<MethodCallListener>>
         listeners =
-        new LinkedHashMap<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>>() {
+        new LinkedHashMap<Object, HashSet<MethodCallListener>>() {
             protected boolean removeEldestEntry(
-                Map.Entry<Object, Pair<WeakReference<?>, HashSet<MethodCallListener>>> eldest) {
+                Map.Entry<Object, HashSet<MethodCallListener>> eldest) {
                 return size() > Integer.parseInt(
                     System.getProperty("appium.override.listener.limit", "5000"));
             }
         };
-
-
-    private static class Pair<K, V> {
-        private final V value;
-
-        public Pair(K key, V value) {
-            this.value = value;
-        }
-
-        public V getValue() {
-            return value;
-        }
-    }
 
     private ProxyListenersContainer() {
     }
@@ -80,9 +66,7 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            Pair<WeakReference<?>, HashSet<MethodCallListener>> pair =
-                new Pair<>(new WeakReference<>(proxyInstance), new HashSet<>(listeners));
-            this.listeners.put(String.valueOf(proxyInstance.getClass()), pair);
+            this.listeners.put(String.valueOf(proxyInstance.getClass()), new HashSet<>(listeners));
         } finally {
             listenersGuard.release();
         }
@@ -101,7 +85,7 @@ class ProxyListenersContainer {
             throw new RuntimeException(e);
         }
         try {
-            return listeners.get(String.valueOf(proxyInstance.getClass())).getValue();
+            return listeners.get(String.valueOf(proxyInstance.getClass()));
         } finally {
             listenersGuard.release();
         }


### PR DESCRIPTION
## Change list

Updating the ProxyListenerContainer to use a LinkedHashMap caching mechanism, in place of a List. This is to improve performance as the amount of listeners grows.

I have defaulted the cache to 5000 decorated pages, but this can be changed if needed through a system property
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] Bugfix (non-breaking change which fixes an issue)


## Details

Original [Discussion](https://github.com/appium/appium/discussions/18860)

