### PR TITLE
fix: Possible NPE in initBiDi()

### DIFF
--- a/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
+++ b/src/main/java/io/appium/java_client/remote/AppiumCommandExecutor.java
@@ -58,8 +58,6 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
 
     private final Optional<DriverService> serviceOptional;
     @Getter
-    private final Factory httpClientFactory;
-    @Getter
     private final AppiumClientConfig appiumClientConfig;
 
     /**
@@ -81,7 +79,6 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         );
         serviceOptional = ofNullable(service);
 
-        this.httpClientFactory = ofNullable(httpClientFactory).orElseGet(HttpCommandExecutor::getDefaultClientFactory);
         this.appiumClientConfig = appiumClientConfig;
     }
 
@@ -141,6 +138,10 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
         return getPrivateFieldValue(HttpCommandExecutor.class, "additionalCommands", Map.class);
     }
 
+    public Factory getHttpClientFactory() {
+        return getPrivateFieldValue(HttpCommandExecutor.class, "httpClientFactory", Factory.class);
+    }
+
     @Nullable
     protected CommandCodec<HttpRequest> getCommandCodec() {
         return this.commandCodec;
@@ -165,8 +166,8 @@ public class AppiumCommandExecutor extends HttpCommandExecutor {
      * @param serverUrl A url to override.
      */
     protected void overrideServerUrl(URL serverUrl) {
-        setPrivateFieldValue(HttpCommandExecutor.class, "client",
-                this.httpClientFactory.createClient(this.appiumClientConfig.baseUrl(serverUrl)));
+        HttpClient newClient = getHttpClientFactory().createClient(appiumClientConfig.baseUrl(serverUrl));
+        setPrivateFieldValue(HttpCommandExecutor.class, "client", newClient);
     }
 
     private Response createSession(Command command) throws IOException {

--- a/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
+++ b/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class AppiumCommandExecutorTest {
-    private static final String APPIUM_URL = "https://appium.exaple.com";
+    private static final String APPIUM_URL = "https://appium.example.com";
 
     private AppiumCommandExecutor createExecutor() {
         URL baseUrl;

--- a/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
+++ b/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
@@ -1,0 +1,40 @@
+package io.appium.java_client.remote;
+
+import io.appium.java_client.AppiumClientConfig;
+import io.appium.java_client.MobileCommand;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class AppiumCommandExecutorTest {
+    private static final String APPIUM_URL = "https://appium.exaple.com";
+
+    private AppiumCommandExecutor createExecutor() {
+        URL baseUrl;
+        try {
+            baseUrl = new URL(APPIUM_URL);
+        } catch (MalformedURLException e) {
+            throw new AssertionError(e);
+        }
+        AppiumClientConfig clientConfig = AppiumClientConfig.defaultConfig().baseUrl(baseUrl);
+        return new AppiumCommandExecutor(MobileCommand.commandRepository, clientConfig);
+    }
+
+    @Test
+    void getAdditionalCommands() {
+        assertNotNull(createExecutor().getAdditionalCommands());
+    }
+
+    @Test
+    void getHttpClientFactory() {
+        assertNotNull(createExecutor().getHttpClientFactory());
+    }
+
+    @Test
+    void overrideServerUrl() {
+        assertDoesNotThrow(() -> createExecutor().overrideServerUrl(new URL("https://direct.example.com")));
+    }
+}

--- a/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
+++ b/src/test/java/io/appium/java_client/remote/AppiumCommandExecutorTest.java
@@ -2,9 +2,10 @@ package io.appium.java_client.remote;
 
 import io.appium.java_client.AppiumClientConfig;
 import io.appium.java_client.MobileCommand;
+import org.junit.jupiter.api.Test;
+
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
## Change list

Make sure `httpClientFactory` in `AppiumCommandExecutor` is not null.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

version 9.5.0, code is like below
```java
DesiredCapabilities capabilities = new DesiredCapabilities();
capabilities.setCapability("webSocketUrl", true);
driver = new AndroidDriver(AppiumClientConfig.defaultConfig().baseUri(URI.create(url)), capabilities);
```
throws
```
Exception in thread "main" java.lang.NullPointerException: 
Cannot invoke "org.openqa.selenium.remote.http.HttpClient$Factory.createClient(org.openqa.selenium.remote.http.ClientConfig)"
because the return value of "io.appium.java_client.remote.AppiumCommandExecutor.getHttpClientFactory()" is null
	at io.appium.java_client.AppiumDriver.initBiDi(AppiumDriver.java:423)
	at io.appium.java_client.AppiumDriver.startSession(AppiumDriver.java:344)
	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:173)
	at io.appium.java_client.AppiumDriver.<init>(AppiumDriver.java:101)
	at io.appium.java_client.AppiumDriver.<init>(AppiumDriver.java:109)
	at io.appium.java_client.android.AndroidDriver.<init>(AndroidDriver.java:223)
```