### PR TITLE
fix(io): close all streams in ListOutputStream#close

### DIFF
--- a/src/main/java/io/appium/java_client/service/local/ListOutputStream.java
+++ b/src/main/java/io/appium/java_client/service/local/ListOutputStream.java
@@ -62,8 +62,20 @@ class ListOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
+        IOException first = null;
         for (OutputStream stream : streams) {
-            stream.close();
+            try {
+                stream.close();
+            } catch (IOException e) {
+                if (first == null) {
+                    first = e;
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        if (first != null) {
+            throw first;
         }
     }
 


### PR DESCRIPTION
## Change list

* Make `ListOutputStream.close()` close **all** underlying `OutputStream`s even if one `close()` throws.
* Collect the first `IOException` and attach subsequent close failures as suppressed exceptions, then rethrow after attempting all closes.

## Types of changes

* [ ] No changes in production code.
* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`ListOutputStream.close()` previously stopped at the first `IOException`, which could leave remaining streams unclosed and potentially leak resources. The updated implementation attempts to close every stream and only throws after cleanup is complete (preserving additional failures via suppressed exceptions).
