### PR TITLE
chore: Build against Selenium nightly build in a separate nightly job

### DIFF
--- a/.github/workflows/ci-selenium-nightly.yml
+++ b/.github/workflows/ci-selenium-nightly.yml
@@ -1,0 +1,48 @@
+name: Build against Selenium nightly build
+
+on:
+  schedule:
+    - cron: '6 6 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        include:
+        - java: 17
+          platform: ubuntu-latest
+        - java: 21
+          platform: ubuntu-latest
+        - java: 25
+          platform: ubuntu-latest
+      fail-fast: false
+
+    runs-on: ${{ matrix.platform }}
+
+    name: JDK ${{ matrix.java }} - ${{ matrix.platform }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+
+    - name: Build with Gradle
+      run: |
+        latest_snapshot=$(curl -sf https://raw.githubusercontent.com/SeleniumHQ/selenium/refs/heads/trunk/java/version.bzl | grep 'SE_VERSION' | sed 's/.*"\(.*\)".*/\1/')
+        echo ">>> $latest_snapshot"
+        echo "latest_snapshot=$latest_snapshot" >> "$GITHUB_ENV"
+        ./gradlew clean build -PisCI -Pselenium.version=$latest_snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5
 
-    - name: Build with Gradle against Selenium nightly build
-      run: |
-        latest_snapshot=$(curl -sf https://raw.githubusercontent.com/SeleniumHQ/selenium/refs/heads/trunk/java/version.bzl | grep 'SE_VERSION' | sed 's/.*"\(.*\)".*/\1/')
-        echo ">>> $latest_snapshot"
-        echo "latest_snapshot=$latest_snapshot" >> "$GITHUB_ENV"
-        ./gradlew clean build -PisCI -Pselenium.version=$latest_snapshot
-
-    - name: Build with Gradle against stable Selenium version
+    - name: Build with Gradle
       run: |
         ./gradlew clean build -PisCI
 


### PR DESCRIPTION
## Change list

#### Before:
GA was building against Selenium nightly build in every PR. 
This is bad because it can break build of every single PR when something is wrong with the Selenium nightly build.

#### After:
GA has a dedicated nightly jobs that runs at 6:06 every night, and builds against the latests Selenium nightly build.
So we don't break builds of current PRs.
 
## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

