### PR TITLE
chore: Limit the maximum selenium version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,19 +34,19 @@ dependencies {
 
     api ('org.seleniumhq.selenium:selenium-api') {
         version {
-            strictly "[${seleniumVersion}, 5.0)"
+            strictly "[${seleniumVersion}, 4.14)"
             prefer "${seleniumVersion}"
         }
     }
     api ('org.seleniumhq.selenium:selenium-remote-driver') {
         version {
-            strictly "[${seleniumVersion}, 5.0)"
+            strictly "[${seleniumVersion}, 4.14)"
             prefer "${seleniumVersion}"
         }
     }
     api ('org.seleniumhq.selenium:selenium-support') {
         version {
-            strictly "[${seleniumVersion}, 5.0)"
+            strictly "[${seleniumVersion}, 4.14)"
             prefer "${seleniumVersion}"
         }
     }


### PR DESCRIPTION
Selenium will stop java8 support since version 4.14, so it makes sense to limit the range now