### PR TITLE
fix: Ensure additional commands get added to the attach-to-session constructor

### DIFF
--- a/src/main/java/io/appium/java_client/AppiumDriver.java
+++ b/src/main/java/io/appium/java_client/AppiumDriver.java
@@ -170,6 +170,7 @@ public class AppiumDriver extends RemoteWebDriver implements
         );
         executor.setCommandCodec(new AppiumW3CHttpCommandCodec());
         executor.setResponseCodec(new W3CHttpResponseCodec());
+        executor.refreshAdditionalCommands();
         setCommandExecutor(executor);
         this.executeMethod = new AppiumExecutionMethod(this);
         super.setErrorHandler(ERROR_HANDLER);


### PR DESCRIPTION
## Change list

Fix AppiumDriver's "attach to a running session" constructor (`AppiumDriver(URL remoteSessionAddress, String platformName, String automationName)`) so Appium-specific commands (settings, pressKeyCode, hideKeyboard, etc.) work when attaching to an existing session instead of creating a new one.

## Types of changes

- [ ] No changes in production code.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Fixes #2428.