### PR TITLE
chore: Remove the obsolete commons-validator dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ dependencies {
         }
     }
     implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'commons-validator:commons-validator:1.7'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
     implementation 'commons-io:commons-io:2.14.0'
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"


### PR DESCRIPTION
## Change list

It turns out it is not used anywhere
 
## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

