### PR TITLE
fix: Deprecate AppiumProtocolHandshake class

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -28,7 +28,6 @@ import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
-import org.openqa.selenium.remote.ProtocolHandshake;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.ResponseCodec;
 import org.openqa.selenium.remote.codec.w3c.W3CHttpCommandCodec;

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -28,6 +28,7 @@ import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.Dialect;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
+import org.openqa.selenium.remote.ProtocolHandshake;
 import org.openqa.selenium.remote.Response;
 import org.openqa.selenium.remote.ResponseCodec;
 import org.openqa.selenium.remote.codec.w3c.W3CHttpCommandCodec;
@@ -172,7 +173,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
             throw new SessionNotCreatedException("Session already exists");
         }
 
-        var result = new AppiumProtocolHandshake().createSession(getClient(), command);
+        var result = new ProtocolHandshake().createSession(getClient(), command);
         Dialect dialect = result.getDialect();
         if (!(dialect.getCommandCodec() instanceof W3CHttpCommandCodec)) {
             throw new SessionNotCreatedException("Only W3C sessions are supported. "

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -173,7 +173,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
             throw new SessionNotCreatedException("Session already exists");
         }
 
-        ProtocolHandshake.Result result = new AppiumProtocolHandshake().createSession(getClient(), command);
+        var result = new AppiumProtocolHandshake().createSession(getClient(), command);
         Dialect dialect = result.getDialect();
         if (!(dialect.getCommandCodec() instanceof W3CHttpCommandCodec)) {
             throw new SessionNotCreatedException("Only W3C sessions are supported. "

--- a/src/main/java/io/appium/java_client/remote/AppiumNewSessionCommandPayload.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumNewSessionCommandPayload.java
@@ -27,6 +27,12 @@ import java.util.stream.Collectors;
 
 import static org.openqa.selenium.remote.DriverCommand.NEW_SESSION;
 
+/**
+ * This class is deprecated and will be removed.
+ *
+ * @deprecated Use CommandPayload instead.
+ */
+@Deprecated
 public class AppiumNewSessionCommandPayload extends CommandPayload {
     /**
      * Appends "appium:" prefix to all non-prefixed non-standard capabilities.

--- a/src/main/java/io/appium/java_client/remote/AppiumProtocolHandshake.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumProtocolHandshake.java
@@ -19,6 +19,8 @@ package io.appium.java_client.remote;
 import org.openqa.selenium.remote.ProtocolHandshake;
 
 /**
+ * This class is deprecated and should be removed.
+ *
  * @deprecated Use ProtocolHandshake instead.
  */
 @Deprecated

--- a/src/main/java/io/appium/java_client/remote/AppiumProtocolHandshake.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumProtocolHandshake.java
@@ -16,108 +16,11 @@
 
 package io.appium.java_client.remote;
 
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.ImmutableCapabilities;
-import org.openqa.selenium.SessionNotCreatedException;
-import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.internal.Either;
-import org.openqa.selenium.json.Json;
-import org.openqa.selenium.json.JsonOutput;
-import org.openqa.selenium.remote.Command;
-import org.openqa.selenium.remote.NewSessionPayload;
 import org.openqa.selenium.remote.ProtocolHandshake;
-import org.openqa.selenium.remote.http.Contents;
-import org.openqa.selenium.remote.http.HttpHandler;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
-
-@SuppressWarnings("UnstableApiUsage")
+/**
+ * @deprecated Use ProtocolHandshake instead.
+ */
+@Deprecated
 public class AppiumProtocolHandshake extends ProtocolHandshake {
-    private static void writeJsonPayload(NewSessionPayload srcPayload, Appendable destination) {
-        try (JsonOutput json = new Json().newOutput(destination)) {
-            json.beginObject();
-
-            json.name("capabilities");
-            json.beginObject();
-
-            json.name("firstMatch");
-            json.beginArray();
-            json.beginObject();
-            json.endObject();
-            json.endArray();
-
-            json.name("alwaysMatch");
-            try {
-                Method getW3CMethod = NewSessionPayload.class.getDeclaredMethod("getW3C");
-                getW3CMethod.setAccessible(true);
-                //noinspection unchecked,resource
-                ((Stream<Map<String, Object>>) getW3CMethod.invoke(srcPayload))
-                        .findFirst()
-                        .map(json::write)
-                        .orElseGet(() -> {
-                            json.beginObject();
-                            json.endObject();
-                            return null;
-                        });
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                throw new WebDriverException(e);
-            }
-
-            json.endObject();  // Close "capabilities" object
-
-            try {
-                Method writeMetaDataMethod = NewSessionPayload.class.getDeclaredMethod(
-                        "writeMetaData", JsonOutput.class);
-                writeMetaDataMethod.setAccessible(true);
-                writeMetaDataMethod.invoke(srcPayload, json);
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                throw new WebDriverException(e);
-            }
-
-            json.endObject();
-        }
-    }
-
-    @Override
-    public Result createSession(HttpHandler client, Command command) throws IOException {
-        //noinspection unchecked
-        Capabilities desired = ((Set<Map<String, Object>>) command.getParameters().get("capabilities"))
-                .stream()
-                .findAny()
-                .map(ImmutableCapabilities::new)
-                .orElseGet(ImmutableCapabilities::new);
-        try (NewSessionPayload payload = NewSessionPayload.create(desired)) {
-            Either<SessionNotCreatedException, Result> result = createSession(client, payload);
-            if (result.isRight()) {
-                return result.right();
-            }
-            throw result.left();
-        }
-    }
-
-    @Override
-    public Either<SessionNotCreatedException, Result> createSession(HttpHandler client, NewSessionPayload payload) {
-
-        StringWriter stringWriter = new StringWriter();
-        writeJsonPayload(payload, stringWriter);
-
-        try {
-            Method createSessionMethod = ProtocolHandshake.class.getDeclaredMethod(
-                    "createSession", HttpHandler.class, Contents.Supplier.class
-            );
-            createSessionMethod.setAccessible(true);
-            //noinspection unchecked
-            return (Either<SessionNotCreatedException, Result>) createSessionMethod.invoke(
-                    this, client, Contents.utf8String(stringWriter.toString())
-            );
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new WebDriverException(e);
-        }
-    }
 }


### PR DESCRIPTION
## Change list

The original ProtocolHandshake class only supports W3C protocol now. There is no need to hack it anymore
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
