### PR TITLE
feat: Allow extension capability keys to contain special characters

### DIFF
--- a/src/main/java/io/appium/java_client/remote/options/W3CCapabilityKeys.java
+++ b/src/main/java/io/appium/java_client/remote/options/W3CCapabilityKeys.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 public class W3CCapabilityKeys implements Predicate<String> {
     public static final W3CCapabilityKeys INSTANCE = new W3CCapabilityKeys();
     private static final Predicate<String> ACCEPTED_W3C_PATTERNS = Stream.of(
-                    "^[\\w-]+:.*$",
+                    "^[^:]+:.*$",
                     "^acceptInsecureCerts$",
                     "^browserName$",
                     "^browserVersion$",

--- a/src/test/java/io/appium/java_client/remote/options/BaseOptionsTest.java
+++ b/src/test/java/io/appium/java_client/remote/options/BaseOptionsTest.java
@@ -1,0 +1,26 @@
+package io.appium.java_client.remote.options;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class BaseOptionsTest {
+
+
+  @ParameterizedTest
+  @CsvSource({
+      "test, appium:test",
+      "appium:test, appium:test",
+      "browserName, browserName",
+      "digital.ai:accessKey, digital.ai:accessKey",
+      "digital-ai:accessKey, digital-ai:accessKey",
+      "<VENDOR-KEY>:<CAP-NAME>:<SUB-CAP-NAME>, <VENDOR-KEY>:<CAP-NAME>:<SUB-CAP-NAME>",
+      "digital-ai:my_custom-cap:xyz, digital-ai:my_custom-cap:xyz",
+      "digital-ai:my_custom-cap?xyz, digital-ai:my_custom-cap?xyz",
+  })
+  void verifyW3CMapping(String capName, String expected) {
+    var w3cName = BaseOptions.toW3cName(capName);
+    assertEquals(expected, w3cName);
+  }
+}


### PR DESCRIPTION
## Change list

Extend the `ACCEPTED_W3C_PATTERNS` from `^[\\w-]+:.*$` to `^[^:]+:.*$`
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

I'm running an Appium-based test suite in a device cloud. This device cloud has some vendor specific capabilities and I have the option to provide these either **with** the prefix `digital.ai` or **without** any prefix.

I used to just use the second option and the following capability statement was no big deal:

```json
{
  "accessKey" : "eyJ...k",
  "appiumVersion" : "2.11.3",
  "app" : "cloud:my-App-Name",
  ...
}
```
But I have the problem that the second option does not work anymore since a few weeks. The actual capabilities look like this

```json
{
  "appium:accessKey" : "eyJ...k",
  "appium:appiumVersion" : "2.11.3",
  "app" : "cloud:my-App-Name",
  ...
}
```
And when I switch to the first option by using the vendor-specific key `digital.ai` I get this:

```json
{
  "appium:digital.ai:accessKey" : "eyJ...k",
  "appium:digital.ai:appiumVersion" : "2.11.3",
  "app" : "cloud:my-App-Name",
  ...
}
```

leading to the point, that the device cloud cannot find the accessKey for auth.

A `.` DOT is not allowed, but a `-` DASH is. I could not find any restrictions in the [spec](https://www.w3.org/TR/webdriver2/#dfn-extension-capability) for this behavior.


