### PR TITLE
ci: Use non-deprecated GH action for Gradle wrapper validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -24,4 +24,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
## Change list

https://github.com/gradle/wrapper-validation-action/releases/tag/v3.3.0:

As of v3 this action has been deprecated by gradle/actions/wrapper-validation. Any workflow that uses gradle/wrapper-validation-action@v3 will transparently delegate to gradle/actions/wrapper-validation@v3.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
