### PR TITLE
Calling NPM without the user's shell profile.

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -147,7 +147,8 @@ public final class AppiumServiceBuilder
         List<String> cmdLine = System.getProperty("os.name").toLowerCase().contains("win")
                 // npm is a batch script, so on windows we need to use cmd.exe in order to execute it
                 ? Arrays.asList("cmd.exe", "/c", String.format("\"%s\" root -g", npm.getAbsolutePath()))
-                : Arrays.asList(npm.getAbsolutePath(), "root", "-g");
+                //ProcessBuilder doesn't execute a shell, some npm functionality requires the user's shell profile
+                : Arrays.asList("/bin/sh", "--login", "-c", npm.getAbsolutePath() + " root -g");
         ProcessBuilder pb = new ProcessBuilder(cmdLine);
         String nodeModulesRoot;
         try {


### PR DESCRIPTION
According to the NPM man page, npm gets its configuration information from 5 separate sources. When npm is launched on a *nix system without the user shell npm skips any configuration in the user's $HOME as well as ignores environment variables that might be set in the user's profile or environment.

This resolves #1889 and @ZuhayrMerchant110's issue as well as mine where the project directory prefixing the appium path.

## Change list

Invoke NPM on Mac and Linux systems with Shell (`/bin/sh`) to have access to user profile configurations.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
