### PR TITLE
fix: Proxy commands issues via RemoteWebElement

### DIFF
--- a/src/main/java/io/appium/java_client/proxy/Helpers.java
+++ b/src/main/java/io/appium/java_client/proxy/Helpers.java
@@ -27,13 +27,11 @@ import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -221,5 +219,29 @@ public class Helpers {
         Class<?> cls;
         Class<?>[] constructorArgTypes;
         ElementMatcher<MethodDescription> extraMethodMatcher;
+    }
+
+    public static RemoteWebElement wrapElement(
+            RemoteWebElement original,
+            HasMethodCallListeners parent,
+            MethodCallListener[] listeners
+    ) {
+        RemoteWebElement proxy = createProxy(
+                RemoteWebElement.class,
+                new Object[]{},
+                new Class[]{},
+                List.of(listeners),
+                ElementMatchers.not(
+                        namedOneOf(
+                        OBJECT_METHOD_NAMES.toArray(new String[0]))
+                                .or(ElementMatchers.named("setId").or(ElementMatchers.named("setParent")))
+                )
+        );
+
+        proxy.setId(original.getId());
+
+        proxy.setParent((RemoteWebDriver) parent);
+
+        return proxy;
     }
 }

--- a/src/main/java/io/appium/java_client/proxy/Interceptor.java
+++ b/src/main/java/io/appium/java_client/proxy/Interceptor.java
@@ -21,10 +21,13 @@ import net.bytebuddy.implementation.bind.annotation.Origin;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.implementation.bind.annotation.SuperCall;
 import net.bytebuddy.implementation.bind.annotation.This;
+import org.openqa.selenium.remote.RemoteWebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import static io.appium.java_client.proxy.MethodCallListener.UNSET;
@@ -108,6 +111,25 @@ public class Interceptor {
                     }
                 }
                 throw e;
+            }
+        }
+
+        if (result instanceof RemoteWebElement) {
+            result = Helpers.wrapElement((RemoteWebElement) result, (HasMethodCallListeners) self, listeners);
+        } else if (result instanceof List) {
+            List<?> originalList = (List<?>) result;
+            if (!originalList.isEmpty() && originalList.get(0) instanceof RemoteWebElement) {
+                List<Object> wrappedList = new ArrayList<>(originalList.size());
+                for (Object item : originalList) {
+                    if (item instanceof RemoteWebElement) {
+                        wrappedList.add(Helpers.wrapElement(
+                                (RemoteWebElement) item,
+                                (HasMethodCallListeners) self, listeners));
+                    } else {
+                        wrappedList.add(item);
+                    }
+                }
+                result = wrappedList;
             }
         }
 


### PR DESCRIPTION
Fixes #2239

## Change list
- Add mechanism to proxy RemoteWebElement methods.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

Commands called on WebElements instances are not proxied when using `createProxy`. Since all webdriver calls route through RemoteWebDriver's `execute` method, which is marked `protected`, that call is not intercepted. Commands like `findElement` return a WebElement instance, and when commands like `click` are called on it, there is no way to intercept them. 

The changes in this PR fix this by creating a proxy for the RemoteWebElement and assigning `id` and `parent` for calls whose result is an instance of RemoteWebElement, thus intercepting these calls without requiring code changes from the user's end.
