### PR TITLE
fix: usage of Optional.orElseThrow after Map.put

### DIFF
--- a/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
+++ b/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
@@ -39,7 +39,7 @@ public class AndroidGeoLocation {
     /**
      * Initializes AndroidLocation instance with longitude and latitude values.
      *
-     * @param latitude  latitude value
+     * @param latitude latitude value
      * @param longitude longitude value
      */
     public AndroidGeoLocation(double latitude, double longitude) {

--- a/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
+++ b/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
@@ -19,6 +19,7 @@ package io.appium.java_client.android.geolocation;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
@@ -39,7 +40,7 @@ public class AndroidGeoLocation {
     /**
      * Initializes AndroidLocation instance with longitude and latitude values.
      *
-     * @param latitude latitude value
+     * @param latitude  latitude value
      * @param longitude longitude value
      */
     public AndroidGeoLocation(double latitude, double longitude) {
@@ -111,10 +112,10 @@ public class AndroidGeoLocation {
      */
     public Map<String, ?> build() {
         var map = new HashMap<String, Object>();
-        ofNullable(longitude).map(x -> map.put("longitude", x)).orElseThrow(() -> new IllegalArgumentException(
-                "A valid 'longitude' must be provided"));
-        ofNullable(latitude).map(x -> map.put("latitude", x)).orElseThrow(() -> new IllegalArgumentException(
-                "A valid 'latitude' must be provided"));
+        map.put("longitude", ofNullable(longitude).orElseThrow(() -> new IllegalArgumentException(
+                "A valid 'longitude' must be provided")));
+        map.put("latitude", ofNullable(latitude).orElseThrow(() -> new IllegalArgumentException(
+                "A valid 'latitude' must be provided")));
         ofNullable(altitude).ifPresent(x -> map.put("altitude", x));
         ofNullable(satellites).ifPresent(x -> map.put("satellites", x));
         ofNullable(speed).ifPresent(x -> map.put("speed", x));

--- a/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
+++ b/src/main/java/io/appium/java_client/android/geolocation/AndroidGeoLocation.java
@@ -19,7 +19,6 @@ package io.appium.java_client.android.geolocation;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
@@ -83,8 +83,9 @@ public class KeyEvent {
      */
     public Map<String, Object> build() {
         var map = new HashMap<String, Object>();
-        Integer keyCode = ofNullable(this.keyCode).orElseThrow(() -> new IllegalStateException("The key code must be set"));
-        map.put("keycode", keyCode);
+        ofNullable(this.keyCode).ifPresentOrElse(x -> map.put("keycode", x), () -> {
+            throw new IllegalStateException("The key code must be set");
+        });
         ofNullable(this.metaState).ifPresent(x -> map.put("metastate", x));
         ofNullable(this.flags).ifPresent(x -> map.put("flags", x));
         return Collections.unmodifiableMap(map);

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
@@ -19,6 +19,7 @@ package io.appium.java_client.android.nativekey;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
@@ -83,8 +84,8 @@ public class KeyEvent {
      */
     public Map<String, Object> build() {
         var map = new HashMap<String, Object>();
-        ofNullable(this.keyCode).map(x -> map.put("keycode", x)).orElseThrow(() -> new IllegalStateException(
-                "The key code must be set"));
+        Integer keyCode = ofNullable(this.keyCode).orElseThrow(() -> new IllegalStateException("The key code must be set"));
+        map.put("keycode", keyCode);
         ofNullable(this.metaState).ifPresent(x -> map.put("metastate", x));
         ofNullable(this.flags).ifPresent(x -> map.put("flags", x));
         return Collections.unmodifiableMap(map);

--- a/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
+++ b/src/main/java/io/appium/java_client/android/nativekey/KeyEvent.java
@@ -19,7 +19,6 @@ package io.appium.java_client.android.nativekey;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 


### PR DESCRIPTION
## Change list
- fix broken `KeyEvent`

## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

After the last change in `KeyEvent` class, it's impossible to use the key event, because the following code always throws an exception:
```          
  ofNullable(this.keyCode)
                    .map(x -> map.put("keycode", x))
                    .orElseThrow(() -> new IllegalStateException("The key code must be set"));
```

since `map.put()` returns null for new key.
 