### PR TITLE
fix: update README by replacing the deprecated new URL(String) with URI(String).toURL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ UiAutomator2Options options = new UiAutomator2Options()
     .setApp("/home/myapp.apk");
 AndroidDriver driver = new AndroidDriver(
     // The default URL in Appium 1 is http://127.0.0.1:4723/wd/hub
-    new URL("http://127.0.0.1:4723"), options
+    new URI("http://127.0.0.1:4723").toURL(), options
 );
 try {
     WebElement el = driver.findElement(AppiumBy.xpath("//Button"));
@@ -193,7 +193,7 @@ XCUITestOptions options = new XCUITestOptions()
     .setApp("/home/myapp.ipa");
 IOSDriver driver = new IOSDriver(
     // The default URL in Appium 1 is http://127.0.0.1:4723/wd/hub
-    new URL("http://127.0.0.1:4723"), options
+    new URI("http://127.0.0.1:4723").toURL(), options
 );
 try {
     WebElement el = driver.findElement(AppiumBy.accessibilityId("myId"));
@@ -214,7 +214,7 @@ BaseOptions options = new BaseOptions()
     .amend("mycapability2", "capvalue2");
 AppiumDriver driver = new AppiumDriver(
     // The default URL in Appium 1 is http://127.0.0.1:4723/wd/hub
-    new URL("http://127.0.0.1:4723"), options
+    new URI("http://127.0.0.1:4723").toURL(), options
 );
 try {
     WebElement el = driver.findElement(AppiumBy.className("myClass"));


### PR DESCRIPTION
## Change list
This PR replaces the deprecated `new URL(String)` constructor with `URI(String).toURL()` in the AndroidDriver initialization code. The `new URL(String)` constructor has been deprecated in Java 20, and this change ensures compatibility with newer Java versions while improving security and consistency in URL handling. 
https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html

## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details
Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted java code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
