### PR TITLE
fix: Correct spelling and semantic mistakes in method naming

### DIFF
--- a/src/main/java/io/appium/java_client/android/options/context/SupportsShowChromedriverLogOption.java
+++ b/src/main/java/io/appium/java_client/android/options/context/SupportsShowChromedriverLogOption.java
@@ -45,8 +45,19 @@ public interface SupportsShowChromedriverLogOption<T extends BaseOptions<T>>
      * @param value Whether to forward chromedriver output to the Appium server log.
      * @return self instance for chaining.
      */
-    default T setDhowChromedriverLog(boolean value) {
+    default T setShowChromedriverLog(boolean value) {
         return amend(SHOW_CHROMEDRIVER_LOG_OPTION, value);
+    }
+
+    /**
+     * If set to true then all the output from chromedriver binary will be
+     * forwarded to the Appium server log. false by default.
+     *
+     * @deprecated Use {@link SupportsShowChromedriverLogOption#setShowChromedriverLog(boolean)} instead.
+     */
+    @Deprecated
+    default T setDhowChromedriverLog(boolean value) {
+        return setShowChromedriverLog(value);
     }
 
     /**
@@ -54,9 +65,19 @@ public interface SupportsShowChromedriverLogOption<T extends BaseOptions<T>>
      *
      * @return True or false.
      */
-    default Optional<Boolean> doesDhowChromedriverLog() {
+    default Optional<Boolean> doesShowChromedriverLog() {
         return Optional.ofNullable(
                 toSafeBoolean(getCapability(SHOW_CHROMEDRIVER_LOG_OPTION))
         );
+    }
+
+    /**
+     * Get whether to forward chromedriver output to the Appium server log.
+     *
+     * @deprecated Use {@link SupportsShowChromedriverLogOption#doesShowChromedriverLog()} (boolean)} instead.
+     */
+    @Deprecated
+    default Optional<Boolean> doesDhowChromedriverLog() {
+        return doesShowChromedriverLog();
     }
 }

--- a/src/main/java/io/appium/java_client/ios/options/simulator/SupportsCustomSslCertOption.java
+++ b/src/main/java/io/appium/java_client/ios/options/simulator/SupportsCustomSslCertOption.java
@@ -40,9 +40,19 @@ public interface SupportsCustomSslCertOption<T extends BaseOptions<T>> extends
     /**
      * Get the SSL certificate content.
      *
+     * @deprecated use {@link SupportsCustomSslCertOption#getCustomSSLCert()} instead
+     */
+    @Deprecated
+    default Optional<String> setCustomSSLCert() {
+        return getCustomSSLCert();
+    }
+
+    /**
+     * Get the SSL certificate content.
+     *
      * @return Certificate content.
      */
-    default Optional<String> setCustomSSLCert() {
+    default Optional<String> getCustomSSLCert() {
         return Optional.ofNullable((String) getCapability(CUSTOM_SSLCERT_OPTION));
     }
 }

--- a/src/main/java/io/appium/java_client/ios/options/simulator/SupportsSimulatorTracePointerOption.java
+++ b/src/main/java/io/appium/java_client/ios/options/simulator/SupportsSimulatorTracePointerOption.java
@@ -55,7 +55,17 @@ public interface SupportsSimulatorTracePointerOption<T extends BaseOptions<T>> e
      *
      * @return True or false.
      */
-    default Optional<Boolean> doesSimulatorTracePointerd() {
+    default Optional<Boolean> doesSimulatorTracePointer() {
         return Optional.ofNullable(toSafeBoolean(getCapability(SIMULATOR_TRACE_POINTER_OPTION)));
+    }
+
+    /**
+     * Get whether to highlight pointer moves in the Simulator window.
+     *
+     * @deprecated use {@link SupportsSimulatorTracePointerOption#doesSimulatorTracePointer()} instead
+     */
+    @Deprecated
+    default Optional<Boolean> doesSimulatorTracePointerd() {
+        return doesSimulatorTracePointer();
     }
 }


### PR DESCRIPTION
## Change list

- corrects spelling and semantic errors
  - `SupportsCustomSslCertOption` method `setCustomSSLCert()` is now `getCustomSSLCert()` affects `XCUITestOptions`
  - `SupportsSimulatorTracePointerOption` method `doesSimulatorTracePointerd()` is now `doesSimulatorTracePointer()` affects `XCUITestOption`
  - `SupportsShowChromedriverLogOption` methods `setDhowChromedriverLog(boolean)` and `doesDhowChromedriverLog()` are now `setShowChromedriverLog(boolean)` and `doesShowChromedriverLog()` respectively  affects `ExpressoOptions` and `UIAutomator2Options`

 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

No functional changes
