### PR TITLE
fix: Change scope of `selenium-support` dependency to `compile`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
             prefer "${seleniumVersion}"
         }
     }
-    implementation ('org.seleniumhq.selenium:selenium-support') {
+    api ('org.seleniumhq.selenium:selenium-support') {
         version {
             strictly "[${seleniumVersion}, 5.0)"
             prefer "${seleniumVersion}"


### PR DESCRIPTION
## Change list

Fixes #2012.

`AppiumFluentWait` (which is a part of Appium Java Client API) extends `FluentWait` from `selenium-support` dependency, thus this dependency must be in compile classpath. 
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation:

> Dependencies appearing in the `api` configurations will be transitively exposed to consumers of the library, and as such will appear on the compile classpath of consumers. Dependencies found in the `implementation` configuration will, on the other hand, not be exposed to consumers, and therefore not leak into the consumers' compile classpath.