### PR TITLE
refactor: Deprecate custom functional interfaces

### DIFF
--- a/src/main/java/io/appium/java_client/functions/ActionSupplier.java
+++ b/src/main/java/io/appium/java_client/functions/ActionSupplier.java
@@ -20,6 +20,12 @@ import io.appium.java_client.PerformsActions;
 
 import java.util.function.Supplier;
 
+/**
+ * Represents a supplier of actions.
+ *
+ * @deprecated Use {@link Supplier} instead
+ */
+@Deprecated
 @FunctionalInterface
 public interface ActionSupplier<T extends PerformsActions<?>> extends Supplier<T> {
 }

--- a/src/main/java/io/appium/java_client/functions/AppiumFunction.java
+++ b/src/main/java/io/appium/java_client/functions/AppiumFunction.java
@@ -28,7 +28,9 @@ import java.util.Optional;
  *
  * @param <F> The input type
  * @param <T> The return type
+ * @deprecated Use {@link java.util.function.Function} instead
  */
+@Deprecated
 @FunctionalInterface
 public interface AppiumFunction<F, T>  extends Function<F, T>, java.util.function.Function<F, T> {
 

--- a/src/main/java/io/appium/java_client/functions/ExpectedCondition.java
+++ b/src/main/java/io/appium/java_client/functions/ExpectedCondition.java
@@ -23,7 +23,9 @@ import org.openqa.selenium.WebDriver;
  * with {@link java.util.function.Function}.
  *
  * @param <T> The return type
+ * @deprecated Use {@link org.openqa.selenium.support.ui.ExpectedCondition} instead
  */
+@Deprecated
 @FunctionalInterface
 public interface ExpectedCondition<T> extends org.openqa.selenium.support.ui.ExpectedCondition<T>,
         AppiumFunction<WebDriver, T> {


### PR DESCRIPTION
## Change list

Custom functional interfaces are not needed anymore: Selenium closed all gaps in functional Java support.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)