### PR TITLE
fix: Use JDK 11 to build Jitpack snapshots

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
-  - openjdk8
+  - openjdk11
 install:
    - ./gradlew clean build publishToMavenLocal -PsigningDisabled=true


### PR DESCRIPTION
## Change list

Update Jitpack config to use JDK 11 to build snapshots.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Since the minimum supported Java version is 11.