### PR TITLE
ci: Automated Release to Maven Central Repository using JReleaser

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish package to the Maven Central Repository
 on:
-  push:
-    branches:
-      - release/mavenCentral
+  release:
+    types: [created]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,8 +18,6 @@ jobs:
 
       - name: Publish package
         env:
-          PGP_SECRET: ${{ secrets.JRELEASER_SIGNING_KEY }}
-          PGP_PASSPHRASE: ${{ secrets.JRELEASER_SIGNING_PASSWORD }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_SIGNING_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_SIGNING_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Publish package to the Maven Central Repository
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - release/mavenCentral
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,12 @@ jobs:
 
       - name: Publish package
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           PGP_SECRET: ${{ secrets.SIGNING_KEY }}
           PGP_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_PASSWORD }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         run: |
           ./gradlew publish
           ./gradlew jreleaserDeploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Publish package
         env:
-          PGP_SECRET: ${{ secrets.SIGNING_KEY }}
-          PGP_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
-          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          PGP_SECRET: ${{ secrets.JRELEASER_SIGNING_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.JRELEASER_SIGNING_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_SIGNING_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_SIGNING_PASSWORD }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.SIGNING_KEY }}
           PGP_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           PGP_SECRET: ${{ secrets.SIGNING_KEY }}
           PGP_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
           ./gradlew publish
           ./gradlew jreleaserDeploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,6 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           PGP_SECRET: ${{ secrets.SIGNING_KEY }}
           PGP_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publish
+        run: |
+          ./gradlew publish
+          ./gradlew jreleaserDeploy

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ classes/
 /.settings
 .classpath
 .project
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -169,14 +169,6 @@ publishing {
     }
 }
 
-signing {
-    required { !'true'.equalsIgnoreCase(project.findProperty('signingDisabled')) }
-    def signingKey = System.getenv("PGP_SECRET")
-    def signingPassword = System.getenv("PGP_PASSPHRASE")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
-}
-
 jreleaser {
     signing {
         active = 'ALWAYS'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ plugins {
     id 'org.jreleaser' version '1.19.0'
 }
 
+group = 'io.appium'
+version = appiumClientVersion
+
 repositories {
     mavenCentral()
 
@@ -175,6 +178,9 @@ signing {
 }
 
 jreleaser {
+    project {
+        version = project.version
+    }
     signing {
         active = 'ALWAYS'
         armored = true

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,12 @@ plugins {
     id 'org.jreleaser' version '1.19.0'
 }
 
+ext {
+    seleniumVersion = project.property('selenium.version')
+    appiumClientVersion = project.property('appiumClient.version')
+    slf4jVersion = '2.0.17'
+}
+
 group = 'io.appium'
 version = appiumClientVersion
 
@@ -33,12 +39,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_11
     withJavadocJar()
     withSourcesJar()
-}
-
-ext {
-    seleniumVersion = project.property('selenium.version')
-    appiumClientVersion = project.property('appiumClient.version')
-    slf4jVersion = '2.0.17'
 }
 
 dependencies {
@@ -178,9 +178,6 @@ signing {
 }
 
 jreleaser {
-    project {
-        version = project.version
-    }
     signing {
         active = 'ALWAYS'
         armored = true

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'signing'
     id 'org.owasp.dependencycheck' version '12.1.3'
     id 'com.gradleup.shadow' version '8.3.7'
+    id 'org.jreleaser' version '1.19.0'
 }
 
 repositories {
@@ -16,7 +17,7 @@ repositories {
 
     if (project.hasProperty("isCI")) {
         maven {
-            url uri('https://oss.sonatype.org/content/repositories/snapshots/')
+            url uri('https://central.sonatype.com/api/v1/publisher')
             mavenContent {
                 snapshotsOnly()
             }
@@ -160,13 +161,7 @@ publishing {
     }
     repositories {
         maven {
-            credentials {
-                username = System.getenv("MAVEN_USERNAME")
-                password = System.getenv("MAVEN_PASSWORD")
-            }
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/'"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            url = layout.buildDirectory.dir('staging-deploy')
         }
     }
 }
@@ -177,6 +172,24 @@ signing {
     def signingPassword = System.getenv("PGP_PASSPHRASE")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications.mavenJava
+}
+
+jreleaser {
+    signing {
+        active = 'ALWAYS'
+        armored = true
+    }
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    active = 'ALWAYS'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepository('build/staging-deploy')
+                }
+            }
+        }
+    }
 }
 
 wrapper {

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,21 +9,17 @@ Its target auditory is project maintainers.
 1. Bump the `appiumClient.version` number in [gradle.properties](../gradle.properties).
 1. Create a pull request to approve the changelog and version bump.
 1. Merge the pull request after it is approved.
-1. Create and push a new repository tag. The tag name should look like 
-  `v<major_number>.<minor_number>.<patch_number>`.
-1. Create a new [Release](https://github.com/appium/java-client/releases/new) in GitHub. 
-  Paste the above changelist into the release notes. Make sure the name of the new release
-  matches to the name of the above tag.
-1. Open [Sonatype](https://oss.sonatype.org/#welcome) in your browser.
-1. Login to Nexus using 1Password credentials. Ask Appium maintainers
-  if you need access to the team's 1Password vault.
-1. Navigate to `Staging Repositories`. 
-1. Select the corresponding release and click `Close`. Note that it may take
-  some minutes until Sonatype picks up the GitHub release.
-1. Wait until checks are completed.
-1. Click `Release`.
-1. After the new release is published, it becomes available in 
-  [Maven Central](https://repo1.maven.org/maven2/io/appium/java-client/)
-  within 30 minutes. Once artifacts are in Maven Central, it normally 
-  takes 1-2 hours before they appear in 
-  [search results](https://central.sonatype.com/artifact/io.appium/java-client).
+1. Create and push a new repository tag. The tag name should look like
+   `v<major_number>.<minor_number>.<patch_number>`.
+1. Create a new [Release](https://github.com/appium/java-client/releases/new) in GitHub.
+   Paste the above changelist into the release notes. Make sure the name of the new release
+   matches to the name of the above tag.
+1. Open [Maven Central Repository](https://central.sonatype.com/) in your browser.
+1. Log in to the `Maven Central Repository` using the credentials stored in 1Password. If you need access to the team's 1Password vault, contact the Appium maintainers.
+1. Navigate to the `Publish` section.
+1. Under `Deployments`, you will see the latest deployment being published. Note: Sometimes the status may remain in the `publishing` state for an extended period, but it will eventually complete.
+1. After the new release is published, it becomes available in
+   [Maven Central](https://repo1.maven.org/maven2/io/appium/java-client/)
+   within 30 minutes. Once artifacts are in Maven Central, it normally
+   takes 1-2 hours before they appear in
+   [search results](https://central.sonatype.com/artifact/io.appium/java-client).


### PR DESCRIPTION
This pull request updates the publishing process for the project to use JReleaser and revises the corresponding documentation. The most important changes include modifying the GitHub Actions workflow to integrate JReleaser and updating the release guide to reflect the new publishing steps.

### Workflow updates for JReleaser integration:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L21-R28): Replaced Maven-specific environment variables with JReleaser-specific variables and added a new `jreleaserDeploy` step to the workflow.

### Documentation updates:
* [`docs/release.md`](diffhunk://#diff-87479ac9ea16cec5ceafce00b3b049d7d5920cb663afae42901f20e7c4e6705dL17-R20): Updated the release guide to replace manual Sonatype Nexus steps with instructions for using the Maven Central Repository via JReleaser.