### PR TITLE
fix: Use WeakHashMap for caching proxy classes 

### DIFF
--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -17,6 +17,8 @@
 package io.appium.java_client.proxy;
 
 import com.google.common.base.Preconditions;
+import java.util.Map;
+import java.util.WeakHashMap;
 import lombok.Value;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.method.MethodDescription;
@@ -32,14 +34,15 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
+/**
+ * The type Helpers.
+ */
 public class Helpers {
     public static final Set<String> OBJECT_METHOD_NAMES = Stream.of(Object.class.getMethods())
             .map(Method::getName)
@@ -51,6 +54,16 @@ public class Helpers {
     // the amount of instrumented proxy classes we create is low in comparison to the amount
     // of proxy instances.
     private static final Map<ProxyClassSignature, Class<?>> CACHED_PROXY_CLASSES = Collections.synchronizedMap(new WeakHashMap<>());
+
+    /**
+     * Gets CACHED_PROXY_CLASSES size.
+     * Used for cache clear up tests.
+     *
+     * @return the cached proxy classes size
+     */
+    public static int getCachedProxyClassesSize() {
+        return CACHED_PROXY_CLASSES.size();
+    }
 
     private Helpers() {
     }
@@ -115,6 +128,7 @@ public class Helpers {
             @Nullable ElementMatcher<MethodDescription> extraMethodMatcher
     ) {
         var signature = ProxyClassSignature.of(cls, constructorArgTypes, extraMethodMatcher);
+        System.out.println("CACHED_PROXY_CLASSES size = " + CACHED_PROXY_CLASSES.size());
         var proxyClass = CACHED_PROXY_CLASSES.computeIfAbsent(signature, k -> {
             Preconditions.checkArgument(constructorArgs.length == constructorArgTypes.length,
                     String.format(

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -41,9 +41,6 @@ import java.util.stream.Stream;
 import static java.util.Objects.requireNonNull;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 
-/**
- * The type Helpers.
- */
 public class Helpers {
     public static final Set<String> OBJECT_METHOD_NAMES = Stream.of(Object.class.getMethods())
             .map(Method::getName)

--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -50,7 +50,7 @@ public class Helpers {
     // the performance and to avoid extensive memory usage for our case, where
     // the amount of instrumented proxy classes we create is low in comparison to the amount
     // of proxy instances.
-    private static final ConcurrentMap<ProxyClassSignature, Class<?>> CACHED_PROXY_CLASSES = new ConcurrentHashMap<>();
+    private static final Map<ProxyClassSignature, Class<?>> CACHED_PROXY_CLASSES = Collections.synchronizedMap(new WeakHashMap<>());
 
     private Helpers() {
     }

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/combined/CombinedWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/combined/CombinedWidgetTest.java
@@ -7,7 +7,6 @@ import io.appium.java_client.pagefactory_tests.widget.tests.AbstractStubWebDrive
 import io.appium.java_client.pagefactory_tests.widget.tests.DefaultStubWidget;
 import io.appium.java_client.pagefactory_tests.widget.tests.android.DefaultAndroidWidget;
 import io.appium.java_client.proxy.Helpers;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/combined/CombinedWidgetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/widget/tests/combined/CombinedWidgetTest.java
@@ -35,24 +35,24 @@ public class CombinedWidgetTest {
      */
     public static Stream<Arguments> data() {
         return Stream.of(
-            Arguments.of(new AppWithCombinedWidgets(),
-                new AbstractStubWebDriver.StubAndroidDriver(), DefaultAndroidWidget.class),
-            Arguments.of(new AppWithCombinedWidgets(),
-                new AbstractStubWebDriver.StubIOSXCUITDriver(), DefaultIosXCUITWidget.class),
-            Arguments.of(new AppWithCombinedWidgets(),
-                new AbstractStubWebDriver.StubBrowserDriver(), DefaultFindByWidget.class),
-            Arguments.of(new AppWithCombinedWidgets(),
-                new AbstractStubWebDriver.StubAndroidBrowserOrWebViewDriver(), DefaultFindByWidget.class),
-            Arguments.of(new AppWithPartiallyCombinedWidgets(),
-                new AbstractStubWebDriver.StubAndroidDriver(), DefaultAndroidWidget.class),
-            Arguments.of(new AppWithPartiallyCombinedWidgets(),
-                new AbstractStubWebDriver.StubIOSXCUITDriver(), DefaultStubWidget.class),
-            Arguments.of(new AppWithPartiallyCombinedWidgets(),
-                new AbstractStubWebDriver.StubWindowsDriver(), DefaultStubWidget.class),
-            Arguments.of(new AppWithPartiallyCombinedWidgets(),
-                new AbstractStubWebDriver.StubBrowserDriver(), DefaultFindByWidget.class),
-            Arguments.of(new AppWithPartiallyCombinedWidgets(),
-                new AbstractStubWebDriver.StubAndroidBrowserOrWebViewDriver(), DefaultFindByWidget.class)
+                Arguments.of(new AppWithCombinedWidgets(),
+                    new AbstractStubWebDriver.StubAndroidDriver(), DefaultAndroidWidget.class),
+                Arguments.of(new AppWithCombinedWidgets(),
+                    new AbstractStubWebDriver.StubIOSXCUITDriver(), DefaultIosXCUITWidget.class),
+                Arguments.of(new AppWithCombinedWidgets(),
+                    new AbstractStubWebDriver.StubBrowserDriver(), DefaultFindByWidget.class),
+                Arguments.of(new AppWithCombinedWidgets(),
+                    new AbstractStubWebDriver.StubAndroidBrowserOrWebViewDriver(), DefaultFindByWidget.class),
+                Arguments.of(new AppWithPartiallyCombinedWidgets(),
+                    new AbstractStubWebDriver.StubAndroidDriver(), DefaultAndroidWidget.class),
+                Arguments.of(new AppWithPartiallyCombinedWidgets(),
+                    new AbstractStubWebDriver.StubIOSXCUITDriver(), DefaultStubWidget.class),
+                Arguments.of(new AppWithPartiallyCombinedWidgets(),
+                    new AbstractStubWebDriver.StubWindowsDriver(), DefaultStubWidget.class),
+                Arguments.of(new AppWithPartiallyCombinedWidgets(),
+                    new AbstractStubWebDriver.StubBrowserDriver(), DefaultFindByWidget.class),
+                Arguments.of(new AppWithPartiallyCombinedWidgets(),
+                    new AbstractStubWebDriver.StubAndroidBrowserOrWebViewDriver(), DefaultFindByWidget.class)
         );
     }
 


### PR DESCRIPTION
## Change list

Fix for https://github.com/appium/java-client/issues/2247
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Expanded test asserts in CombinedWidgetTest, happy to move if better place.