### PR TITLE
fix: Add explicit dependency on JSR 305 annotations library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     }
     implementation 'com.google.code.gson:gson:2.12.1'
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 dependencyCheck {


### PR DESCRIPTION
## Change list

Fix the build: fix: add explicit dependency on JSR 305 annotations library.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

The annotations `javax.annotation.Nonnull` and `javax.annotation.Nullable` used in the codebase came from library `com.google.code.findbugs:jsr305`. This library was a dependency of `com.google.guava:guava`, which in its turn is a depedendency of Selenium. But `jsr305` dependency was removed in Guava `33.4.3` (https://github.com/google/guava/issues/2960), and Guava was bumped from `33.4.0` to `33.4.5` in Selenium (https://github.com/SeleniumHQ/selenium/commit/ced5b224afaf19bce239fd17d11f026570ff14b3). As the result `com.google.code.findbugs:jsr305` is not present in classpath anymore and lead to build failures: https://github.com/appium/java-client/actions/runs/14034948997/job/39290753396?pr=2279
```
/Users/runner/work/java-client/java-client/src/main/java/io/appium/java_client/MobileCommand.java:27: error: package javax.annotation does not exist

import javax.annotation.Nullable;
> Task :compileJava
                       ^
/Users/runner/work/java-client/java-client/src/main/java/io/appium/java_client/ExecutesDriverScript.java:23: error: package javax.annotation does not exist
import javax.annotation.Nullable;
                       ^
/Users/runner/work/java-client/java-client/src/main/java/io/appium/java_client/AppiumClientConfig.java:26: error: package javax.annotation does not exist
import javax.annotation.Nullable;
...
````

Short-term solution is to add JSR 305 dependency explicitly.
Long-term solution can be migration to JSpecify.