### PR TITLE
Added composeTestTag property to AndroidFindBy annotation

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AndroidFindBy.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AndroidFindBy.java
@@ -44,6 +44,14 @@ public @interface AndroidFindBy {
     String uiAutomator() default "";
 
     /**
+     * A String of Compose testTag.
+     * Refer to https://developer.android.com/develop/ui/compose/testing
+     *
+     * @return an Android Compose test tag string
+     */
+    String composeTestTag() default "";
+
+    /**
      * It an UI automation accessibility Id which is a convenient to Android.
      * About Android accessibility
      * https://developer.android.com/intl/ru/training/accessibility/accessible-app.html

--- a/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
+++ b/src/main/java/io/appium/java_client/pagefactory/bys/builder/Strategies.java
@@ -39,6 +39,16 @@ enum Strategies {
             return super.getBy(annotation);
         }
     },
+    BYTESTTAG("composeTestTag") {
+        @Override By getBy(Annotation annotation) {
+            String value = getValue(annotation, this);
+            if (annotation.annotationType().equals(AndroidFindBy.class)
+                    || annotation.annotationType().equals(AndroidBy.class)) {
+                return AppiumBy.androidUIAutomator("new UiSelector().resourceId(\"" + value + "\")");
+            }
+            return super.getBy(annotation);
+        }
+    },
     BYACCESSIBILITY("accessibility") {
         @Override By getBy(Annotation annotation) {
             return AppiumBy.accessibilityId(getValue(annotation, this));


### PR DESCRIPTION
## Change list

Added composeTestTag property to AndroidFindBy annotation.
This property makes simple writing tests for android Compose UI
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Android Compose UI by default provide test tag for testing. However, it doesn't work out the box in the Appium.

For example:

```
// Compose view
 IconButton(
            modifier = Modifier.semantics {
                testTag = "somTestTag"
            },
            onClick = {.... }
        ) {
        .....
```

```
// Appium page object

  @AndroidFindBy(uiAutomator = "new UiSelector().resourceId(\"somTestTag\")")
    protected WebElement iconButton;
```

With changes from this PR, code will be simplified:

```
@AndroidFindBy(composeTestTag = "somTestTag")
    protected WebElement iconButton;

```