### PR TITLE
docs: clarify fingerPrint id is enrolled emulator id (#845)

### DIFF
--- a/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
+++ b/src/main/java/io/appium/java_client/android/AndroidMobileCommandHelper.java
@@ -141,7 +141,8 @@ public class AndroidMobileCommandHelper extends MobileCommand {
     /**
      * This method forms a {@link Map} of parameters for the finger print authentication invocation.
      *
-     * @param fingerPrintId finger prints stored in Android Keystore system (from 1 to 10)
+     * @param fingerPrintId enrolled virtual fingerprint id passed to
+     *                      {@code adb emu finger touch}, not the emulator UI Finger 1-10 labels
      * @return a key-value pair. The key is the command name. The value is a {@link Map} command arguments.
      */
     @Deprecated

--- a/src/main/java/io/appium/java_client/android/AuthenticatesByFinger.java
+++ b/src/main/java/io/appium/java_client/android/AuthenticatesByFinger.java
@@ -14,7 +14,8 @@ public interface AuthenticatesByFinger extends ExecutesMethod, CanRememberExtens
     /**
      * Authenticate users by using their finger print scans on supported emulators.
      *
-     * @param fingerPrintId finger prints stored in Android Keystore system (from 1 to 10)
+     * @param fingerPrintId enrolled virtual fingerprint id passed to
+     *                      {@code adb emu finger touch}, not the emulator UI Finger 1-10 labels
      */
     default void fingerPrint(int fingerPrintId) {
         final String extName = "mobile: fingerprint";


### PR DESCRIPTION
## Change list

`fingerPrint` javadoc said ids are 1-10. That is the emulator UI label, not the integer `adb emu finger touch` uses after enrollment. I updated the param docs on `AuthenticatesByFinger` and `AndroidMobileCommandHelper`.

## Types of changes

- [x] No changes in production code.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

The e2e test already calls `driver.fingerPrint(1234)`.

Fixes #845