### PR TITLE
docs: updated maven central release badge to shields.io and central sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # java-client
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.appium/java-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.appium/java-client)
+[![Maven Central Version](https://img.shields.io/maven-central/v/io.appium/java-client)](https://central.sonatype.com/artifact/io.appium/java-client)
 [![Javadocs](https://www.javadoc.io/badge/io.appium/java-client.svg)](https://www.javadoc.io/doc/io.appium/java-client)
 [![Appium Java Client CI](https://github.com/appium/java-client/actions/workflows/gradle.yml/badge.svg)](https://github.com/appium/java-client/actions/workflows/gradle.yml)
 


### PR DESCRIPTION
## Change list

Currently the maven release badge uses [jirutka/maven-badges](https://github.com/jirutka/maven-badges) which has been archived and moved to [softwaremill/maven-badges](https://github.com/softwaremill/maven-badges). 

I tried using the badge from new implementation  but it does not return the latest version available i.e. 9.5.0

[![Maven Central](https://maven-badges.sml.io/sonatype-central/io.appium/java-client/badge.svg)](https://maven-badges.sml.io/sonatype-central/io.appium/java-client)

```
[![Maven Central](https://maven-badges.sml.io/sonatype-central/io.appium/java-client/badge.svg)](https://maven-badges.sml.io/sonatype-central/io.appium/java-client)
```

I found an alternative solution from [shields.io](https://shields.io/badges/maven-central-version) which seems to be working fine and it makes use of this [metadata URL](https://github.com/badges/shields/tree/dac16f7f6179b0393aa2b466c761ccd62eb64aa2/services/maven-central) `https://repo1.maven.org/maven2/${group}/${artifact}/maven-metadata.xml` which is likely to return always the latest available version on maven central. 

The original badge from shields.io does not have a URL to maven central repository, so additionally I have also updated the badge URL to point to the https://central.sonatype.com/ as this seems to be the updated source of maven releases https://central.sonatype.org/faq/what-happened-to-search-maven-org/

[![Maven Central Version](https://img.shields.io/maven-central/v/io.appium/java-client)](https://central.sonatype.com/artifact/io.appium/java-client)


## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Details

With this change, I hope users will always be displayed the latest version of java-client available on correct maven central repository
