### PR TITLE
ci: Fix download URLs for Flutter apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ env:
   XCODE_VERSION: "16.4"
   IOS_DEVICE_NAME: iPhone 16
   IOS_PLATFORM_VERSION: "18.5"
-  FLUTTER_ANDROID_APP: "https://github.com/AppiumTestDistribution/appium-flutter-server/releases/latest/download/app-debug.apk"
-  FLUTTER_IOS_APP: "https://github.com/AppiumTestDistribution/appium-flutter-server/releases/latest/download/ios.zip"
+  FLUTTER_ANDROID_APP: "https://github.com/AppiumTestDistribution/appium-flutter-server/releases/download/0.0.33/app-debug.apk"
+  FLUTTER_IOS_APP: "https://github.com/AppiumTestDistribution/appium-flutter-server/releases/download/0.0.33/ios.zip"
   PREBUILT_WDA_PATH: ${{ github.workspace }}/wda/WebDriverAgentRunner-Runner.app
 
 jobs:


### PR DESCRIPTION
## Change list

The latest release of https://github.com/AppiumTestDistribution/appium-flutter-server (0.0.34) does not contain the builds for apps.
 
## Types of changes

What types of changes are you proposing/introducing to Java client?

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
