### PR TITLE
ci: Increase the server startup timeout

### DIFF
--- a/src/test/java/io/appium/java_client/ios/BaseIOSTest.java
+++ b/src/test/java/io/appium/java_client/ios/BaseIOSTest.java
@@ -33,8 +33,8 @@ public class BaseIOSTest {
     public static final String PLATFORM_VERSION = System.getenv("IOS_PLATFORM_VERSION") != null
             ? System.getenv("IOS_PLATFORM_VERSION")
             : "14.5";
-    public static final Duration WDA_LAUNCH_TIMEOUT = Duration.ofSeconds(240);
-    public static final Duration SERVER_START_TIMEOUT = Duration.ofSeconds(40);
+    public static final Duration WDA_LAUNCH_TIMEOUT = Duration.ofMinutes(4);
+    public static final Duration SERVER_START_TIMEOUT = Duration.ofMinutes(3);
 
     /**
      * Starts a local server.


### PR DESCRIPTION
## Change list

iOS is still unbelievably slow in the CI env. Thus bumping the timeout to 3 minutes
 
## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

