### PR TITLE
Update IOSDriver.java

### DIFF
--- a/src/main/java/io/appium/java_client/ios/IOSDriver.java
+++ b/src/main/java/io/appium/java_client/ios/IOSDriver.java
@@ -44,7 +44,6 @@ import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DriverCommand;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.Response;
-import org.openqa.selenium.remote.html5.RemoteLocationContext;
 import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.HttpClient;
 
@@ -277,20 +276,6 @@ public class IOSDriver extends AppiumDriver implements
             execute(DriverCommand.SET_ALERT_VALUE, Map.of("value", keysToSend));
         }
 
-    }
-
-    /**
-     * Provides the location context.
-     *
-     * @return instance of {@link RemoteLocationContext}
-     * @deprecated This method, {@link org.openqa.selenium.html5.LocationContext} and {@link RemoteLocationContext}
-     *     interface are deprecated, use {@link #getLocation()} and
-     *     {@link #setLocation(io.appium.java_client.Location)} instead.
-     */
-    @Override
-    @Deprecated(forRemoval = true)
-    public RemoteLocationContext getLocationContext() {
-        return locationContext;
     }
 
     @Override


### PR DESCRIPTION
Removed the html5 package as this package is no longer supported and deprecated in Selenium 4. Due to this we face compilation issue for java-client wherever it is used. For now I am submitting the PR for IOSDriver. Please check for other related files where html5 is being used and remove the imports.