### PR TITLE
fix: Fix compatibility with latest Selenium snapshots

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.CapabilityType;
+import org.openqa.selenium.remote.CommandInfo;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.ErrorHandler;
 import org.openqa.selenium.remote.ExecuteMethod;
@@ -242,22 +243,23 @@ public class AppiumDriver extends RemoteWebDriver implements
      * @param methodName The name of custom appium command.
      */
     public void addCommand(HttpMethod httpMethod, String url, String methodName) {
+        CommandInfo commandInfo;
         switch (httpMethod) {
             case GET:
-                MobileCommand.commandRepository.put(methodName, MobileCommand.getC(url));
+                commandInfo = MobileCommand.getC(url);
                 break;
             case POST:
-                MobileCommand.commandRepository.put(methodName, MobileCommand.postC(url));
+                commandInfo = MobileCommand.postC(url);
                 break;
             case DELETE:
-                MobileCommand.commandRepository.put(methodName, MobileCommand.deleteC(url));
+                commandInfo = MobileCommand.deleteC(url);
                 break;
             default:
                 throw new WebDriverException(String.format("Unsupported HTTP Method: %s. Only %s methods are supported",
                         httpMethod,
                         Arrays.toString(HttpMethod.values())));
         }
-        ((AppiumCommandExecutor) getCommandExecutor()).refreshAdditionalCommands();
+        ((AppiumCommandExecutor) getCommandExecutor()).defineCommand(methodName, commandInfo);
     }
 
     @Override

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -133,7 +133,7 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         ReflectionHelpers.setPrivateFieldValue(cls, this, fieldName, newValue);
     }
 
-    protected Map<String, CommandInfo> getAdditionalCommands() {
+    public Map<String, CommandInfo> getAdditionalCommands() {
         //noinspection unchecked
         return getPrivateFieldValue(HttpCommandExecutor.class, "additionalCommands", Map.class);
     }

--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -192,7 +192,11 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
     }
 
     public void refreshAdditionalCommands() {
-        getAdditionalCommands().forEach(this::defineCommand);
+        getAdditionalCommands().forEach(super::defineCommand);
+    }
+
+    public void defineCommand(String commandName, CommandInfo info) {
+        super.defineCommand(commandName, info);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Change list

Fix compatibility with latest Selenium snapshots.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Recently Selenium team has introduced an update for Appium client adding ability to get `additionalCommands` in `HttpCommandExecutor`: https://github.com/SeleniumHQ/selenium/commit/59aa1a0b5128fcd5e12fe918fd109d443e9f5586.
But since new method is `public` and the same Appium method in `AppiumCommandExecutor.java` is `protected`, this collision introduces an error at the build stage:
```
/Users/runner/work/java-client/java-client/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java:136: error: getAdditionalCommands() in AppiumCommandExecutor cannot override getAdditionalCommands() in HttpCommandExecutor

    protected Map<String, CommandInfo> getAdditionalCommands() {
> Task :compileJava FAILED
                                       ^
```