### PR TITLE
fix: avoid using system default locale

### DIFF
--- a/src/e2eAndroidTest/java/io/appium/java_client/android/AndroidScreenRecordTest.java
+++ b/src/e2eAndroidTest/java/io/appium/java_client/android/AndroidScreenRecordTest.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriverException;
 
 import java.time.Duration;
 
+import static java.util.Locale.ROOT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
@@ -26,7 +27,7 @@ public class AndroidScreenRecordTest extends BaseAndroidTest {
                             .withTimeLimit(Duration.ofSeconds(5))
             );
         } catch (WebDriverException e) {
-            if (e.getMessage().toLowerCase().contains("emulator")) {
+            if (e.getMessage() != null && e.getMessage().toLowerCase(ROOT).contains("emulator")) {
                 // screen recording only works on real devices
                 return;
             }

--- a/src/main/java/io/appium/java_client/HasBrowserCheck.java
+++ b/src/main/java/io/appium/java_client/HasBrowserCheck.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.CapabilityType;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public interface HasBrowserCheck extends ExecutesMethod, HasCapabilities {
@@ -34,7 +35,7 @@ public interface HasBrowserCheck extends ExecutesMethod, HasCapabilities {
         }
         try {
             var context = ((SupportsContextSwitching) this).getContext();
-            return context != null && !context.toUpperCase().contains(NATIVE_CONTEXT);
+            return context != null && !context.toUpperCase(ROOT).contains(NATIVE_CONTEXT);
         } catch (WebDriverException e) {
             return false;
         }

--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -21,6 +21,8 @@ import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.util.Map;
 
+import static java.util.Locale.ROOT;
+
 /**
  * This util class helps to prepare parameters of Android-specific JSONWP
  * commands.
@@ -241,7 +243,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
             String phoneNumber, GsmCallActions gsmCallActions) {
         return Map.entry(GSM_CALL, Map.of(
                 "phoneNumber", phoneNumber,
-                "action", gsmCallActions.name().toLowerCase()
+                "action", gsmCallActions.name().toLowerCase(ROOT)
         ));
     }
 
@@ -275,7 +277,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
     @Deprecated
     public static Map.Entry<String, Map<String, ?>> gsmVoiceCommand(
             GsmVoiceState gsmVoiceState) {
-        return Map.entry(GSM_VOICE, Map.of("state", gsmVoiceState.name().toLowerCase()));
+        return Map.entry(GSM_VOICE, Map.of("state", gsmVoiceState.name().toLowerCase(ROOT)));
     }
 
     /**
@@ -289,7 +291,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
     @Deprecated
     public static Map.Entry<String, Map<String, ?>> networkSpeedCommand(
             NetworkSpeed networkSpeed) {
-        return Map.entry(NETWORK_SPEED, Map.of("netspeed", networkSpeed.name().toLowerCase()));
+        return Map.entry(NETWORK_SPEED, Map.of("netspeed", networkSpeed.name().toLowerCase(ROOT)));
     }
 
     /**
@@ -317,7 +319,7 @@ public class AndroidMobileCommandHelper extends MobileCommand {
     @Deprecated
     public static Map.Entry<String, Map<String, ?>> powerACCommand(
             PowerACState powerACState) {
-        return Map.entry(POWER_AC_STATE, Map.of("state", powerACState.name().toLowerCase()));
+        return Map.entry(POWER_AC_STATE, Map.of("state", powerACState.name().toLowerCase(ROOT)));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/android/HasAndroidClipboard.java
+++ b/src/main/java/io/appium/java_client/android/HasAndroidClipboard.java
@@ -25,6 +25,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import static io.appium.java_client.MobileCommand.SET_CLIPBOARD;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public interface HasAndroidClipboard extends HasClipboard {
@@ -39,7 +40,7 @@ public interface HasAndroidClipboard extends HasClipboard {
         CommandExecutionHelper.execute(this, Map.entry(SET_CLIPBOARD,
                 Map.of(
                         "content", new String(requireNonNull(base64Content), StandardCharsets.UTF_8),
-                        "contentType", contentType.name().toLowerCase(),
+                        "contentType", contentType.name().toLowerCase(ROOT),
                         "label", requireNonNull(label)
                 )
         ));

--- a/src/main/java/io/appium/java_client/android/SupportsSpecialEmulatorCommands.java
+++ b/src/main/java/io/appium/java_client/android/SupportsSpecialEmulatorCommands.java
@@ -14,6 +14,7 @@ import static io.appium.java_client.MobileCommand.NETWORK_SPEED;
 import static io.appium.java_client.MobileCommand.POWER_AC_STATE;
 import static io.appium.java_client.MobileCommand.POWER_CAPACITY;
 import static io.appium.java_client.MobileCommand.SEND_SMS;
+import static java.util.Locale.ROOT;
 
 public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanRememberExtensionPresence {
 
@@ -53,7 +54,7 @@ public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanReme
         try {
             CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, Map.of(
                     "phoneNumber", phoneNumber,
-                    "action", gsmCallAction.toString().toLowerCase()
+                    "action", gsmCallAction.toString().toLowerCase(ROOT)
             ));
         } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
@@ -61,7 +62,7 @@ public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanReme
                     markExtensionAbsence(extName),
                     Map.entry(GSM_CALL, Map.of(
                             "phoneNumber", phoneNumber,
-                            "action", gsmCallAction.toString().toLowerCase()
+                            "action", gsmCallAction.toString().toLowerCase(ROOT)
                     ))
             );
         }
@@ -99,14 +100,14 @@ public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanReme
         final String extName = "mobile: gsmVoice";
         try {
             CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, Map.of(
-                    "state", gsmVoiceState.toString().toLowerCase()
+                    "state", gsmVoiceState.toString().toLowerCase(ROOT)
             ));
         } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
             CommandExecutionHelper.execute(
                     markExtensionAbsence(extName),
                     Map.entry(GSM_VOICE, Map.of(
-                            "state", gsmVoiceState.name().toLowerCase()
+                            "state", gsmVoiceState.name().toLowerCase(ROOT)
                     ))
             );
         }
@@ -121,14 +122,14 @@ public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanReme
         final String extName = "mobile: networkSpeed";
         try {
             CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, Map.of(
-                    "speed", networkSpeed.toString().toLowerCase()
+                    "speed", networkSpeed.toString().toLowerCase(ROOT)
             ));
         } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
             CommandExecutionHelper.execute(
                     markExtensionAbsence(extName),
                     Map.entry(NETWORK_SPEED, Map.of(
-                            "netspeed", networkSpeed.name().toLowerCase()
+                            "netspeed", networkSpeed.name().toLowerCase(ROOT)
                     ))
             );
         }
@@ -165,14 +166,14 @@ public interface SupportsSpecialEmulatorCommands extends ExecutesMethod, CanReme
         final String extName = "mobile: powerAC";
         try {
             CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, Map.of(
-                    "state", powerACState.toString().toLowerCase()
+                    "state", powerACState.toString().toLowerCase(ROOT)
             ));
         } catch (UnsupportedCommandException e) {
             // TODO: Remove the fallback
             CommandExecutionHelper.execute(
                     markExtensionAbsence(extName),
                     Map.entry(POWER_AC_STATE, Map.of(
-                            "state", powerACState.name().toLowerCase()
+                            "state", powerACState.name().toLowerCase(ROOT)
                     ))
             );
         }

--- a/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
+++ b/src/main/java/io/appium/java_client/clipboard/HasClipboard.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static io.appium.java_client.MobileCommand.GET_CLIPBOARD;
 import static io.appium.java_client.MobileCommand.SET_CLIPBOARD;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public interface HasClipboard extends ExecutesMethod, CanRememberExtensionPresence {
@@ -40,7 +41,7 @@ public interface HasClipboard extends ExecutesMethod, CanRememberExtensionPresen
         final String extName = "mobile: setClipboard";
         var args = Map.of(
                 "content", new String(requireNonNull(base64Content), StandardCharsets.UTF_8),
-                "contentType", contentType.name().toLowerCase()
+                "contentType", contentType.name().toLowerCase(ROOT)
         );
         try {
             CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, args);
@@ -58,7 +59,7 @@ public interface HasClipboard extends ExecutesMethod, CanRememberExtensionPresen
      */
     default String getClipboard(ClipboardContentType contentType) {
         final String extName = "mobile: getClipboard";
-        var args = Map.of("contentType", contentType.name().toLowerCase());
+        var args = Map.of("contentType", contentType.name().toLowerCase(ROOT));
         try {
             return CommandExecutionHelper.executeScript(assertExtensionExists(extName), extName, args);
         } catch (UnsupportedCommandException e) {

--- a/src/main/java/io/appium/java_client/driverscripts/ScriptOptions.java
+++ b/src/main/java/io/appium/java_client/driverscripts/ScriptOptions.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
@@ -59,7 +60,7 @@ public class ScriptOptions {
      */
     public Map<String, Object> build() {
         var map = new HashMap<String, Object>();
-        ofNullable(scriptType).ifPresent(x -> map.put("type", x.name().toLowerCase()));
+        ofNullable(scriptType).ifPresent(x -> map.put("type", x.name().toLowerCase(ROOT)));
         ofNullable(timeoutMs).ifPresent(x -> map.put("timeout", x));
         return Collections.unmodifiableMap(map);
     }

--- a/src/main/java/io/appium/java_client/gecko/options/SupportsVerbosityOption.java
+++ b/src/main/java/io/appium/java_client/gecko/options/SupportsVerbosityOption.java
@@ -22,6 +22,8 @@ import org.openqa.selenium.Capabilities;
 
 import java.util.Optional;
 
+import static java.util.Locale.ROOT;
+
 public interface SupportsVerbosityOption<T extends BaseOptions<T>> extends
         Capabilities, CanSetCapability<T> {
     String VERBOSITY_OPTION = "verbosity";
@@ -34,7 +36,7 @@ public interface SupportsVerbosityOption<T extends BaseOptions<T>> extends
      * @return self instance for chaining.
      */
     default T setVerbosity(Verbosity verbosity) {
-        return amend(VERBOSITY_OPTION, verbosity.name().toLowerCase());
+        return amend(VERBOSITY_OPTION, verbosity.name().toLowerCase(ROOT));
     }
 
     /**
@@ -45,7 +47,7 @@ public interface SupportsVerbosityOption<T extends BaseOptions<T>> extends
     default Optional<Verbosity> getVerbosity() {
         return Optional.ofNullable(getCapability(VERBOSITY_OPTION))
                 .map(String::valueOf)
-                .map(String::toUpperCase)
+                .map(verbosity -> verbosity.toUpperCase(ROOT))
                 .map(Verbosity::valueOf);
     }
 }

--- a/src/main/java/io/appium/java_client/internal/filters/AppiumIdempotencyFilter.java
+++ b/src/main/java/io/appium/java_client/internal/filters/AppiumIdempotencyFilter.java
@@ -20,7 +20,8 @@ import org.openqa.selenium.remote.http.Filter;
 import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.HttpMethod;
 
-import java.util.UUID;
+import static java.util.Locale.ROOT;
+import static java.util.UUID.randomUUID;
 
 public class AppiumIdempotencyFilter implements Filter {
     // https://github.com/appium/appium-base-driver/pull/400
@@ -30,7 +31,7 @@ public class AppiumIdempotencyFilter implements Filter {
     public HttpHandler apply(HttpHandler next) {
         return req -> {
             if (req.getMethod() == HttpMethod.POST && req.getUri().endsWith("/session")) {
-                req.setHeader(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString().toLowerCase());
+                req.setHeader(IDEMPOTENCY_KEY_HEADER, randomUUID().toString().toLowerCase(ROOT));
             }
             return next.execute(req);
         };

--- a/src/main/java/io/appium/java_client/internal/filters/AppiumUserAgentFilter.java
+++ b/src/main/java/io/appium/java_client/internal/filters/AppiumUserAgentFilter.java
@@ -24,6 +24,8 @@ import org.openqa.selenium.remote.http.Filter;
 import org.openqa.selenium.remote.http.HttpHandler;
 import org.openqa.selenium.remote.http.HttpHeader;
 
+import static java.util.Locale.ROOT;
+
 /**
  * Manage Appium Client configurations.
  */
@@ -54,7 +56,7 @@ public class AppiumUserAgentFilter implements Filter {
      *         like by this filter.
      */
     private static boolean containsAppiumName(@Nullable String userAgent) {
-        return userAgent != null && userAgent.toLowerCase().contains(USER_AGENT_PREFIX.toLowerCase());
+        return userAgent != null && userAgent.toLowerCase(ROOT).contains(USER_AGENT_PREFIX.toLowerCase(ROOT));
     }
 
     /**

--- a/src/main/java/io/appium/java_client/ios/IOSStartScreenRecordingOptions.java
+++ b/src/main/java/io/appium/java_client/ios/IOSStartScreenRecordingOptions.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
@@ -73,7 +74,7 @@ public class IOSStartScreenRecordingOptions
      * @return self instance for chaining.
      */
     public IOSStartScreenRecordingOptions withVideoQuality(VideoQuality videoQuality) {
-        this.videoQuality = requireNonNull(videoQuality).name().toLowerCase();
+        this.videoQuality = requireNonNull(videoQuality).name().toLowerCase(ROOT);
         return this;
     }
 

--- a/src/main/java/io/appium/java_client/ios/options/simulator/SupportsSimulatorPasteboardAutomaticSyncOption.java
+++ b/src/main/java/io/appium/java_client/ios/options/simulator/SupportsSimulatorPasteboardAutomaticSyncOption.java
@@ -22,6 +22,8 @@ import org.openqa.selenium.Capabilities;
 
 import java.util.Optional;
 
+import static java.util.Locale.ROOT;
+
 public interface SupportsSimulatorPasteboardAutomaticSyncOption<T extends BaseOptions<T>> extends
         Capabilities, CanSetCapability<T> {
     String SIMULATOR_PASTEBOARD_AUTOMATIC_SYNC = "simulatorPasteboardAutomaticSync";
@@ -37,7 +39,7 @@ public interface SupportsSimulatorPasteboardAutomaticSyncOption<T extends BaseOp
      * @return self instance for chaining.
      */
     default T setSimulatorPasteboardAutomaticSync(PasteboardSyncState state) {
-        return amend(SIMULATOR_PASTEBOARD_AUTOMATIC_SYNC, state.toString().toLowerCase());
+        return amend(SIMULATOR_PASTEBOARD_AUTOMATIC_SYNC, state.toString().toLowerCase(ROOT));
     }
 
     /**
@@ -47,6 +49,6 @@ public interface SupportsSimulatorPasteboardAutomaticSyncOption<T extends BaseOp
      */
     default Optional<PasteboardSyncState> getSimulatorPasteboardAutomaticSync() {
         return Optional.ofNullable(getCapability(SIMULATOR_PASTEBOARD_AUTOMATIC_SYNC))
-                .map(v -> PasteboardSyncState.valueOf(String.valueOf(v).toUpperCase()));
+                .map(v -> PasteboardSyncState.valueOf(String.valueOf(v).toUpperCase(ROOT)));
     }
 }

--- a/src/main/java/io/appium/java_client/pagefactory/OverrideWidgetReader.java
+++ b/src/main/java/io/appium/java_client/pagefactory/OverrideWidgetReader.java
@@ -28,6 +28,7 @@ import static io.appium.java_client.pagefactory.WidgetConstructorUtil.findConven
 import static io.appium.java_client.remote.MobilePlatform.ANDROID;
 import static io.appium.java_client.remote.MobilePlatform.IOS;
 import static io.appium.java_client.remote.MobilePlatform.WINDOWS;
+import static java.util.Locale.ROOT;
 
 class OverrideWidgetReader {
     private static final Class<? extends Widget> EMPTY = Widget.class;
@@ -74,7 +75,7 @@ class OverrideWidgetReader {
 
     static Class<? extends Widget> getMobileNativeWidgetClass(Class<? extends Widget> declaredClass,
                                                               AnnotatedElement annotatedElement, String platform) {
-        String transformedPlatform = String.valueOf(platform).toUpperCase().trim();
+        String transformedPlatform = String.valueOf(platform).toUpperCase(ROOT).trim();
 
         if (ANDROID.equalsIgnoreCase(transformedPlatform)) {
             return getConvenientClass(declaredClass, annotatedElement, ANDROID_UI_AUTOMATOR);

--- a/src/main/java/io/appium/java_client/pagefactory/utils/WebDriverUnpackUtility.java
+++ b/src/main/java/io/appium/java_client/pagefactory/utils/WebDriverUnpackUtility.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import static io.appium.java_client.HasBrowserCheck.NATIVE_CONTEXT;
 import static io.appium.java_client.pagefactory.bys.ContentType.HTML_OR_DEFAULT;
 import static io.appium.java_client.pagefactory.bys.ContentType.NATIVE_MOBILE_SPECIFIC;
+import static java.util.Locale.ROOT;
 
 public final class WebDriverUnpackUtility {
     private WebDriverUnpackUtility() {
@@ -108,7 +109,7 @@ public final class WebDriverUnpackUtility {
 
         var contextAware = unpackObjectFromSearchContext(context, SupportsContextSwitching.class);
         if (contextAware.map(SupportsContextSwitching::getContext)
-                .filter(c -> c.toUpperCase().contains(NATIVE_CONTEXT)).isPresent()) {
+                .filter(c -> c.toUpperCase(ROOT).contains(NATIVE_CONTEXT)).isPresent()) {
             return NATIVE_MOBILE_SPECIFIC;
         }
 

--- a/src/main/java/io/appium/java_client/remote/SupportsRotation.java
+++ b/src/main/java/io/appium/java_client/remote/SupportsRotation.java
@@ -25,6 +25,8 @@ import org.openqa.selenium.remote.Response;
 
 import java.util.Map;
 
+import static java.util.Locale.ROOT;
+
 public interface SupportsRotation extends WebDriver, ExecutesMethod {
     /**
      * Get device rotation.
@@ -43,7 +45,7 @@ public interface SupportsRotation extends WebDriver, ExecutesMethod {
 
     default void rotate(ScreenOrientation orientation) {
         execute(MobileCommand.SET_SCREEN_ORIENTATION,
-                Map.of("orientation", orientation.value().toUpperCase()));
+                Map.of("orientation", orientation.value().toUpperCase(ROOT)));
     }
 
     /**
@@ -54,6 +56,6 @@ public interface SupportsRotation extends WebDriver, ExecutesMethod {
     default ScreenOrientation getOrientation() {
         Response response = execute(MobileCommand.GET_SCREEN_ORIENTATION);
         String orientation = String.valueOf(response.getValue());
-        return ScreenOrientation.valueOf(orientation.toUpperCase());
+        return ScreenOrientation.valueOf(orientation.toUpperCase(ROOT));
     }
 }

--- a/src/main/java/io/appium/java_client/remote/options/SupportsOrientationOption.java
+++ b/src/main/java/io/appium/java_client/remote/options/SupportsOrientationOption.java
@@ -21,6 +21,8 @@ import org.openqa.selenium.ScreenOrientation;
 
 import java.util.Optional;
 
+import static java.util.Locale.ROOT;
+
 public interface SupportsOrientationOption<T extends BaseOptions<T>> extends
         Capabilities, CanSetCapability<T> {
     String ORIENTATION_OPTION = "orientation";
@@ -44,7 +46,7 @@ public interface SupportsOrientationOption<T extends BaseOptions<T>> extends
         return Optional.ofNullable(getCapability(ORIENTATION_OPTION))
                 .map(v -> v instanceof ScreenOrientation
                         ? (ScreenOrientation) v
-                        : ScreenOrientation.valueOf((String.valueOf(v)).toUpperCase())
+                        : ScreenOrientation.valueOf((String.valueOf(v)).toUpperCase(ROOT))
                 );
     }
 }

--- a/src/main/java/io/appium/java_client/remote/options/SupportsPageLoadStrategyOption.java
+++ b/src/main/java/io/appium/java_client/remote/options/SupportsPageLoadStrategyOption.java
@@ -21,6 +21,8 @@ import org.openqa.selenium.PageLoadStrategy;
 
 import java.util.Optional;
 
+import static java.util.Locale.ROOT;
+
 public interface SupportsPageLoadStrategyOption<T extends BaseOptions<T>> extends
         Capabilities, CanSetCapability<T> {
     String PAGE_LOAD_STRATEGY_OPTION = "pageLoadStrategy";
@@ -43,7 +45,7 @@ public interface SupportsPageLoadStrategyOption<T extends BaseOptions<T>> extend
     default Optional<PageLoadStrategy> getPageLoadStrategy() {
         return Optional.ofNullable(getCapability(PAGE_LOAD_STRATEGY_OPTION))
                 .map(String::valueOf)
-                .map(String::toUpperCase)
+                .map(strategy -> strategy.toUpperCase(ROOT))
                 .map(PageLoadStrategy::valueOf);
     }
 }

--- a/src/main/java/io/appium/java_client/remote/options/UnhandledPromptBehavior.java
+++ b/src/main/java/io/appium/java_client/remote/options/UnhandledPromptBehavior.java
@@ -19,6 +19,8 @@ package io.appium.java_client.remote.options;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static java.util.Locale.ROOT;
+
 public enum UnhandledPromptBehavior {
     DISMISS, ACCEPT,
     DISMISS_AND_NOTIFY, ACCEPT_AND_NOTIFY,
@@ -26,7 +28,7 @@ public enum UnhandledPromptBehavior {
 
     @Override
     public String toString() {
-        return name().toLowerCase().replace("_", " ");
+        return name().toLowerCase(ROOT).replace("_", " ");
     }
 
     /**

--- a/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.appium.java_client.service.local.AppiumServiceBuilder.BROADCAST_IP4_ADDRESS;
 import static io.appium.java_client.service.local.AppiumServiceBuilder.BROADCAST_IP6_ADDRESS;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 import static org.slf4j.event.Level.DEBUG;
@@ -407,7 +408,7 @@ public final class AppiumDriverLocalService extends DriverService {
         String loggerName = APPIUM_SERVICE_SLF4J_LOGGER_PREFIX;
         Level level = INFO;
         if (m.find()) {
-            loggerName += "." + m.group(2).toLowerCase().replaceAll("\\s+", "");
+            loggerName += "." + m.group(2).toLowerCase(ROOT).replaceAll("\\s+", "");
             if (m.group(1) != null) {
                 level = DEBUG;
             }

--- a/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
+++ b/src/main/java/io/appium/java_client/service/local/AppiumServiceBuilder.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static org.openqa.selenium.remote.CapabilityType.PLATFORM_NAME;
 
@@ -143,7 +144,7 @@ public final class AppiumServiceBuilder
 
     private static File findMainScript() {
         File npm = findNpm();
-        List<String> cmdLine = System.getProperty("os.name").toLowerCase().contains("win")
+        List<String> cmdLine = System.getProperty("os.name").toLowerCase(ROOT).contains("win")
                 // npm is a batch script, so on windows we need to use cmd.exe in order to execute it
                 ? Arrays.asList("cmd.exe", "/c", String.format("\"%s\" root -g", npm.getAbsolutePath()))
                 : Arrays.asList(npm.getAbsolutePath(), "root", "-g");


### PR DESCRIPTION
For example, if the system default locale is Turkish ("tr_TR"), then `ClipboardContentType.PLAINTEXT` argument gets converted to "plaıntext", not "plaintext".

## Change list

1. Replace `toLowerCase()` -> `toLowerCase(ROOT)`
2. Replace `toUpperCase()` -> `toUpperCase(ROOT)`

"ROOT" is a specific locale that at least works well for latin letters (that are used in content types, enum names etc.)

 
## Types of changes

What types of changes are you proposing/introducing to Java client?
_Put an `x` in the boxes that apply_

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

