### PR TITLE
fix(touch): validate RemoteWebElement in ElementOption.withElement

### DIFF
--- a/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
+++ b/src/main/java/io/appium/java_client/touch/offset/ElementOption.java
@@ -84,9 +84,9 @@ public class ElementOption extends PointOption<ElementOption> {
      */
     public ElementOption withElement(WebElement element) {
         requireNonNull(element);
-        checkArgument(true, "Element should be an instance of the class which "
-                + "extends org.openqa.selenium.remote.RemoteWebElement",
-            element instanceof RemoteWebElement);
+        checkArgument(element instanceof RemoteWebElement,
+                "Element should be an instance of the class which "
+                        + "extends org.openqa.selenium.remote.RemoteWebElement");
         elementId = ((RemoteWebElement) element).getId();
         return this;
     }

--- a/src/test/java/io/appium/java_client/touch/offset/ElementOptionTest.java
+++ b/src/test/java/io/appium/java_client/touch/offset/ElementOptionTest.java
@@ -1,0 +1,38 @@
+package io.appium.java_client.touch.offset;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import java.lang.reflect.Proxy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ElementOptionTest {
+
+    @Test
+    void withElementRejectsNonRemoteWebElement() {
+        WebElement stub = (WebElement) Proxy.newProxyInstance(
+                WebElement.class.getClassLoader(),
+                new Class<?>[]{WebElement.class},
+                (proxy, method, args) -> {
+                    if ("toString".equals(method.getName())) {
+                        return "stub-web-element";
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    if (method.getReturnType().equals(int.class)) {
+                        return 0;
+                    }
+                    return null;
+                });
+
+        IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> ElementOption.element(stub));
+
+        assertThat(thrown.getMessage(), containsString("RemoteWebElement"));
+    }
+}


### PR DESCRIPTION
## Change list

- Fix `ElementOption.withElement` so Guava `checkArgument` actually validates `instanceof RemoteWebElement`
- Add a unit test that a non-`RemoteWebElement` throws `IllegalArgumentException` (not `ClassCastException`)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`checkArgument` was invoked as:

```java
checkArgument(true, "Element should be an instance…", element instanceof RemoteWebElement);
```

With Guava’s `(boolean expression, String template, Object… args)` overload, the first argument is the condition. Passing hard-coded `true` meant the `instanceof` check never failed; a non-`RemoteWebElement` then crashed on the cast with `ClassCastException` instead of the intended `IllegalArgumentException`.

Fixed to:

```java
checkArgument(element instanceof RemoteWebElement,
    "Element should be an instance of the class which "
        + "extends org.openqa.selenium.remote.RemoteWebElement");
```

Note: `ElementOption` is `@Deprecated` (legacy TouchAction), but the validation was still wrong.

No existing GitHub issue — found via code review.

## Checklist

- [x] I have read the contributing docs
- [x] Added a unit test (no device required)
