### PR TITLE
fix: Cache dynamic proxy classes created by ByteBuddy

### DIFF
--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -50,7 +50,7 @@ public class Helpers {
     // the performance and to avoid extensive memory usage for our case, where
     // the amount of instrumented proxy classes we create is low in comparison to the amount
     // of proxy instances.
-    private static final ConcurrentMap<ClassSignature, Class<?>> CACHED_PROXY_CLASSES = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<ProxyClassSignature, Class<?>> CACHED_PROXY_CLASSES = new ConcurrentHashMap<>();
 
     private Helpers() {
     }
@@ -114,7 +114,7 @@ public class Helpers {
             Collection<MethodCallListener> listeners,
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
-        var signature = ClassSignature.of(cls, constructorArgTypes, extraMethodMatcher);
+        var signature = ProxyClassSignature.of(cls, constructorArgTypes, extraMethodMatcher);
         var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, k -> {
             Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
                     String.format(
@@ -216,7 +216,7 @@ public class Helpers {
     }
 
     @Value(staticConstructor = "of")
-    private static class ClassSignature {
+    private static class ProxyClassSignature {
         Class<?> cls;
         Class<?>[] constructorArgTypes;
         ElementMatcher<MethodDescription> extraMethodMatcher;

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -115,7 +115,7 @@ public class Helpers {
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
         var signature = ClassSignature.of(cls, constructorArgTypes, extraMethodMatcher);
-        var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, (k) -> {
+        var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, k -> {
             Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
                     String.format(
                             "Constructor arguments array length %d must be equal to the types array length %d",

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -45,7 +45,7 @@ public class Helpers {
             .map(Method::getName)
             .collect(Collectors.toSet());
 
-    // Each proxy classes created by ByteBuddy get automatically cached by the
+    // Each proxy class created by ByteBuddy gets automatically cached by the
     // given class loader. It is important to have this cache here in order to improve
     // the performance and to avoid extensive memory usage for our case, where
     // the amount of instrumented proxy classes we create is low in comparison to the amount
@@ -114,7 +114,7 @@ public class Helpers {
             Collection<MethodCallListener> listeners,
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
-        var signature = ClassSignature.of(cls, constructorArgs, constructorArgTypes);
+        var signature = ClassSignature.of(cls, constructorArgs, constructorArgTypes, extraMethodMatcher);
         var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, (k) -> {
             Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
                     String.format(
@@ -220,5 +220,6 @@ public class Helpers {
         Class<?> cls;
         Object[] constructorArgs;
         Class<?>[] constructorArgTypes;
+        ElementMatcher<MethodDescription> extraMethodMatcher;
     }
 }

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -17,6 +17,7 @@
 package io.appium.java_client.proxy;
 
 import com.google.common.base.Preconditions;
+import lombok.Value;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.modifier.Visibility;
@@ -31,6 +32,8 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +44,13 @@ public class Helpers {
     public static final Set<String> OBJECT_METHOD_NAMES = Stream.of(Object.class.getMethods())
             .map(Method::getName)
             .collect(Collectors.toSet());
+
+    // Each proxy classes created by ByteBuddy get automatically cached by the
+    // given class loader. It is important to have this cache here in order to improve
+    // the performance and to avoid extensive memory usage for our case, where
+    // the amount of instrumented proxy classes we create is low in comparison to the amount
+    // of proxy instances.
+    private static final ConcurrentMap<ClassSignature, Class<?>> CACHED_PROXY_CLASSES = new ConcurrentHashMap<>();
 
     private Helpers() {
     }
@@ -104,32 +114,35 @@ public class Helpers {
             Collection<MethodCallListener> listeners,
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
-        Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
-                String.format(
-                        "Constructor arguments array length %d must be equal to the types array length %d",
-                        constructorArgs.length, constructorArgTypes.length
-                )
-        );
-        Preconditions.checkArgument(!listeners.isEmpty(), "The collection of listeners must not be empty");
-        requireNonNull(cls, "Class must not be null");
-        Preconditions.checkArgument(!cls.isInterface(), "Class must not be an interface");
+        var signature = ClassSignature.of(cls, constructorArgs, constructorArgTypes);
+        var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, (k) -> {
+            Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
+                    String.format(
+                            "Constructor arguments array length %d must be equal to the types array length %d",
+                            constructorArgs.length, constructorArgTypes.length
+                    )
+            );
+            Preconditions.checkArgument(!listeners.isEmpty(), "The collection of listeners must not be empty");
+            requireNonNull(cls, "Class must not be null");
+            Preconditions.checkArgument(!cls.isInterface(), "Class must not be an interface");
 
-        ElementMatcher.Junction<MethodDescription> matcher = ElementMatchers.isPublic();
-        //noinspection resource
-        Class<?> proxy = new ByteBuddy()
-                .subclass(cls)
-                .method(extraMethodMatcher == null ? matcher : matcher.and(extraMethodMatcher))
-                .intercept(MethodDelegation.to(Interceptor.class))
-                // https://github.com/raphw/byte-buddy/blob/2caef35c172897cbdd21d163c55305a64649ce41/byte-buddy-dep/src/test/java/net/bytebuddy/ByteBuddyTutorialExamplesTest.java#L346
-                .defineField("methodCallListeners", MethodCallListener[].class, Visibility.PRIVATE)
-                .implement(HasMethodCallListeners.class).intercept(FieldAccessor.ofBeanProperty())
-                .make()
-                .load(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
-                .getLoaded()
-                .asSubclass(cls);
+            ElementMatcher.Junction<MethodDescription> matcher = ElementMatchers.isPublic();
+            //noinspection resource
+            return new ByteBuddy()
+                    .subclass(cls)
+                    .method(extraMethodMatcher == null ? matcher : matcher.and(extraMethodMatcher))
+                    .intercept(MethodDelegation.to(Interceptor.class))
+                    // https://github.com/raphw/byte-buddy/blob/2caef35c172897cbdd21d163c55305a64649ce41/byte-buddy-dep/src/test/java/net/bytebuddy/ByteBuddyTutorialExamplesTest.java#L346
+                    .defineField("methodCallListeners", MethodCallListener[].class, Visibility.PRIVATE)
+                    .implement(HasMethodCallListeners.class).intercept(FieldAccessor.ofBeanProperty())
+                    .make()
+                    .load(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                    .getLoaded()
+                    .asSubclass(cls);
+        });
 
         try {
-            T result = cls.cast(proxy.getConstructor(constructorArgTypes).newInstance(constructorArgs));
+            T result = cls.cast(proxyClass.getConstructor(constructorArgTypes).newInstance(constructorArgs));
             ((HasMethodCallListeners) result).setMethodCallListeners(listeners.toArray(MethodCallListener[]::new));
             return result;
         } catch (SecurityException | ReflectiveOperationException e) {
@@ -200,5 +213,12 @@ public class Helpers {
             MethodCallListener listener
     ) {
         return createProxy(cls, constructorArgs, constructorArgTypes, Collections.singletonList(listener));
+    }
+
+    @Value(staticConstructor = "of")
+    private static class ClassSignature {
+        Class<?> cls;
+        Object[] constructorArgs;
+        Class<?>[] constructorArgTypes;
     }
 }

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -114,7 +114,7 @@ public class Helpers {
             Collection<MethodCallListener> listeners,
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
-        var signature = ClassSignature.of(cls, constructorArgs, constructorArgTypes, extraMethodMatcher);
+        var signature = ClassSignature.of(cls, constructorArgTypes, extraMethodMatcher);
         var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, (k) -> {
             Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
                     String.format(
@@ -218,7 +218,6 @@ public class Helpers {
     @Value(staticConstructor = "of")
     private static class ClassSignature {
         Class<?> cls;
-        Object[] constructorArgs;
         Class<?>[] constructorArgTypes;
         ElementMatcher<MethodDescription> extraMethodMatcher;
     }


### PR DESCRIPTION
## Change list

I assume I've finally found the reason for the extensive memory usage described in https://github.com/appium/java-client/issues/2119

Each proxy class created by ByteBuddy gets automatically cached by the
given class loader. It is important to have a custom cache in order to improve
the performance and to avoid extensive memory usage for our case, where
the amount of instrumented proxy classes we create is low in comparison to the amount
of proxy instances.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)