### PR TITLE
fix: class of proxy method in AppiumClientConfig

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumClientConfig.java
+++ b/src/main/java/io/appium/java_client/AppiumClientConfig.java
@@ -147,7 +147,7 @@ public class AppiumClientConfig extends ClientConfig {
 
 
     @Override
-    public ClientConfig proxy(Proxy proxy) {
+    public AppiumClientConfig proxy(Proxy proxy) {
         ClientConfig clientConfig = super.proxy(proxy);
         return buildAppiumClientConfig(clientConfig, directConnect);
     }


### PR DESCRIPTION
## Change list

Noticed the class of return value in `proxy` in AppiumClientConfig should be AppiumClientConfig
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

`ClientConfig` should be `AppiumClientConfig` as same as other methods in the class