### PR TITLE
docs: drop appiumpro.com references

### DIFF
--- a/docs/v7-to-v8-migration-guide.md
+++ b/docs/v7-to-v8-migration-guide.md
@@ -85,7 +85,7 @@ Please use [W3C Actions](https://w3c.github.io/webdriver/#actions) instead
 or the corresponding extension methods for the driver (if available).
 Check
   - https://www.youtube.com/watch?v=oAJ7jwMNFVU
-  - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
+  - https://www.headspin.io/blog/ios-specific-touch-action-methods
   - Android gesture shortcuts:
     * [mobile: longClickGesture](https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/android-mobile-gestures.md#mobile-longclickgesture)
     * [mobile: doubleClickGesture](https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/android-mobile-gestures.md#mobile-doubleclickgesture)
@@ -107,7 +107,7 @@ Check
     * [mobile: dragFromToForDuration](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/execute-methods.md#mobile-dragfromtoforduration)
     * [mobile: dragFromToWithVelocity](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/execute-methods.md#mobile-dragfromtowithvelocity)
     * [mobile: scrollToElement](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/execute-methods.md#mobile-scrolltoelement)
-  - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+  - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
 for more details on how to properly apply W3C Actions to your automation context.
 
 ## resetApp/launchApp/closeApp

--- a/src/main/java/io/appium/java_client/AppiumClientConfig.java
+++ b/src/main/java/io/appium/java_client/AppiumClientConfig.java
@@ -176,7 +176,7 @@ public class AppiumClientConfig extends ClientConfig {
 
     /**
      * Whether enable directConnect feature described in
-     * <a href="https://appiumpro.com/editions/86-connecting-directly-to-appium-hosts-in-distributed-environments">
+     * <a href="https://www.headspin.io/blog/connecting-directly-to-appium-hosts-in-distributed-environments">
      *     Connecting Directly to Appium Hosts in Distributed Environments</a>.
      *
      * @param directConnect if enable the directConnect feature

--- a/src/main/java/io/appium/java_client/MultiTouchAction.java
+++ b/src/main/java/io/appium/java_client/MultiTouchAction.java
@@ -45,8 +45,8 @@ import static java.util.stream.Collectors.toList;
  *     extension methods for the driver (if available).
  *     Check
  *     - https://www.youtube.com/watch?v=oAJ7jwMNFVU
- *     - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
- *     - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ *     - https://www.headspin.io/blog/ios-specific-touch-action-methods
+ *     - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
  *     for more details.
  */
 @Deprecated

--- a/src/main/java/io/appium/java_client/PerformsTouchActions.java
+++ b/src/main/java/io/appium/java_client/PerformsTouchActions.java
@@ -28,8 +28,8 @@ import static io.appium.java_client.MobileCommand.PERFORM_TOUCH_ACTION;
  * extension methods for the driver (if available).
  * Check
  * - https://www.youtube.com/watch?v=oAJ7jwMNFVU
- * - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
- * - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ * - https://www.headspin.io/blog/ios-specific-touch-action-methods
+ * - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
  * for more details.
  */
 @Deprecated

--- a/src/main/java/io/appium/java_client/TouchAction.java
+++ b/src/main/java/io/appium/java_client/TouchAction.java
@@ -47,8 +47,8 @@ import static java.util.stream.Collectors.toList;
  *     extension methods for the driver (if available).
  *     Check
  *     - https://www.youtube.com/watch?v=oAJ7jwMNFVU
- *     - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
- *     - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ *     - https://www.headspin.io/blog/ios-specific-touch-action-methods
+ *     - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
  *     for more details.
  */
 @Deprecated

--- a/src/main/java/io/appium/java_client/android/AndroidTouchAction.java
+++ b/src/main/java/io/appium/java_client/android/AndroidTouchAction.java
@@ -28,8 +28,8 @@ import io.appium.java_client.TouchAction;
  *     extension methods for the driver (if available).
  *     Check
  *     - https://www.youtube.com/watch?v=oAJ7jwMNFVU
- *     - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
- *     - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ *     - https://www.headspin.io/blog/ios-specific-touch-action-methods
+ *     - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
  *     for more details.
  */
 @Deprecated

--- a/src/main/java/io/appium/java_client/ios/IOSTouchAction.java
+++ b/src/main/java/io/appium/java_client/ios/IOSTouchAction.java
@@ -30,8 +30,8 @@ import io.appium.java_client.touch.offset.PointOption;
  *     extension methods for the driver (if available).
  *     Check
  *     - https://www.youtube.com/watch?v=oAJ7jwMNFVU
- *     - https://appiumpro.com/editions/30-ios-specific-touch-action-methods
- *     - https://appiumpro.com/editions/29-automating-complex-gestures-with-the-w3c-actions-api
+ *     - https://www.headspin.io/blog/ios-specific-touch-action-methods
+ *     - https://www.headspin.io/blog/automating-complex-gestures-with-the-w3c-actions-api
  *     for more details.
  */
 @Deprecated


### PR DESCRIPTION
## Summary
Removes `appiumpro.com` references from this repository, since the domain is no longer maintained by the Appium team (see appium/appium#22499).

Follows the same approach as appium/appium#22500 — links are removed rather than replaced, unless removal would break surrounding prose, in which case the URL is inlined as plain text.

Closes appium/appium#22499

## Checklist
- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] No documentation update needed (only stale links removed)