### PR TITLE
chore: patch AutomationName with Chromium

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ _Put an `x` in the boxes that apply_
 
 - [ ] No changes in production code.
 - [ ] Bugfix (non-breaking change which fixes an issue)
-- [x] New feature (non-breaking change which adds functionality)
+- [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ _Put an `x` in the boxes that apply_
 
 - [ ] No changes in production code.
 - [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
+- [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 

--- a/src/main/java/io/appium/java_client/remote/AutomationName.java
+++ b/src/main/java/io/appium/java_client/remote/AutomationName.java
@@ -34,6 +34,8 @@ public interface AutomationName {
     String SAFARI = "Safari";
     // https://github.com/appium/appium-geckodriver
     String GECKO = "Gecko";
+    // https://github.com/appium/appium-chromium-driver
+    String CHROMIUM = "Chromium";
 
     // Third-party drivers
     // https://github.com/YOU-i-Labs/appium-youiengine-driver


### PR DESCRIPTION
## Change list

Patch AutomationName with Chromium variable.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

For running the Chromium driver, we need to set the automation name to Chromium. So, I added this variable to the interface.
