### PR TITLE
chore: make API changes compatible with Selenium 4.42.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ repositories {
     }
 }
 
+configurations.configureEach {
+    resolutionStrategy.cacheChangingModulesFor 1, 'minutes'
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.daemon=true
 
-selenium.version=4.40.0
+#selenium.version=4.40.0
+selenium.version=4.42.0-SNAPSHOT
 # Please increment the value in a release
 appiumClient.version=10.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.daemon=true
 
-#selenium.version=4.40.0
-selenium.version=4.42.0-SNAPSHOT
+selenium.version=4.42.0
 # Please increment the value in a release
 appiumClient.version=10.0.0

--- a/src/main/java/io/appium/java_client/AppiumExecutionMethod.java
+++ b/src/main/java/io/appium/java_client/AppiumExecutionMethod.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client;
 
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.remote.ExecuteMethod;
 import org.openqa.selenium.remote.Response;
 
@@ -35,7 +36,9 @@ public class AppiumExecutionMethod implements ExecuteMethod {
      * @param parameters is a map which contains parameter names as keys and parameter values
      * @return a command execution result
      */
-    public Object execute(String commandName, Map<String, ?> parameters) {
+    @Nullable
+    @SuppressWarnings("unchecked")
+    public <T> T execute(String commandName, @Nullable Map<String, ?> parameters) {
         Response response;
 
         if (parameters == null || parameters.isEmpty()) {
@@ -44,6 +47,6 @@ public class AppiumExecutionMethod implements ExecuteMethod {
             response = driver.execute(commandName, parameters);
         }
 
-        return response.getValue();
+        return (T) response.getValue();
     }
 }

--- a/src/main/java/io/appium/java_client/AppiumExecutionMethod.java
+++ b/src/main/java/io/appium/java_client/AppiumExecutionMethod.java
@@ -16,6 +16,7 @@
 
 package io.appium.java_client;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.remote.ExecuteMethod;
 import org.openqa.selenium.remote.Response;
@@ -37,8 +38,7 @@ public class AppiumExecutionMethod implements ExecuteMethod {
      * @return a command execution result
      */
     @Nullable
-    @SuppressWarnings("unchecked")
-    public <T> T execute(String commandName, @Nullable Map<String, ?> parameters) {
+    public Object execute(@NonNull String commandName, @Nullable Map<String, ?> parameters) {
         Response response;
 
         if (parameters == null || parameters.isEmpty()) {
@@ -47,6 +47,6 @@ public class AppiumExecutionMethod implements ExecuteMethod {
             response = driver.execute(commandName, parameters);
         }
 
-        return (T) response.getValue();
+        return response.getValue();
     }
 }

--- a/src/main/java/io/appium/java_client/AppiumFluentWait.java
+++ b/src/main/java/io/appium/java_client/AppiumFluentWait.java
@@ -19,6 +19,9 @@ package io.appium.java_client;
 import com.google.common.base.Throwables;
 import lombok.AccessLevel;
 import lombok.Getter;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.ui.FluentWait;
@@ -32,7 +35,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+@NullMarked
 public class AppiumFluentWait<T> extends FluentWait<T> {
+    @Nullable
     private Function<IterationInfo, Duration> pollingStrategy = null;
 
     private static final Duration DEFAULT_POLL_DELAY_DURATION = Duration.ZERO;
@@ -133,7 +138,7 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
         return ignoredExceptions;
     }
 
-    protected Supplier<String> getMessageSupplier() {
+    protected Supplier<@Nullable String> getMessageSupplier() {
         return messageSupplier;
     }
 
@@ -203,7 +208,7 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
      * @throws TimeoutException If the timeout expires.
      */
     @Override
-    public <V> V until(Function<? super T, V> isTrue) {
+    public <V extends @Nullable Object> @NonNull V until(Function<? super T, ? extends V> isTrue) {
         final var start = getClock().instant();
         // Adding pollDelay to end instant will allow to verify the condition for the expected timeout duration.
         final var end = start.plus(getTimeout()).plus(pollDelay);
@@ -211,7 +216,7 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
         return performIteration(isTrue, start, end);
     }
 
-    private <V> V performIteration(Function<? super T, V> isTrue, Instant start, Instant end) {
+    private <V extends @Nullable Object> @NonNull V performIteration(Function<? super T, ? extends V> isTrue, Instant start, Instant end) {
         var iterationNumber = 1;
         Throwable lastException;
 
@@ -245,8 +250,8 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
         }
     }
 
-    private <V> void handleTimeoutException(Throwable lastException, Function<? super T, V> isTrue) {
-        var message = Optional.ofNullable(getMessageSupplier())
+    private <V> void handleTimeoutException(@Nullable Throwable lastException, Function<? super T, ? extends V> isTrue) {
+        var message = Optional.of(getMessageSupplier())
                 .map(Supplier::get)
                 .orElseGet(() -> "waiting for " + isTrue);
 

--- a/src/main/java/io/appium/java_client/AppiumFluentWait.java
+++ b/src/main/java/io/appium/java_client/AppiumFluentWait.java
@@ -216,7 +216,8 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
         return performIteration(isTrue, start, end);
     }
 
-    private <V extends @Nullable Object> @NonNull V performIteration(Function<? super T, ? extends V> isTrue, Instant start, Instant end) {
+    private <V extends @Nullable Object> @NonNull V performIteration(
+            Function<? super T, ? extends V> isTrue, Instant start, Instant end) {
         var iterationNumber = 1;
         Throwable lastException;
 
@@ -250,7 +251,8 @@ public class AppiumFluentWait<T> extends FluentWait<T> {
         }
     }
 
-    private <V> void handleTimeoutException(@Nullable Throwable lastException, Function<? super T, ? extends V> isTrue) {
+    private <V> void handleTimeoutException(
+            @Nullable Throwable lastException, Function<? super T, ? extends V> isTrue) {
         var message = Optional.of(getMessageSupplier())
                 .map(Supplier::get)
                 .orElseGet(() -> "waiting for " + isTrue);


### PR DESCRIPTION

## Change list

Unfortunately, signature of this public method have been changed in Selenium 4.42.0-SNAPSHOT:

* org.openqa.selenium.support.ui.FluentWait#until

 
When Selenium 4.24.0 gets release, we will need to merge this PR to fix the compilation error. 

## Types of changes

- [ ] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

### FlluentWait
See PR https://github.com/SeleniumHQ/selenium/pull/17149/changes (fixes issue https://github.com/SeleniumHQ/selenium/issues/17122 - compilation error in Kotlin projects because of nullable/nonnullable types).

Before:
```java
  @Override
  public <V> V until(Function<? super T, @Nullable V> isTrue) { ... }
```

After:
```java
  @Override
  public <V extends @Nullable Object> @NonNull V until(Function<? super T, ? extends V> isTrue) { ... }
```